### PR TITLE
perf: DSV4 chunked prefill (1.7x), attention/router kernel rework, decode I/O overlap

### DIFF
--- a/Sources/Mference/Infrastructure/Streaming/PreadExpertStreamer.swift
+++ b/Sources/Mference/Infrastructure/Streaming/PreadExpertStreamer.swift
@@ -72,6 +72,10 @@ public final class PreadExpertStreamer: @unchecked Sendable {
     private var slotExpert: [Int]
     private var slotLastUse: [Int]
     private var expertUseCount: [Int]
+    /// Slots a speculative read is currently filling. Their contents are
+    /// undefined until the read lands, so they are neither matchable as hits
+    /// (`slotExpert` is cleared to -1) nor available as eviction victims.
+    private var speculativeInFlight: [Bool]
     private var useClock = 0
     private let cacheLock = NSLock()
 
@@ -140,6 +144,7 @@ public final class PreadExpertStreamer: @unchecked Sendable {
         self.slotBuffers = buffers
         self.slotExpert = [Int](repeating: -1, count: slotCount)
         self.slotLastUse = [Int](repeating: 0, count: slotCount)
+        self.speculativeInFlight = [Bool](repeating: false, count: slotCount)
         self.expertUseCount = [Int](repeating: 0, count: max(1, layout.expertsPerLayer))
     }
 
@@ -214,6 +219,14 @@ public final class PreadExpertStreamer: @unchecked Sendable {
         for slot in avoidingSlots where !reserved[slot] {
             reserved[slot] = true
         }
+        // A slot a speculative read is still filling must not be handed to the
+        // real plan: its buffer is being written from another thread. Callers
+        // join outstanding speculation before planning, so in practice this
+        // loop reserves nothing — it is the backstop that keeps a skipped join
+        // from turning into a data race.
+        for slot in 0..<slotCount where speculativeInFlight[slot] && !reserved[slot] {
+            reserved[slot] = true
+        }
 
         let misses = experts.indices.filter { assignedSlots[$0] == -1 }
         let evictable = (0..<slotCount)
@@ -283,6 +296,103 @@ public final class PreadExpertStreamer: @unchecked Sendable {
         return plan.assignedSlots.map { slot in
             (slotBuffers[slot], UInt64(0), layout.expertStride)
         }
+    }
+
+    /// Read-only residency probe: which of `experts` are *not* currently in a
+    /// slot, deduplicated and in request order. Unlike `planExpertsCached` this
+    /// touches neither the LFU counters nor the use clock nor slot assignment,
+    /// so a speculative caller cannot make a guessed expert look popular.
+    public func nonResidentExperts(_ experts: [Int]) -> [Int] {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        var resident = Set<Int>()
+        for slot in 0..<slotCount where slotExpert[slot] >= 0 {
+            resident.insert(slotExpert[slot])
+        }
+        var seen = Set<Int>()
+        return experts.filter { expert in
+            expert >= 0 && !resident.contains(expert) && seen.insert(expert).inserted
+        }
+    }
+
+    /// Reserves slots for a speculative read of `experts` (which the caller has
+    /// already filtered through `nonResidentExperts`).
+    ///
+    /// Eviction protection, in order of importance:
+    /// * slots holding one of the predicted experts are never victims;
+    /// * slots another speculative read is filling are never victims;
+    /// * `keepEvictable` slots are left untouched so the real plan that follows
+    ///   always has room for its own misses — a wrong guess can slow the cache
+    ///   down but can never make the next plan unplaceable.
+    ///
+    /// Victims are picked with the normal eviction order but *no* LFU or clock
+    /// bookkeeping is written: an unconfirmed guess must not shift the policy.
+    /// Reserved slots are marked empty for the duration of the read.
+    public func reserveSpeculativeSlots(experts: [Int],
+                                        keepEvictable: Int) -> [(expert: Int, slot: Int)] {
+        guard !experts.isEmpty else { return [] }
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
+        let wanted = Set(experts)
+        var reserved = [Bool](repeating: false, count: slotCount)
+        for slot in 0..<slotCount
+            where speculativeInFlight[slot] || wanted.contains(slotExpert[slot]) {
+            reserved[slot] = true
+        }
+        let evictable = (0..<slotCount)
+            .filter { !reserved[$0] }
+            .sorted { shouldEvictSlot($0, before: $1) }
+        let budget = min(experts.count, max(0, evictable.count - max(0, keepEvictable)))
+        guard budget > 0 else { return [] }
+
+        var reservation: [(expert: Int, slot: Int)] = []
+        reservation.reserveCapacity(budget)
+        for index in 0..<budget {
+            let slot = evictable[index]
+            speculativeInFlight[slot] = true
+            slotExpert[slot] = -1
+            reservation.append((experts[index], slot))
+        }
+        return reservation
+    }
+
+    /// Runs a reservation from `reserveSpeculativeSlots` and publishes the
+    /// results. Slots whose read failed stay empty rather than claiming to hold
+    /// an expert; the in-flight mark is always cleared. Returns the bytes read.
+    @discardableResult
+    public func executeSpeculativeReservation(
+        _ reservation: [(expert: Int, slot: Int)]
+    ) -> UInt64 {
+        guard !reservation.isEmpty else { return 0 }
+        let loadedLock = NSLock()
+        nonisolated(unsafe) var loaded: [Int] = []
+        DispatchQueue.concurrentPerform(iterations: reservation.count) { index in
+            let entry = reservation[index]
+            guard (try? self.loadExpert(layer: 0,
+                                        expert: entry.expert,
+                                        slot: entry.slot)) != nil else { return }
+            loadedLock.lock()
+            loaded.append(index)
+            loadedLock.unlock()
+        }
+
+        cacheLock.lock()
+        for index in loaded {
+            slotExpert[reservation[index].slot] = reservation[index].expert
+        }
+        for entry in reservation {
+            speculativeInFlight[entry.slot] = false
+        }
+        cacheLock.unlock()
+        return UInt64(loaded.count) * layout.expertStride
+    }
+
+    /// Test/diagnostic view of slot residency.
+    public func residentExpertsSnapshot() -> [Int] {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        return slotExpert
     }
 
     public func adviseExpertCachePlanMisses(_ plan: ExpertCachePlan) -> ExpertIOAdviceResult {

--- a/Sources/Mference/Kernels/DSV4/DSV4Kernels.swift
+++ b/Sources/Mference/Kernels/DSV4/DSV4Kernels.swift
@@ -3,13 +3,19 @@ import Metal
 
 /// Swift wrappers for the DeepSeek-V4 kernel family (`Metal/DSV4/dsv4.metal`):
 /// interleaved trailing partial RoPE, shared-KV MQA decode attention with
-/// per-head sinks over [window ring ‖ compressed entries], the CSA/HCA window
-/// compressor, the lightning-indexer scorer, mHC stream mixing, and the
-/// clamped-SwiGLU elementwise.
+/// per-head sinks over [window ring ‖ compressed entries], the grouped
+/// low-rank output projection, the CSA/HCA window compressor, the
+/// lightning-indexer scorer, mHC stream mixing, and the clamped-SwiGLU
+/// elementwise.
 final class DSV4Kernels {
-    /// Compressed-entry ceiling baked into the attention kernel's threadgroup
-    /// logits array (`kDSV4MaxEntries` = 128 window + 2048 compressed).
-    static let maxCompressedEntries = 2048
+    /// Query heads serviced by one attention threadgroup, one simdgroup each.
+    /// Must equal `kDSV4HeadsPerTG` in `dsv4.metal`.
+    static let attentionHeadsPerThreadgroup = 8
+    /// KV width the attention kernel is written for (`kDSV4AttnHeadDim`).
+    static let attentionHeadDim = 512
+    /// Output rows one `dsv4_o_group_gemv_int4` threadgroup covers, one
+    /// simdgroup each. Must equal its `rows_per_tg`.
+    private static let oGroupRowsPerThreadgroup = 8
     /// Sentinel `selected_count` meaning "attend to every compressed entry".
     static let selectAll: UInt32 = 0xFFFF_FFFF
 
@@ -31,6 +37,7 @@ final class DSV4Kernels {
     private let mainInvFreq: MTLBuffer
     private let compressInvFreq: MTLBuffer
     private let attentionPSO: MTLComputePipelineState
+    private let oGroupPSO: MTLComputePipelineState
     private let compressEmitPSO: MTLComputePipelineState
     private let indexerScorePSO: MTLComputePipelineState
     private let hcWeightsPSO: MTLComputePipelineState
@@ -50,6 +57,13 @@ final class DSV4Kernels {
                                   value: .uint32(UInt32(config.hyperConnections.mult))),
             MetalFunctionConstant(index: 104, value: .uint32(UInt32(config.hiddenSize))),
             MetalFunctionConstant(index: 105, value: .bool(true)),
+            MetalFunctionConstant(
+                index: 106,
+                value: .uint32(UInt32(config.compressedAttention.oLoraRank))),
+            MetalFunctionConstant(
+                index: 107,
+                value: .uint32(UInt32(config.numHeads * config.fullHeadDim
+                                      / max(config.compressedAttention.oGroups, 1)))),
         ]
         self.ropePSO = try context.pipeline(
             "dsv4_rope_interleaved_trailing", constants: constants)
@@ -86,6 +100,9 @@ final class DSV4Kernels {
         self.compressInvFreq = compressBuf
         self.attentionPSO = try context.pipeline(
             "dsv4_attention_decode", constants: constants,
+            maxTotalThreadsPerThreadgroup: 256)
+        self.oGroupPSO = try context.pipeline(
+            "dsv4_o_group_gemv_int4", constants: constants,
             maxTotalThreadsPerThreadgroup: 256)
         self.compressEmitPSO = try context.pipeline("dsv4_compress_emit")
         self.indexerScorePSO = try context.pipeline("dsv4_indexer_score")
@@ -133,32 +150,29 @@ final class DSV4Kernels {
     /// attends to every compressed entry (windowed layers pass
     /// `compressedCount == 0`).
     func encodeAttention(commandBuffer: MTLCommandBuffer,
-                         q: MTLBuffer,
+                         q: MTLBuffer, qOffset: Int = 0,
                          windowKV: MTLBuffer,
                          compressedKV: MTLBuffer,
                          selected: MTLBuffer,
                          sinks: MTLBuffer, sinksOffset: Int,
-                         out: MTLBuffer,
+                         out: MTLBuffer, outOffset: Int = 0,
                          headDim: Int, numHeads: Int,
                          windowCount: Int, windowStartPos: Int, ringCapacity: Int,
                          compressedCount: Int, selectedCount: UInt32,
                          scale: Float) {
-        // The kernel materializes min(selected, compressed) entry logits, so
-        // bound what it actually loads: a CSA layer past 8K tokens has more
-        // than 2048 *emitted* entries but the indexer has already narrowed
-        // attention to its top-512 picks.
-        let attendedCompressed = selectedCount == Self.selectAll
-            ? compressedCount
-            : min(Int(selectedCount), compressedCount)
-        precondition(attendedCompressed <= Self.maxCompressedEntries)
+        // The online-softmax kernel streams entries, so there is no ceiling on
+        // window + compressed rows. It does assume the absorbed-MLA KV width:
+        // one simdgroup lane owns four half4 of a row.
+        precondition(headDim == Self.attentionHeadDim,
+                     "dsv4_attention_decode is written for headDim \(Self.attentionHeadDim), got \(headDim)")
         guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
         enc.setComputePipelineState(attentionPSO)
-        enc.setBuffer(q, offset: 0, index: 0)
+        enc.setBuffer(q, offset: qOffset, index: 0)
         enc.setBuffer(windowKV, offset: 0, index: 1)
         enc.setBuffer(compressedKV, offset: 0, index: 2)
         enc.setBuffer(selected, offset: 0, index: 3)
         enc.setBuffer(sinks, offset: sinksOffset, index: 4)
-        enc.setBuffer(out, offset: 0, index: 5)
+        enc.setBuffer(out, offset: outOffset, index: 5)
         var hd = UInt32(headDim)
         var wc = UInt32(windowCount)
         var ws = UInt32(windowStartPos)
@@ -166,6 +180,7 @@ final class DSV4Kernels {
         var cc = UInt32(compressedCount)
         var sc = selectedCount
         var sl = scale
+        var nh = UInt32(numHeads)
         enc.setBytes(&hd, length: MemoryLayout<UInt32>.size, index: 6)
         enc.setBytes(&wc, length: MemoryLayout<UInt32>.size, index: 7)
         enc.setBytes(&ws, length: MemoryLayout<UInt32>.size, index: 8)
@@ -173,9 +188,50 @@ final class DSV4Kernels {
         enc.setBytes(&cc, length: MemoryLayout<UInt32>.size, index: 10)
         enc.setBytes(&sc, length: MemoryLayout<UInt32>.size, index: 11)
         enc.setBytes(&sl, length: MemoryLayout<Float>.size, index: 12)
+        enc.setBytes(&nh, length: MemoryLayout<UInt32>.size, index: 13)
+        let headsPerGroup = Self.attentionHeadsPerThreadgroup
+        let groups = (numHeads + headsPerGroup - 1) / headsPerGroup
         enc.dispatchThreadgroups(
-            MTLSize(width: numHeads, height: 1, depth: 1),
-            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+            MTLSize(width: groups, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: headsPerGroup * 32,
+                                           height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// The grouped low-rank output projection in one dispatch: `groups`
+    /// contiguous INT4 weight blocks of `rank` rows each, group `g` reading
+    /// `x` at `g * groupIn`. Replaces one GEMV per group.
+    func encodeOGroupProjection(commandBuffer: MTLCommandBuffer,
+                                weights: MTLBuffer, weightsOffset: Int,
+                                scales: MTLBuffer, scalesOffset: Int,
+                                biases: MTLBuffer, biasesOffset: Int,
+                                x: MTLBuffer, xOffset: Int = 0,
+                                y: MTLBuffer, yOffset: Int = 0,
+                                rank: Int, groupIn: Int, groups: Int) {
+        precondition(groupIn % Quantization.groupSize == 0,
+                     "groupIn must be a multiple of \(Quantization.groupSize)")
+        precondition(weightsOffset % 2 == 0,
+                     "dsv4_o_group_gemv_int4 needs a 2-aligned weightsOffset, got \(weightsOffset)")
+        guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
+        enc.setComputePipelineState(oGroupPSO)
+        enc.setBuffer(weights, offset: weightsOffset, index: 0)
+        enc.setBuffer(scales, offset: scalesOffset, index: 1)
+        enc.setBuffer(biases, offset: biasesOffset, index: 2)
+        enc.setBuffer(x, offset: xOffset, index: 3)
+        enc.setBuffer(y, offset: yOffset, index: 4)
+        var r = UInt32(rank)
+        var gi = UInt32(groupIn)
+        var g = UInt32(groups)
+        enc.setBytes(&r, length: MemoryLayout<UInt32>.size, index: 5)
+        enc.setBytes(&gi, length: MemoryLayout<UInt32>.size, index: 6)
+        enc.setBytes(&g, length: MemoryLayout<UInt32>.size, index: 7)
+        let rowsPerGroup = Self.oGroupRowsPerThreadgroup
+        let rows = rank * groups
+        enc.dispatchThreadgroups(
+            MTLSize(width: (rows + rowsPerGroup - 1) / rowsPerGroup,
+                    height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: rowsPerGroup * 32,
+                                           height: 1, depth: 1))
         enc.endEncoding()
     }
 
@@ -251,24 +307,31 @@ final class DSV4Kernels {
     }
 
     /// mHC mixing weights for one sublayer site.
+    ///
+    /// `streamsOffset` selects one token's stream block inside a chunk-wide
+    /// `[tokens, hcMult * hidden]` buffer; chunked prefill uses it to replay
+    /// the decode dispatch per token without copying. Zero (the default) is
+    /// the decode path.
     func encodeHCWeights(commandBuffer: MTLCommandBuffer,
-                         streams: MTLBuffer,
+                         streams: MTLBuffer, streamsOffset: Int = 0,
                          fn: MTLBuffer, fnOffset: Int,
                          base: MTLBuffer, baseOffset: Int,
                          scale: MTLBuffer, scaleOffset: Int,
-                         outPre: MTLBuffer, outPost: MTLBuffer, outComb: MTLBuffer,
+                         outPre: MTLBuffer, outPreOffset: Int = 0,
+                         outPost: MTLBuffer, outPostOffset: Int = 0,
+                         outComb: MTLBuffer, outCombOffset: Int = 0,
                          hcMult: Int, hidden: Int, sinkhornIters: Int,
                          hcEps: Float, rmsEps: Float) {
         precondition(hcMult <= 4, "dsv4_hc_weights sizes its mix scratch for hc_mult <= 4")
         guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
         enc.setComputePipelineState(hcWeightsPSO)
-        enc.setBuffer(streams, offset: 0, index: 0)
+        enc.setBuffer(streams, offset: streamsOffset, index: 0)
         enc.setBuffer(fn, offset: fnOffset, index: 1)
         enc.setBuffer(base, offset: baseOffset, index: 2)
         enc.setBuffer(scale, offset: scaleOffset, index: 3)
-        enc.setBuffer(outPre, offset: 0, index: 4)
-        enc.setBuffer(outPost, offset: 0, index: 5)
-        enc.setBuffer(outComb, offset: 0, index: 6)
+        enc.setBuffer(outPre, offset: outPreOffset, index: 4)
+        enc.setBuffer(outPost, offset: outPostOffset, index: 5)
+        enc.setBuffer(outComb, offset: outCombOffset, index: 6)
         var mult = UInt32(hcMult)
         var hid = UInt32(hidden)
         var iters = UInt32(sinkhornIters)
@@ -286,13 +349,15 @@ final class DSV4Kernels {
     }
 
     func encodeHCCollapse(commandBuffer: MTLCommandBuffer,
-                          streams: MTLBuffer, pre: MTLBuffer, x: MTLBuffer,
+                          streams: MTLBuffer, streamsOffset: Int = 0,
+                          pre: MTLBuffer, preOffset: Int = 0,
+                          x: MTLBuffer, xOffset: Int = 0,
                           hcMult: Int, hidden: Int) {
         guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
         enc.setComputePipelineState(hcCollapsePSO)
-        enc.setBuffer(streams, offset: 0, index: 0)
-        enc.setBuffer(pre, offset: 0, index: 1)
-        enc.setBuffer(x, offset: 0, index: 2)
+        enc.setBuffer(streams, offset: streamsOffset, index: 0)
+        enc.setBuffer(pre, offset: preOffset, index: 1)
+        enc.setBuffer(x, offset: xOffset, index: 2)
         var mult = UInt32(hcMult)
         var hid = UInt32(hidden)
         enc.setBytes(&mult, length: MemoryLayout<UInt32>.size, index: 3)
@@ -305,17 +370,19 @@ final class DSV4Kernels {
     /// `outStreams[k] = post[k] * sub + combᵀ @ streams` — reads `streams`,
     /// writes `outStreams` (caller ping-pongs).
     func encodeHCPlaceMix(commandBuffer: MTLCommandBuffer,
-                          streams: MTLBuffer, sub: MTLBuffer,
-                          post: MTLBuffer, comb: MTLBuffer,
-                          outStreams: MTLBuffer,
+                          streams: MTLBuffer, streamsOffset: Int = 0,
+                          sub: MTLBuffer, subOffset: Int = 0,
+                          post: MTLBuffer, postOffset: Int = 0,
+                          comb: MTLBuffer, combOffset: Int = 0,
+                          outStreams: MTLBuffer, outStreamsOffset: Int = 0,
                           hcMult: Int, hidden: Int) {
         guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
         enc.setComputePipelineState(hcPlaceMixPSO)
-        enc.setBuffer(streams, offset: 0, index: 0)
-        enc.setBuffer(sub, offset: 0, index: 1)
-        enc.setBuffer(post, offset: 0, index: 2)
-        enc.setBuffer(comb, offset: 0, index: 3)
-        enc.setBuffer(outStreams, offset: 0, index: 4)
+        enc.setBuffer(streams, offset: streamsOffset, index: 0)
+        enc.setBuffer(sub, offset: subOffset, index: 1)
+        enc.setBuffer(post, offset: postOffset, index: 2)
+        enc.setBuffer(comb, offset: combOffset, index: 3)
+        enc.setBuffer(outStreams, offset: outStreamsOffset, index: 4)
         var mult = UInt32(hcMult)
         var hid = UInt32(hidden)
         enc.setBytes(&mult, length: MemoryLayout<UInt32>.size, index: 5)
@@ -326,7 +393,7 @@ final class DSV4Kernels {
     }
 
     func encodeHyperHead(commandBuffer: MTLCommandBuffer,
-                         streams: MTLBuffer,
+                         streams: MTLBuffer, streamsOffset: Int = 0,
                          fn: MTLBuffer, fnOffset: Int,
                          base: MTLBuffer, baseOffset: Int,
                          scale: MTLBuffer, scaleOffset: Int,
@@ -334,7 +401,7 @@ final class DSV4Kernels {
                          hcMult: Int, hidden: Int, hcEps: Float, rmsEps: Float) {
         guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
         enc.setComputePipelineState(hyperHeadPSO)
-        enc.setBuffer(streams, offset: 0, index: 0)
+        enc.setBuffer(streams, offset: streamsOffset, index: 0)
         enc.setBuffer(fn, offset: fnOffset, index: 1)
         enc.setBuffer(base, offset: baseOffset, index: 2)
         enc.setBuffer(scale, offset: scaleOffset, index: 3)
@@ -354,13 +421,15 @@ final class DSV4Kernels {
     }
 
     func encodeSwigluClampMul(commandBuffer: MTLCommandBuffer,
-                              gate: MTLBuffer, up: MTLBuffer, out: MTLBuffer,
+                              gate: MTLBuffer, gateOffset: Int = 0,
+                              up: MTLBuffer, upOffset: Int = 0,
+                              out: MTLBuffer, outOffset: Int = 0,
                               n: Int, limit: Float) {
         guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
         enc.setComputePipelineState(swigluClampPSO)
-        enc.setBuffer(gate, offset: 0, index: 0)
-        enc.setBuffer(up, offset: 0, index: 1)
-        enc.setBuffer(out, offset: 0, index: 2)
+        enc.setBuffer(gate, offset: gateOffset, index: 0)
+        enc.setBuffer(up, offset: upOffset, index: 1)
+        enc.setBuffer(out, offset: outOffset, index: 2)
         var count = UInt32(n)
         var lim = limit
         enc.setBytes(&count, length: MemoryLayout<UInt32>.size, index: 3)
@@ -371,12 +440,13 @@ final class DSV4Kernels {
     }
 
     func encodeBroadcastStreams(commandBuffer: MTLCommandBuffer,
-                                x: MTLBuffer, streams: MTLBuffer,
+                                x: MTLBuffer, xOffset: Int = 0,
+                                streams: MTLBuffer, streamsOffset: Int = 0,
                                 hcMult: Int, hidden: Int) {
         guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
         enc.setComputePipelineState(broadcastPSO)
-        enc.setBuffer(x, offset: 0, index: 0)
-        enc.setBuffer(streams, offset: 0, index: 1)
+        enc.setBuffer(x, offset: xOffset, index: 0)
+        enc.setBuffer(streams, offset: streamsOffset, index: 1)
         var mult = UInt32(hcMult)
         var hid = UInt32(hidden)
         enc.setBytes(&mult, length: MemoryLayout<UInt32>.size, index: 2)

--- a/Sources/Mference/Kernels/MoE/MoE.swift
+++ b/Sources/Mference/Kernels/MoE/MoE.swift
@@ -86,9 +86,11 @@ final class MoE {
             routerName,
             constants: routerConstants,
             maxTotalThreadsPerThreadgroup: 512)
-        self.routerSelectK8PSO = try context.pipeline("router_topk_select_k8")
+        // One-SIMD parallel selection; bit-identical to the serial
+        // `router_topk_select_k8` reference kernel (see RouterTopKParityTests).
+        self.routerSelectK8PSO = try context.pipeline("router_topk_select_k8_par")
         self.routerSelectK8SpecializedPSO = try context.pipeline(
-            "router_topk_select_k8",
+            "router_topk_select_k8_par",
             constants: routerConstants)
         self.phase1U16PSO = try context.pipeline(
             "moe_phase1_gate_up_act_u16load", constants: activationConstants)

--- a/Sources/Mference/Kernels/MoE/MoEDeepseekV4.swift
+++ b/Sources/Mference/Kernels/MoE/MoEDeepseekV4.swift
@@ -56,10 +56,12 @@ final class MoEDeepseekV4 {
             "router_gemv_bf16_r4",
             constants: routerConstants,
             maxTotalThreadsPerThreadgroup: 512)
+        // One-SIMD parallel selection and weighting; bit-identical to the serial
+        // reference kernels (see RouterTopKParityTests).
         self.routerSelectK6PSO = try context.pipeline(
-            "router_topk_select_sqrtsoftplus_k6",
+            "router_topk_select_sqrtsoftplus_k6_par",
             constants: routerConstants)
-        self.hashWeightsK6PSO = try context.pipeline("router_hash_weights_k6")
+        self.hashWeightsK6PSO = try context.pipeline("router_hash_weights_k6_par")
         self.phase1Int2PSO = try context.pipeline(
             "moe_phase1_gate_up_act_int2", constants: moeConstants)
         self.phase1SubsetInt2PSO = try context.pipeline(

--- a/Sources/Mference/Kernels/MoE/SpeculativeRouterDSV4.swift
+++ b/Sources/Mference/Kernels/MoE/SpeculativeRouterDSV4.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Metal
+
+/// PILOT router-lookahead for DeepSeek-V4: layer L+1's router applied to layer
+/// L's post-attention state, encoded into layer L's command buffer so the CPU
+/// learns a *guess* at the next layer's expert set at the same wake as the real
+/// router readback — no extra command buffer, no extra sync.
+///
+/// Deliberately a separate object from `MoEDeepseekV4` rather than an extra
+/// method on it: it must not share that class's `routerLogits` singleton (the
+/// real router's logits are live in the same command buffer), and keeping it in
+/// its own file means the speculative path cannot perturb the validated decode
+/// router. Same kernels and same function constants as the real router, so the
+/// ranking — sqrtsoftplus scoring, correction-bias-adjusted selection — is
+/// bit-identical to what layer L+1 will compute for real. Recall depends
+/// entirely on that fidelity; only the *input activation* is an approximation.
+final class SpeculativeRouterDSV4 {
+
+    private let gemvPSO: MTLComputePipelineState
+    private let selectPSO: MTLComputePipelineState
+    private let logits: MTLBuffer
+    /// Predicted expert ids, `topK` x UInt32. Read by the CPU on the router
+    /// signal.
+    let predictedIndices: MTLBuffer
+    /// The select kernel writes gate weights alongside the indices; the
+    /// prediction never uses them, but the kernel contract needs the buffer.
+    private let discardedWeights: MTLBuffer
+
+    init(context: MetalContext,
+         numExperts: UInt32,
+         d: UInt32,
+         topK: UInt32) throws {
+        let routerConstants: [MetalFunctionConstant] = [
+            MetalFunctionConstant(index: 40, value: .uint32(numExperts)),
+            MetalFunctionConstant(index: 41, value: .uint32(d)),
+            MetalFunctionConstant(index: 42, value: .uint32(topK)),
+            MetalFunctionConstant(index: 43, value: .bool(true)),
+        ]
+        self.gemvPSO = try context.pipeline(
+            "router_gemv_bf16_r4",
+            constants: routerConstants,
+            maxTotalThreadsPerThreadgroup: 512)
+        self.selectPSO = try context.pipeline(
+            "router_topk_select_sqrtsoftplus_k6_par",
+            constants: routerConstants)
+
+        guard let logits = context.device.makeBuffer(
+            length: Int(numExperts) * MemoryLayout<Float>.stride,
+            options: .storageModeShared),
+              let indices = context.device.makeBuffer(
+                length: Int(topK) * MemoryLayout<UInt32>.stride,
+                options: .storageModeShared),
+              let weights = context.device.makeBuffer(
+                length: Int(topK) * MemoryLayout<Float>.stride,
+                options: .storageModeShared) else {
+            throw MetalError.noDevice
+        }
+        logits.label = "pilot_router_logits"
+        indices.label = "pilot_router_indices"
+        self.logits = logits
+        self.predictedIndices = indices
+        self.discardedWeights = weights
+    }
+
+    /// Encodes the lookahead GEMV + top-k. Must be encoded *before* the router
+    /// signal so the CPU sees the prediction at the same wake as the real
+    /// indices.
+    func encodePrediction(commandBuffer: MTLCommandBuffer,
+                          weights: MTLBuffer, weightsOffset: Int,
+                          hidden: MTLBuffer,
+                          onesScale: MTLBuffer,
+                          correctionBias: MTLBuffer, correctionBiasOffset: Int,
+                          numExperts: UInt32,
+                          d: UInt32,
+                          routeScale: Float) {
+        var expertCount = numExperts
+        var dimension = d
+        if let encoder = commandBuffer.makeComputeCommandEncoder() {
+            encoder.setComputePipelineState(gemvPSO)
+            encoder.setBuffer(weights, offset: weightsOffset, index: 0)
+            encoder.setBuffer(hidden, offset: 0, index: 1)
+            encoder.setBuffer(onesScale, offset: 0, index: 2)
+            encoder.setBuffer(logits, offset: 0, index: 3)
+            encoder.setBytes(&expertCount, length: MemoryLayout<UInt32>.stride, index: 4)
+            encoder.setBytes(&dimension, length: MemoryLayout<UInt32>.stride, index: 5)
+            encoder.dispatchThreadgroups(
+                MTLSize(width: (Int(numExperts) + 3) / 4, height: 1, depth: 1),
+                threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+            encoder.endEncoding()
+        }
+
+        var scale = routeScale
+        if let encoder = commandBuffer.makeComputeCommandEncoder() {
+            encoder.setComputePipelineState(selectPSO)
+            encoder.setBuffer(logits, offset: 0, index: 0)
+            encoder.setBuffer(correctionBias, offset: correctionBiasOffset, index: 1)
+            encoder.setBuffer(predictedIndices, offset: 0, index: 2)
+            encoder.setBuffer(discardedWeights, offset: 0, index: 3)
+            encoder.setBytes(&expertCount, length: MemoryLayout<UInt32>.stride, index: 4)
+            encoder.setBytes(&scale, length: MemoryLayout<Float>.stride, index: 5)
+            encoder.dispatchThreadgroups(
+                MTLSize(width: 1, height: 1, depth: 1),
+                threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+            encoder.endEncoding()
+        }
+    }
+}

--- a/Sources/Mference/Metal/DSV4/dsv4.metal
+++ b/Sources/Mference/Metal/DSV4/dsv4.metal
@@ -15,6 +15,8 @@ constant uint FC_DSV4_ROPE_DIM [[function_constant(102)]];     // 64
 constant uint FC_DSV4_HC_MULT [[function_constant(103)]];      // 4
 constant uint FC_DSV4_HIDDEN [[function_constant(104)]];       // 4096
 constant bool FC_DSV4_USE_FC [[function_constant(105)]];
+constant uint FC_DSV4_O_RANK [[function_constant(106)]];       // 1024
+constant uint FC_DSV4_O_GROUP_IN [[function_constant(107)]];   // 4096
 
 static inline uint dsv4_head_dim(constant uint& v) {
     return (is_function_constant_defined(FC_DSV4_USE_FC) && FC_DSV4_USE_FC &&
@@ -23,6 +25,15 @@ static inline uint dsv4_head_dim(constant uint& v) {
 static inline uint dsv4_rope_dim(constant uint& v) {
     return (is_function_constant_defined(FC_DSV4_USE_FC) && FC_DSV4_USE_FC &&
             is_function_constant_defined(FC_DSV4_ROPE_DIM)) ? FC_DSV4_ROPE_DIM : v;
+}
+static inline uint dsv4_o_rank(constant uint& v) {
+    return (is_function_constant_defined(FC_DSV4_USE_FC) && FC_DSV4_USE_FC &&
+            is_function_constant_defined(FC_DSV4_O_RANK)) ? FC_DSV4_O_RANK : v;
+}
+static inline uint dsv4_o_group_in(constant uint& v) {
+    return (is_function_constant_defined(FC_DSV4_USE_FC) && FC_DSV4_USE_FC &&
+            is_function_constant_defined(FC_DSV4_O_GROUP_IN))
+        ? FC_DSV4_O_GROUP_IN : v;
 }
 
 // Interleaved partial RoPE on the trailing `rope_dim` channels of each of
@@ -56,20 +67,191 @@ kernel void dsv4_rope_interleaved_trailing(
     x[base + 2u * tid + 1u] = half(x1 * c + x0 * s);
 }
 
-// Softmax attention for one token: 64 query heads over one shared K=V head.
-// KV rows come from two regions: the sliding-window ring (`window_count`
-// valid rows of `ring_capacity`, slot = absolute_position % ring_capacity)
-// and the compressed-entry cache. `selected` restricts the compressed region
-// to `selected_count` entries (lightning-indexer output); `selected_count ==
-// 0xFFFFFFFF` means "all compressed entries". Every head folds its learnable
-// sink logit into the softmax denominator (the sink contributes no value).
+// Softmax attention for one token: `num_heads` query heads over one shared
+// K=V head. KV rows come from two regions: the sliding-window ring
+// (`window_count` valid rows of `ring_capacity`, slot = absolute_position %
+// ring_capacity) and the compressed-entry cache. `selected` restricts the
+// compressed region to `selected_count` entries (lightning-indexer output);
+// `selected_count == 0xFFFFFFFF` means "all compressed entries". Every head
+// folds its learnable sink logit into the softmax denominator (the sink
+// contributes no value).
 //
-// Grid: num_heads threadgroups x 256 threads. Threadgroup memory holds the
-// logits (window + compressed <= kDSV4MaxEntries).
-constant constexpr uint kDSV4MaxEntries = 2176;   // 128 window + 2048 compressed
-constant constexpr uint kDSV4Threads = 256;
+// One threadgroup services `kDSV4HeadsPerTG` heads, one simdgroup each, so a
+// KV row is fetched from device memory once per head group instead of once
+// per head (64 heads over one shared K=V row). Rows are staged into
+// threadgroup memory `kDSV4StageRows` at a time — the staging loop is fully
+// coalesced across the 256 threads, and every head then consumes the staged
+// row for both the QK dot and the value accumulation (K == V).
+//
+// The softmax runs online (running max, running denominator, output rescaled
+// in registers), so no per-entry logit array exists and the kernel imposes no
+// ceiling on window + compressed entries.
+//
+// Requires head_dim == 512 (the DeepSeek-V4 absorbed-MLA KV width): each lane
+// of a simdgroup owns exactly four half4 of a row. `DSV4Kernels` enforces it.
+//
+// Grid: ceil(num_heads / kDSV4HeadsPerTG) threadgroups x 256 threads.
+constant constexpr uint kDSV4HeadsPerTG = 8;
+constant constexpr uint kDSV4AttnHeadDim = 512;
+constant constexpr uint kDSV4RowVec4 = kDSV4AttnHeadDim / 4;    // 128 half4
+constant constexpr uint kDSV4StageRows = 16;                    // 16 KB shared
+constant constexpr uint kDSV4Threads = kDSV4HeadsPerTG * 32;    // 256
+
+// Accumulate one staged KV row into a head's online-softmax state. K == V, so
+// the same staged row drives both the logit dot and the value sum.
+static inline void dsv4_attend_shared_row(
+    threadgroup const half4* kv4,
+    half4 q0, half4 q1, half4 q2, half4 q3,
+    float scale, uint lane,
+    thread float& m, thread float& denom,
+    thread float4& o0, thread float4& o1,
+    thread float4& o2, thread float4& o3
+) {
+    const half4 k0 = kv4[lane +  0u];
+    const half4 k1 = kv4[lane + 32u];
+    const half4 k2 = kv4[lane + 64u];
+    const half4 k3 = kv4[lane + 96u];
+
+    float score = dot(float4(q0), float4(k0)) + dot(float4(q1), float4(k1))
+                + dot(float4(q2), float4(k2)) + dot(float4(q3), float4(k3));
+    score = simd_sum(score) * scale;
+
+    const float new_m = max(m, score);
+    const float rescale = fast::exp(m - new_m);
+    const float w = fast::exp(score - new_m);
+    denom = fma(denom, rescale, w);
+    o0 = fma(o0, rescale, float4(k0) * w);
+    o1 = fma(o1, rescale, float4(k1) * w);
+    o2 = fma(o2, rescale, float4(k2) * w);
+    o3 = fma(o3, rescale, float4(k3) * w);
+    m = new_m;
+}
+
+// Fold the head's learnable sink logit into the running denominator. The sink
+// contributes no value, so it only rescales the accumulator.
+static inline void dsv4_attend_sink(
+    float sink,
+    thread float& m, thread float& denom,
+    thread float4& o0, thread float4& o1,
+    thread float4& o2, thread float4& o3
+) {
+    const float new_m = max(m, sink);
+    const float rescale = fast::exp(m - new_m);
+    denom = fma(denom, rescale, fast::exp(sink - new_m));
+    o0 *= rescale;
+    o1 *= rescale;
+    o2 *= rescale;
+    o3 *= rescale;
+    m = new_m;
+}
 
 kernel void dsv4_attention_decode(
+    device const half* q [[buffer(0)]],                 // [H, head_dim], roped
+    device const half* window_kv [[buffer(1)]],         // ring [capacity, head_dim]
+    device const half* compressed_kv [[buffer(2)]],     // [T, head_dim]
+    device const uint* selected [[buffer(3)]],          // indexer picks
+    device const float* sinks [[buffer(4)]],            // [H]
+    device half* out [[buffer(5)]],                     // [H, head_dim]
+    constant uint& head_dim_in [[buffer(6)]],
+    constant uint& window_count [[buffer(7)]],
+    constant uint& window_start_pos [[buffer(8)]],      // abs pos of oldest row
+    constant uint& ring_capacity [[buffer(9)]],
+    constant uint& compressed_count [[buffer(10)]],
+    constant uint& selected_count [[buffer(11)]],
+    constant float& scale [[buffer(12)]],
+    constant uint& num_heads [[buffer(13)]],
+    uint group [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint sg [[simdgroup_index_in_threadgroup]]
+) {
+    threadgroup half4 kv_shared[kDSV4StageRows * kDSV4RowVec4];
+    const uint head_dim = dsv4_head_dim(head_dim_in);
+    const bool use_all = selected_count == 0xFFFFFFFFu;
+    const uint comp_used = use_all
+        ? compressed_count
+        : min(selected_count, compressed_count);
+
+    // A tail simdgroup with no head of its own still has to reach every
+    // barrier, so it rides along on the last head and drops its store.
+    const uint head = group * kDSV4HeadsPerTG + sg;
+    const bool active = head < num_heads;
+    const uint head_idx = active ? head : num_heads - 1u;
+
+    device const half4* q4 = (device const half4*)(q + head_idx * head_dim);
+    const half4 q0 = q4[lane +  0u];
+    const half4 q1 = q4[lane + 32u];
+    const half4 q2 = q4[lane + 64u];
+    const half4 q3 = q4[lane + 96u];
+
+    float m = -FLT_MAX / 2.0f;
+    float denom = 0.0f;
+    float4 o0 = 0.0f;
+    float4 o1 = 0.0f;
+    float4 o2 = 0.0f;
+    float4 o3 = 0.0f;
+
+    // Sliding-window ring rows, oldest first.
+    for (uint base = 0; base < window_count; base += kDSV4StageRows) {
+        const uint rows = min(kDSV4StageRows, window_count - base);
+        for (uint off = tid; off < rows * kDSV4RowVec4; off += kDSV4Threads) {
+            const uint r = off / kDSV4RowVec4;
+            const uint c = off % kDSV4RowVec4;
+            const uint slot = (window_start_pos + base + r) % ring_capacity;
+            kv_shared[off] =
+                ((device const half4*)(window_kv + slot * head_dim))[c];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; ++r) {
+            dsv4_attend_shared_row(kv_shared + r * kDSV4RowVec4,
+                                   q0, q1, q2, q3, scale, lane,
+                                   m, denom, o0, o1, o2, o3);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Compressed entries, indexer-selected subset or all of them.
+    for (uint base = 0; base < comp_used; base += kDSV4StageRows) {
+        const uint rows = min(kDSV4StageRows, comp_used - base);
+        for (uint off = tid; off < rows * kDSV4RowVec4; off += kDSV4Threads) {
+            const uint r = off / kDSV4RowVec4;
+            const uint c = off % kDSV4RowVec4;
+            const uint ci = base + r;
+            const uint entry = use_all ? ci : selected[ci];
+            const uint row = min(entry, compressed_count - 1u);
+            kv_shared[off] =
+                ((device const half4*)(compressed_kv + row * head_dim))[c];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; ++r) {
+            dsv4_attend_shared_row(kv_shared + r * kDSV4RowVec4,
+                                   q0, q1, q2, q3, scale, lane,
+                                   m, denom, o0, o1, o2, o3);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    dsv4_attend_sink(sinks[head_idx], m, denom, o0, o1, o2, o3);
+
+    if (!active) return;
+    const float inv_denom = denom == 0.0f ? 0.0f : 1.0f / denom;
+    device half4* dst4 = (device half4*)(out + head * head_dim);
+    dst4[lane +  0u] = half4(o0 * inv_denom);
+    dst4[lane + 32u] = half4(o1 * inv_denom);
+    dst4[lane + 64u] = half4(o2 * inv_denom);
+    dst4[lane + 96u] = half4(o3 * inv_denom);
+}
+
+// Pre-restructuring two-pass attention, kept as the parity reference for
+// `DSV4AttentionParityTests`. It materializes every logit in threadgroup
+// memory (hence the kDSV4MaxEntries ceiling the online-softmax kernel above
+// removes) and re-walks all rows from every thread. Not used at runtime — no
+// production pipeline is built for it.
+//
+// Grid: num_heads threadgroups x 256 threads.
+constant constexpr uint kDSV4MaxEntries = 2176;   // 128 window + 2048 compressed
+
+kernel void dsv4_attention_decode_reference(
     device const half* q [[buffer(0)]],                 // [H, head_dim], roped
     device const half* window_kv [[buffer(1)]],         // ring [capacity, head_dim]
     device const half* compressed_kv [[buffer(2)]],     // [T, head_dim]
@@ -164,6 +346,41 @@ kernel void dsv4_attention_decode(
         }
         out[head * head_dim + d] = half(acc * inv_denom);
     }
+}
+
+// Grouped low-rank output projection (o_a): all `groups` head-group GEMVs in
+// one dispatch. The groups share one INT4 weight tensor — group g owns rows
+// [g*rank, (g+1)*rank) and consumes the activation slice [g*group_in,
+// (g+1)*group_in) — so the output row index alone selects both the weight row
+// and the activation slice, and the per-group dispatches collapse into one
+// grid over `groups * rank` rows. The row math is
+// `dequant_int4_gemv_simd_body`'s verbatim, so results are bit-identical to
+// the per-group dispatches it replaces.
+//
+// Grid: ceil(groups*rank / 8) threadgroups x 256 threads (8 rows per group).
+kernel void dsv4_o_group_gemv_int4(
+    device const uint8_t* W [[buffer(0)]],
+    device const bfloat* scales [[buffer(1)]],
+    device const bfloat* biases [[buffer(2)]],
+    device const half* x [[buffer(3)]],
+    device half* y [[buffer(4)]],
+    constant uint& rank_in [[buffer(5)]],
+    constant uint& group_in_in [[buffer(6)]],
+    constant uint& groups [[buffer(7)]],
+    uint tg_idx [[threadgroup_position_in_grid]],
+    uint sg_idx [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    constexpr uint rows_per_tg = 8;
+    const uint rank = dsv4_o_rank(rank_in);
+    const uint group_in = dsv4_o_group_in(group_in_in);
+    const uint rows = groups * rank;
+    const uint row = tg_idx * rows_per_tg + sg_idx;
+    if (row >= rows) return;
+    dequant_int4_gemv_simd_body(W, scales, biases,
+                                x + (row / rank) * group_in, y,
+                                rows, group_in,
+                                rows_per_tg, tg_idx, sg_idx, lane);
 }
 
 // One compressor window emission (paper eqs. 20-23): per output channel c,

--- a/Sources/Mference/Metal/MoE/moe.metal
+++ b/Sources/Mference/Metal/MoE/moe.metal
@@ -184,6 +184,9 @@ kernel void router_gemv_bf16_r4(
     if (lane == 0) out_logits[e] = acc;
 }
 
+// Serial single-thread selection. Superseded in production by the one-SIMD
+// `_par` kernels below; kept because the parity tests compare the parallel
+// results against it bit for bit.
 kernel void router_topk_select_k8(
     device const float* logits [[buffer(0)]],
     device const bfloat* per_expert_scale [[buffer(1)]],
@@ -218,6 +221,111 @@ kernel void router_topk_select_k8(
         }
         top_idx[pos] = e;
         top_score[pos] = s;
+    }
+
+    const float max_s = top_score[0];
+    float sum_exp = 0.0f;
+    float exps[8];
+    for (uint i = 0; i < 8; ++i) {
+        const float ex = fast::exp(top_score[i] - max_s);
+        exps[i] = ex;
+        sum_exp += ex;
+    }
+    for (uint i = 0; i < 8; ++i) {
+        const uint expert_idx = top_idx[i];
+        const float weight = exps[i] / sum_exp;
+        out_indices[i] = expert_idx;
+        out_weights[i] = half(weight * float(per_expert_scale[expert_idx]));
+    }
+}
+
+// --- One-SIMD parallel top-k selection ------------------------------------
+//
+// The serial selects above walk all `num_experts` logits on a single thread of
+// a whole dispatch, on the per-layer critical path. These replacements keep the
+// same single 32-thread dispatch but spread the scan across the SIMD, and are
+// bit-identical to the serial result rather than merely equivalent.
+//
+// Ownership is blocked: lane L owns experts [L*per, L*per + per) with
+// per = ceil(NE/32) <= 8 for NE <= 256, and out-of-range slots carry a -INFINITY
+// sentinel so short or non-multiple-of-32 expert counts need no special case.
+// Each of the K steps takes a lane-local strict-`>` ascending max (lowest index
+// wins inside a lane, matching the serial ascending scan) and then a
+// shuffle-down argmax whose ties prefer the LOWER index. Together those
+// reproduce the serial "first strictly-greater score wins, equal score keeps the
+// earlier expert" order exactly. A per-lane taken bitmask retires winners.
+// The normalization tail stays serial on lane 0 with the same operations in the
+// same order, so the emitted weights match bit for bit.
+constant constexpr uint kRouterMaxPerLane = 8;   // num_experts <= 256
+constant constexpr uint kRouterNoWinner = 0xFFFFFFFFu;
+
+static inline uint router_select_next_one_simd(
+    thread const float* ch,
+    thread uint& taken,
+    uint per,
+    uint base
+) {
+    float bv = -INFINITY;
+    uint bi = kRouterNoWinner;
+    for (uint j = 0; j < per; ++j) {
+        if (!(taken & (1u << j)) && ch[j] > bv) {
+            bv = ch[j];
+            bi = base + j;
+        }
+    }
+    for (uint off = 16u; off > 0u; off >>= 1) {
+        const float ov = simd_shuffle_down(bv, off);
+        const uint oi = simd_shuffle_down(bi, off);
+        if (ov > bv || (ov == bv && oi < bi)) {
+            bv = ov;
+            bi = oi;
+        }
+    }
+    bi = simd_broadcast(bi, 0);
+    if (bi != kRouterNoWinner && bi >= base && bi < base + per) {
+        taken |= 1u << (bi - base);
+    }
+    return bi;
+}
+
+kernel void router_topk_select_k8_par(
+    device const float* logits [[buffer(0)]],
+    device const bfloat* per_expert_scale [[buffer(1)]],
+    device uint* out_indices [[buffer(2)]],
+    device half* out_weights [[buffer(3)]],
+    constant uint& num_experts [[buffer(4)]],
+    uint sg_idx [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    const uint NE = router_fc_num_experts(num_experts);
+    // Out-of-contract dispatches are a visible no-op, never an OOB write.
+    if (sg_idx != 0u || NE > 32u * kRouterMaxPerLane) return;
+
+    const uint per = (NE + 31u) / 32u;
+    const uint base = lane * per;
+    float ch[kRouterMaxPerLane];
+    for (uint j = 0; j < per; ++j) {
+        const uint e = base + j;
+        ch[j] = (e < NE) ? logits[e] : -INFINITY;
+    }
+
+    uint taken = 0u;
+    uint top_idx[8];
+    for (uint k = 0; k < 8; ++k) {
+        top_idx[k] = router_select_next_one_simd(ch, taken, per, base);
+    }
+    if (lane != 0u) return;
+
+    // Fewer experts than K leaves trailing steps without a winner. The serial
+    // kernel leaves those slots at index 0 with score -INFINITY; mirror that.
+    float top_score[8];
+    for (uint i = 0; i < 8; ++i) {
+        if (top_idx[i] == kRouterNoWinner) {
+            top_idx[i] = 0u;
+            top_score[i] = -INFINITY;
+        } else {
+            top_score[i] = logits[top_idx[i]];
+        }
     }
 
     const float max_s = top_score[0];
@@ -507,6 +615,8 @@ static inline float sqrtsoftplus(float x) {
     return sqrt(sp);
 }
 
+// Serial single-thread selection, superseded in production by
+// `router_topk_select_sqrtsoftplus_k6_par`; kept as the parity reference.
 kernel void router_topk_select_sqrtsoftplus_k6(
     device const float* logits [[buffer(0)]],
     device const float* correction_bias [[buffer(1)]],
@@ -557,9 +667,63 @@ kernel void router_topk_select_sqrtsoftplus_k6(
     }
 }
 
+// One-SIMD replacement for `router_topk_select_sqrtsoftplus_k6`. Selection uses
+// the same blocked-ownership argmax reduction as `router_topk_select_k8_par`;
+// the score is sqrtsoftplus(logit) + correction bias, and the weight tail is
+// the serial code verbatim on lane 0, so the emitted indices and FP16 weights
+// are bit-identical.
+kernel void router_topk_select_sqrtsoftplus_k6_par(
+    device const float* logits [[buffer(0)]],
+    device const float* correction_bias [[buffer(1)]],
+    device uint* out_indices [[buffer(2)]],
+    device half* out_weights [[buffer(3)]],
+    constant uint& num_experts [[buffer(4)]],
+    constant float& route_scale [[buffer(5)]],
+    uint sg_idx [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    const uint NE = router_fc_num_experts(num_experts);
+    if (sg_idx != 0u || NE > 32u * kRouterMaxPerLane) return;
+
+    const uint per = (NE + 31u) / 32u;
+    const uint base = lane * per;
+    float ch[kRouterMaxPerLane];
+    for (uint j = 0; j < per; ++j) {
+        const uint e = base + j;
+        ch[j] = (e < NE) ? (sqrtsoftplus(logits[e]) + correction_bias[e])
+                         : -INFINITY;
+    }
+
+    uint taken = 0u;
+    uint top_idx[6];
+    for (uint k = 0; k < 6; ++k) {
+        top_idx[k] = router_select_next_one_simd(ch, taken, per, base);
+    }
+    if (lane != 0u) return;
+
+    // The serial kernel leaves unfilled slots at index 0; mirror that so the
+    // sqrtsoftplus(logits[0]) contribution below matches.
+    for (uint i = 0; i < 6; ++i) {
+        if (top_idx[i] == kRouterNoWinner) top_idx[i] = 0u;
+    }
+    float scores[6];
+    float sum = 0.0f;
+    for (uint i = 0; i < 6; ++i) {
+        scores[i] = sqrtsoftplus(logits[top_idx[i]]);
+        sum += scores[i];
+    }
+    const float inv = route_scale / (sum + 1e-20f);
+    for (uint i = 0; i < 6; ++i) {
+        out_indices[i] = top_idx[i];
+        out_weights[i] = half(scores[i] * inv);
+    }
+}
+
 // Hash-routed layers: expert indices are a frozen tid2eid[token] lookup done
 // on the CPU; only the weights come from the learned gate. Scores the 6
 // given experts, renormalizes, scales.
+//
+// Serial reference; production uses `router_hash_weights_k6_par`.
 kernel void router_hash_weights_k6(
     device const float* logits [[buffer(0)]],
     device const uint* indices [[buffer(1)]],
@@ -574,6 +738,32 @@ kernel void router_hash_weights_k6(
         scores[i] = sqrtsoftplus(logits[indices[i]]);
         sum += scores[i];
     }
+    const float inv = route_scale / (sum + 1e-20f);
+    for (uint i = 0; i < 6; ++i) {
+        out_weights[i] = half(scores[i] * inv);
+    }
+}
+
+// One-SIMD variant of `router_hash_weights_k6`: lanes 0..5 evaluate the six
+// sqrtsoftplus scores concurrently, then lane 0 runs the serial accumulation
+// and normalization in the original order. `simd_shuffle` moves exact bits, so
+// the result matches the serial kernel exactly.
+kernel void router_hash_weights_k6_par(
+    device const float* logits [[buffer(0)]],
+    device const uint* indices [[buffer(1)]],
+    device half* out_weights [[buffer(2)]],
+    constant float& route_scale [[buffer(3)]],
+    uint sg_idx [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    if (sg_idx != 0u) return;
+    const float own = (lane < 6u) ? sqrtsoftplus(logits[indices[lane]]) : 0.0f;
+    float scores[6];
+    for (uint i = 0; i < 6; ++i) scores[i] = simd_shuffle(own, i);
+    if (lane != 0u) return;
+
+    float sum = 0.0f;
+    for (uint i = 0; i < 6; ++i) sum += scores[i];
     const float inv = route_scale / (sum + 1e-20f);
     for (uint i = 0; i < 6; ++i) {
         out_weights[i] = half(scores[i] * inv);
@@ -915,4 +1105,142 @@ kernel void moe_phase2_down_reduce_k8(
         acc += partial[4]; acc += partial[5]; acc += partial[6]; acc += partial[7];
         y[d] = half(acc);
     }
+}
+
+// ============================================================================
+// DeepSeek-V4 chunked-prefill routed MoE — pair-major (additive; Wave-2B).
+//
+// Decode runs one token at a time: six experts are streamed in, phase 1 fills
+// `acts[slot]`, and `moe_phase2_down_reduce_int2_k6` fuses the down projection
+// with the weighted reduce. Prefill cannot afford that: every token re-reads
+// its six 8 MB expert blobs, so a 629-token prompt reads ~1.3 TB.
+//
+// The prefill variants below are *pair-major*: the chunk's (token, rank)
+// routes are sorted by expert and processed one expert tile at a time, so an
+// expert blob is read once per chunk instead of once per token. The
+// arithmetic is unchanged — the same `moe_int2_*` helpers, the same clamp,
+// the same activation, the same `routing_w * value` product, the same
+// residual-first FP32 accumulation in rank order — so results are
+// bit-identical to the decode path. The only structural difference is that the
+// down projection writes an FP32 per-route partial (decode keeps it in
+// threadgroup memory), which carries strictly more precision than the
+// threadgroup float the fused kernel reduces.
+// ============================================================================
+
+struct DSV4PrefillRoute {
+    uint token;       // row of `x` / of the output
+    uint rank;        // routing slot 0..top_k-1 (selects the routing weight)
+    uint local_slot;  // index into the tile's RoutedBlobs
+    uint reserved;
+};
+
+// acts[(token * top_k + rank) * F + f], one simdgroup per (route, f) row.
+kernel void dsv4_prefill_moe_phase1_pairs_int2(
+    device const RoutedBlobs& routed [[buffer(0)]],
+    constant ExpertOffsets& routed_offsets [[buffer(1)]],
+    device const half* x [[buffer(2)]],            // [tokens, D]
+    device half* acts [[buffer(3)]],               // [tokens * top_k, F]
+    constant uint& D [[buffer(4)]],
+    constant uint& F [[buffer(5)]],
+    constant uint& top_k [[buffer(6)]],
+    constant uint& gate_group_size [[buffer(7)]],
+    device const DSV4PrefillRoute* routes [[buffer(8)]],
+    constant uint& route_start [[buffer(9)]],
+    constant uint& route_count [[buffer(10)]],
+    uint tg_idx [[threadgroup_position_in_grid]],
+    uint sg_idx [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    constexpr uint rows_per_tg = 8;
+    const uint DD = moe_fc_d(D);
+    const uint FF = moe_fc_f(F);
+    const uint KK = moe_fc_top_k(top_k);
+    const uint rowg = tg_idx * rows_per_tg + sg_idx;
+    if (rowg >= route_count * FF) return;
+    const uint route_index = rowg / FF;
+    const uint f = rowg % FF;
+    const DSV4PrefillRoute r = routes[route_start + route_index];
+    if (r.local_slot >= kMaxStreamedExperts) return;
+
+    device const uint8_t* base = routed.blob[r.local_slot];
+    const ExpertOffsets re = routed_offsets;
+    const float2 gu = moe_int2_gate_up_rows_simd_dev_vec(
+        base + re.gate_W_off,
+        (device const bfloat*)(base + re.gate_s_off),
+        (device const bfloat*)(base + re.gate_b_off),
+        base + re.up_W_off,
+        (device const bfloat*)(base + re.up_s_off),
+        (device const bfloat*)(base + re.up_b_off),
+        x + uint(r.token) * DD, f, DD, gate_group_size, lane);
+    if (lane == 0) {
+        const float2 cgu = moe_swiglu_clamp(gu.x, gu.y);
+        acts[(uint(r.token) * KK + uint(r.rank)) * FF + f] =
+            half(moe_hidden_activation(cgu.x) * cgu.y);
+    }
+}
+
+// partials[(token * top_k + rank) * D + d] = routing_w[...] * down_row(acts).
+// FP32 output so the reduce below matches the fused decode kernel exactly.
+kernel void dsv4_prefill_moe_down_pairs_int2(
+    device const RoutedBlobs& routed [[buffer(0)]],
+    constant ExpertOffsets& routed_offsets [[buffer(1)]],
+    device const half* acts [[buffer(2)]],         // [tokens * top_k, F]
+    device const half* routing_w [[buffer(3)]],    // [tokens * top_k]
+    device float* partials [[buffer(4)]],          // [tokens * top_k, D]
+    constant uint& D [[buffer(5)]],
+    constant uint& F [[buffer(6)]],
+    constant uint& top_k [[buffer(7)]],
+    device const DSV4PrefillRoute* routes [[buffer(8)]],
+    constant uint& route_start [[buffer(9)]],
+    constant uint& route_count [[buffer(10)]],
+    uint tg_idx [[threadgroup_position_in_grid]],
+    uint sg_idx [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    constexpr uint rows_per_tg = 8;
+    const uint DD = moe_fc_d(D);
+    const uint FF = moe_fc_f(F);
+    const uint KK = moe_fc_top_k(top_k);
+    const uint rowg = tg_idx * rows_per_tg + sg_idx;
+    if (rowg >= route_count * DD) return;
+    const uint route_index = rowg / DD;
+    const uint d = rowg % DD;
+    const DSV4PrefillRoute r = routes[route_start + route_index];
+    if (r.local_slot >= kMaxStreamedExperts) return;
+    const uint pair = uint(r.token) * KK + uint(r.rank);
+
+    device const uint8_t* base = routed.blob[r.local_slot];
+    const ExpertOffsets re = routed_offsets;
+    const float value = moe_int2_gemv_row_simd_dev_vec(
+        base + re.down_W_off,
+        (device const bfloat*)(base + re.down_s_off),
+        (device const bfloat*)(base + re.down_b_off),
+        acts + pair * FF, d, FF, lane);
+    if (lane == 0) {
+        partials[pair * DD + d] = float(routing_w[pair]) * value;
+    }
+}
+
+// y[token] = residual[token] + sum_{rank} partials[token, rank] — the same
+// residual-first, rank-ordered FP32 accumulation as
+// `moe_phase2_down_reduce_int2_k6`.
+kernel void dsv4_prefill_moe_reduce_pairs_k6(
+    device const float* partials [[buffer(0)]],    // [tokens * 6, D]
+    device const half* residual [[buffer(1)]],     // [tokens, D]
+    device half* y [[buffer(2)]],                  // [tokens, D]
+    constant uint& D [[buffer(3)]],
+    uint2 gid [[thread_position_in_grid]]
+) {
+    const uint DD = moe_fc_d(D);
+    if (gid.x >= DD) return;
+    const uint row = gid.y * DD + gid.x;
+    const uint base = gid.y * 6u * DD + gid.x;
+    float acc = float(residual[row]);
+    acc += partials[base + 0u * DD];
+    acc += partials[base + 1u * DD];
+    acc += partials[base + 2u * DD];
+    acc += partials[base + 3u * DD];
+    acc += partials[base + 4u * DD];
+    acc += partials[base + 5u * DD];
+    y[row] = half(acc);
 }

--- a/Sources/Mference/Runtime/Inference/ModelExpertIO.swift
+++ b/Sources/Mference/Runtime/Inference/ModelExpertIO.swift
@@ -104,6 +104,14 @@ extension Model {
         return slotCount
     }
 
+    /// Direct handle on a layer's expert streamer. Used by the speculative
+    /// prefetch path, which reserves slots on the caller's thread and then
+    /// executes the reads on a background queue without re-resolving the layer.
+    public func routedExpertStreamer(layer: Int) throws -> PreadExpertStreamer {
+        try ensureLayerOpened(layer)
+        return streamersQueue.sync { streamersBox.streamers[layer]! }
+    }
+
     public func routedExpertBuffers(for plan: RoutedExpertFetchPlan) throws -> [TensorView] {
         try ensureLayerOpened(plan.layer)
         let streamer = streamersQueue.sync { streamersBox.streamers[plan.layer]! }

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner+DSV4Prefill.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner+DSV4Prefill.swift
@@ -300,30 +300,44 @@ final class DSV4ChunkedPrefill {
         return !(raw == "off" || raw == "0" || raw == "false")
     }
 
-    /// Whether a chunk starting at `startPosition` can run batched.
+    /// How many tokens from the start of a chunk can run batched.
     ///
     /// The lightning indexer selects a top-`indexTopK` subset of compressed
     /// entries once a CSA layer holds more than `indexTopK` of them, and the
     /// selection is a CPU top-k over a GPU readback taken *in the middle* of
     /// the layer. Batching a whole chunk into one command buffer cannot host a
-    /// per-token mid-layer readback, so chunks that reach that context length
-    /// fall back to the token-by-token path.
+    /// per-token mid-layer readback, so positions past that context length
+    /// fall back to the token-by-token path. A chunk that crosses the cutover
+    /// keeps its eligible prefix batched; only the remainder falls back.
+    static func batchedTokenPrefix(config: ArchConfig,
+                                   startPosition: Int,
+                                   tokenCount: Int,
+                                   expertCacheSlots: Int?) -> Int {
+        guard batchedPathEnabled else { return 0 }
+        guard config.routerScoringFunc == "sqrtsoftplus",
+              config.topKExperts == MoEDeepseekV4.topK else { return 0 }
+        if let expertCacheSlots, expertCacheSlots < 1 { return 0 }
+        let ca = config.compressedAttention
+        guard ca.csaCompressRate > 0 else { return 0 }
+        let hasCSA = (0..<config.numLayers).contains { config.layerIsCSA($0) }
+        guard hasCSA else { return tokenCount }
+        // A position is batchable while the compressed-entry count after it
+        // stays within the selection threshold:
+        //   (lastPosition + 1) / csaCompressRate <= indexTopK
+        // which holds for lastPosition + 1 <= (indexTopK + 1) * rate - 1.
+        let batchablePositions = (ca.indexTopK + 1) * ca.csaCompressRate - 1
+        return max(0, min(tokenCount, batchablePositions - startPosition))
+    }
+
+    /// Whether a whole chunk starting at `startPosition` can run batched.
     static func supports(config: ArchConfig,
                          startPosition: Int,
                          tokenCount: Int,
                          expertCacheSlots: Int?) -> Bool {
-        guard batchedPathEnabled else { return false }
-        guard config.routerScoringFunc == "sqrtsoftplus",
-              config.topKExperts == MoEDeepseekV4.topK else { return false }
-        if let expertCacheSlots, expertCacheSlots < 1 { return false }
-        let ca = config.compressedAttention
-        guard ca.csaCompressRate > 0 else { return false }
-        let hasCSA = (0..<config.numLayers).contains { config.layerIsCSA($0) }
-        guard hasCSA else { return true }
-        // Compressed entries after the last token of the chunk.
-        let lastPosition = startPosition + tokenCount - 1
-        let entries = (lastPosition + 1) / ca.csaCompressRate
-        return entries <= ca.indexTopK
+        batchedTokenPrefix(config: config,
+                           startPosition: startPosition,
+                           tokenCount: tokenCount,
+                           expertCacheSlots: expertCacheSlots) >= tokenCount
     }
 
     // MARK: - Entry point

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner+DSV4Prefill.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner+DSV4Prefill.swift
@@ -1,0 +1,1055 @@
+import Foundation
+import Metal
+
+// ============================================================================
+// DeepSeek-V4 chunked prefill.
+//
+// The v1 DSV4 prefill replayed `produceTokenDSV4` once per prompt token. That
+// is correct but pathologically slow for one reason: routed-expert I/O. Every
+// token streams 43 layers x 6 experts x 8 MB, so a 629-token prompt reads
+// ~1.3 TB off the expert file and prefill runs at decode speed (measured
+// 3.4 tok/s on an M5).
+//
+// This path keeps the token loop but turns it inside out: **layer-major**.
+// For one chunk of T tokens it walks layers on the outside and tokens on the
+// inside, which buys two things:
+//
+//  1. All T tokens' attention-site dispatches for a layer go into ONE command
+//     buffer, so the per-layer CPU/GPU round trip is paid once per chunk
+//     instead of once per token.
+//  2. The layer's routed MoE becomes **pair-major**: the chunk's (token, rank)
+//     routes are sorted by expert, split into tiles of at most
+//     `kMaxStreamedExperts`, and each tile is streamed in once and applied to
+//     every route that lands on it. An expert blob is read once per chunk
+//     instead of once per token.
+//
+// Correctness contract: prefill(T) must equal T sequential decode steps,
+// bit-for-bit. That is achieved by construction, not by tolerance:
+//
+//  * Every dispatch is the *same* kernel the decode path encodes, with the
+//    same arguments. Chunk-wide buffers are addressed with byte offsets, which
+//    only shifts a base pointer.
+//  * Metal executes dispatches within a command buffer in submission order, so
+//    replaying token t's chain into a shared scratch buffer before token t+1's
+//    is equivalent to running them in separate command buffers. Only state that
+//    outlives a token (residual streams, routed input, routing decisions,
+//    shared-expert output) is stored per token.
+//  * The compressor / window-ring / indexer bookkeeping is the decode
+//    bookkeeping, stepped on the CPU while encoding, in token order.
+//  * The pair-major MoE kernels reuse `moe.metal`'s INT2 helpers verbatim and
+//    reduce residual-first in rank order, matching
+//    `moe_phase2_down_reduce_int2_k6` exactly. The one structural change --
+//    the down projection lands in an FP32 per-route partial instead of
+//    threadgroup memory -- preserves the value bit-for-bit.
+//
+// Falls back to the token-by-token path (see `supports`) when the chunk would
+// need lightning-indexer selection, which requires a mid-layer CPU readback
+// per token.
+// ============================================================================
+
+/// Everything the chunked DSV4 prefill needs from `RealForwardRunner`. Built
+/// at the call site inside `prefillChunked`, which is the only place the
+/// runner's private members are visible.
+struct DSV4PrefillBindings {
+    let model: Model
+    let ctx: MetalContext
+    let cfg: ArchConfig
+    let dsv4: DSV4Kernels
+    let moeDSV4: MoEDeepseekV4
+    let state: DSV4StateManager
+    let int4: DequantInt4GEMV
+    let rms: RMSNorm
+    let embed: EmbedLookupInt4
+    let fusionHead: LMHeadChainInt4
+    let sharedExperts: [DSV4PrefillSharedExpert]
+    let effectiveScales: [MTLBuffer]
+    let useFusedGreedyHead: Bool
+}
+
+struct DSV4PrefillSharedExpert {
+    let gate: SharedExpertInt8Proj
+    let up: SharedExpertInt8Proj
+    let down: SharedExpertInt8Proj
+}
+
+/// A routed tile whose GPU work is still executing while the next tile's
+/// experts are being read.
+private struct PendingRoutedTile {
+    let cb: MTLCommandBuffer
+    let assignedSlots: [Int]
+}
+
+/// One (token, routing rank) route bound to a tile-local expert slot. Must
+/// match `DSV4PrefillRoute` in `moe.metal`.
+private struct DSV4PrefillRoute {
+    var token: UInt32
+    var rank: UInt32
+    var localSlot: UInt32
+    var reserved: UInt32 = 0
+}
+
+final class DSV4ChunkedPrefill {
+    /// Experts bound by one routed tile. Matches `kMaxStreamedExperts` in
+    /// `moe.metal` (the `RoutedBlobs` argument-buffer struct).
+    static let tileExpertCapacity = 8
+
+    private let b: DSV4PrefillBindings
+    private let chunkTokens: Int
+
+    /// Largest chunk this instance's scratch can serve.
+    var chunkCapacity: Int { chunkTokens }
+
+    private let phase1PSO: MTLComputePipelineState
+    private let downPSO: MTLComputePipelineState
+    private let reducePSO: MTLComputePipelineState
+    private let routerGemvPSO: MTLComputePipelineState
+    private let routerSelectPSO: MTLComputePipelineState
+    private let routerHashPSO: MTLComputePipelineState
+    private let argEncoder: MTLArgumentEncoder
+    /// One argument buffer per in-flight routed tile. Its contents are read at
+    /// GPU execution time, so a tile still running must keep its own.
+    private let argBuffers: [MTLBuffer]
+    private let tileScheduler: PrefillRoutedTileScheduler
+    /// Depth-1 lookahead needs `(depth + 1) * tileExperts` cache slots. Below
+    /// that the tiles run serially.
+    private let pipelineTiles: Bool
+
+    // Chunk-wide state (one slice per token).
+    private let streams: MTLBuffer          // [T, mult * D] FP16
+    private let streamsAlt: MTLBuffer       // [T, mult * D] FP16
+    private let routedX: MTLBuffer          // [T, D] FP16
+    private let h1: MTLBuffer               // [T, D] FP16 shared-expert output
+    private let h2: MTLBuffer               // [T, D] FP16 routed + shared
+    private let routeIndices: MTLBuffer     // [T, topK] UInt32
+    private let routeWeights: MTLBuffer     // [T, topK] FP16
+    private let acts: MTLBuffer             // [T * topK, FmoE] FP16
+    private let partials: MTLBuffer         // [T * topK, D] FP32
+    private let routesBuffer: MTLBuffer     // [T * topK] DSV4PrefillRoute
+    private let routerLogits: MTLBuffer     // [numExperts] FP32
+    private let hcPostF: MTLBuffer          // [T, mult] FP32
+    private let hcCombF: MTLBuffer          // [T, mult * mult] FP32
+
+    // Single-token scratch. Safe to share across the chunk's tokens because
+    // dispatches inside a command buffer run in submission order.
+    private let hidden: MTLBuffer
+    private let normed: MTLBuffer
+    private let qaBuf: MTLBuffer
+    private let qScratch: MTLBuffer
+    private let attnOut: MTLBuffer
+    private let oGrouped: MTLBuffer
+    private let oOut: MTLBuffer
+    private let hcPreA: MTLBuffer
+    private let hcPostA: MTLBuffer
+    private let hcCombA: MTLBuffer
+    private let hcPreF: MTLBuffer
+    private let denseGate: MTLBuffer
+    private let denseUp: MTLBuffer
+    private let denseAct: MTLBuffer
+    private let selected: MTLBuffer
+
+    private static let fp16 = MemoryLayout<Float16>.stride
+
+    /// Byte strides of the per-token slices.
+    private let streamStride: Int
+    private let hiddenStride: Int
+    private let actStride: Int
+    private let partialStride: Int
+    private let hcPostStride: Int
+    private let hcCombStride: Int
+
+    // MARK: - Setup
+
+    init(bindings: DSV4PrefillBindings, chunkTokens: Int) throws {
+        precondition(chunkTokens > 0)
+        self.b = bindings
+        self.chunkTokens = chunkTokens
+        let cfg = bindings.cfg
+        let ctx = bindings.ctx
+        let device = ctx.device
+        let D = cfg.hiddenSize
+        let mult = cfg.hyperConnections.mult
+        let topK = cfg.topKExperts
+        let fp16 = Self.fp16
+
+        let moeConstants: [MetalFunctionConstant] = [
+            MetalFunctionConstant(index: 0, value: .uint32(UInt32(D))),
+            MetalFunctionConstant(index: 1, value: .uint32(UInt32(cfg.moeIntermediateSize))),
+            MetalFunctionConstant(index: 2, value: .uint32(UInt32(MoEDeepseekV4.topK))),
+            MetalFunctionConstant(index: 3, value: .bool(true)),
+            MetalFunctionConstant(index: 4, value: .bool(cfg.hiddenActivation == "silu")),
+            MetalFunctionConstant(index: 5, value: .float(Float(cfg.swigluLimit))),
+        ]
+        let routerConstants: [MetalFunctionConstant] = [
+            MetalFunctionConstant(index: 40, value: .uint32(UInt32(cfg.numExperts))),
+            MetalFunctionConstant(index: 41, value: .uint32(UInt32(D))),
+            MetalFunctionConstant(index: 42, value: .uint32(UInt32(MoEDeepseekV4.topK))),
+            MetalFunctionConstant(index: 43, value: .bool(true)),
+        ]
+        self.phase1PSO = try ctx.pipeline("dsv4_prefill_moe_phase1_pairs_int2",
+                                          constants: moeConstants)
+        self.downPSO = try ctx.pipeline("dsv4_prefill_moe_down_pairs_int2",
+                                        constants: moeConstants)
+        self.reducePSO = try ctx.pipeline("dsv4_prefill_moe_reduce_pairs_k6",
+                                          constants: moeConstants)
+        // The router kernels are the decode ones; only the buffer offsets
+        // differ, so selection and weighting stay bit-identical.
+        self.routerGemvPSO = try ctx.pipeline("router_gemv_bf16_r4",
+                                              constants: routerConstants,
+                                              maxTotalThreadsPerThreadgroup: 512)
+        self.routerSelectPSO = try ctx.pipeline(
+            "router_topk_select_sqrtsoftplus_k6_par", constants: routerConstants)
+        self.routerHashPSO = try ctx.pipeline("router_hash_weights_k6_par")
+
+        guard let phase1Fn = ctx.library.makeFunction(
+                name: "dsv4_prefill_moe_phase1_pairs_int2") else {
+            throw MetalError.noDevice
+        }
+        self.argEncoder = phase1Fn.makeArgumentEncoder(bufferIndex: 0)
+        let slotCount = bindings.model.routedExpertCacheSlotCount(layer: 0)
+        let tileWidth = max(1, min(Self.tileExpertCapacity, slotCount ?? Self.tileExpertCapacity))
+        let schedulerConfig = PrefillRoutedTileSchedulerConfig(maxPendingDepth: 1,
+                                                               tileExperts: tileWidth)
+        self.tileScheduler = PrefillRoutedTileScheduler(config: schedulerConfig)
+        self.pipelineTiles = Self.pipeliningEnabled
+            && schedulerConfig.fitsSlotBudget(slotCount: slotCount ?? 0)
+        let argBufferCount = pipelineTiles ? schedulerConfig.maxPendingDepth + 1 : 1
+        var argPool: [MTLBuffer] = []
+        for index in 0..<argBufferCount {
+            guard let buf = device.makeBuffer(length: max(argEncoder.encodedLength, 16),
+                                              options: .storageModeShared) else {
+                throw ModelError.residentBufferWrapFailed
+            }
+            buf.label = "dsv4.prefill.routedArgumentBuffer.\(index)"
+            argPool.append(buf)
+        }
+        self.argBuffers = argPool
+
+        func buf(_ bytes: Int, _ label: String) throws -> MTLBuffer {
+            guard let b = device.makeBuffer(length: max(bytes, 16),
+                                            options: .storageModeShared) else {
+                throw ModelError.residentBufferWrapFailed
+            }
+            b.label = label
+            return b
+        }
+
+        self.streamStride = mult * D * fp16
+        self.hiddenStride = D * fp16
+        self.actStride = cfg.moeIntermediateSize * fp16
+        self.partialStride = D * MemoryLayout<Float>.stride
+        self.hcPostStride = mult * MemoryLayout<Float>.stride
+        self.hcCombStride = mult * mult * MemoryLayout<Float>.stride
+
+        self.streams = try buf(chunkTokens * streamStride, "dsv4.prefill.streams")
+        self.streamsAlt = try buf(chunkTokens * streamStride, "dsv4.prefill.streamsAlt")
+        self.routedX = try buf(chunkTokens * hiddenStride, "dsv4.prefill.routedX")
+        self.h1 = try buf(chunkTokens * hiddenStride, "dsv4.prefill.h1")
+        self.h2 = try buf(chunkTokens * hiddenStride, "dsv4.prefill.h2")
+        self.routeIndices = try buf(chunkTokens * topK * MemoryLayout<UInt32>.stride,
+                                    "dsv4.prefill.routeIndices")
+        self.routeWeights = try buf(chunkTokens * topK * fp16,
+                                    "dsv4.prefill.routeWeights")
+        self.acts = try buf(chunkTokens * topK * actStride, "dsv4.prefill.acts")
+        self.partials = try buf(chunkTokens * topK * partialStride,
+                                "dsv4.prefill.partials")
+        self.routesBuffer = try buf(chunkTokens * topK * MemoryLayout<DSV4PrefillRoute>.stride,
+                                    "dsv4.prefill.routes")
+        self.routerLogits = try buf(cfg.numExperts * MemoryLayout<Float>.stride,
+                                    "dsv4.prefill.routerLogits")
+        self.hcPostF = try buf(chunkTokens * hcPostStride, "dsv4.prefill.hcPostF")
+        self.hcCombF = try buf(chunkTokens * hcCombStride, "dsv4.prefill.hcCombF")
+
+        let ca = cfg.compressedAttention
+        self.hidden = try buf(hiddenStride, "dsv4.prefill.hidden")
+        self.normed = try buf(hiddenStride, "dsv4.prefill.normed")
+        self.qaBuf = try buf(ca.qLoraRank * fp16, "dsv4.prefill.qa")
+        self.qScratch = try buf(cfg.numHeads * cfg.fullHeadDim * fp16, "dsv4.prefill.q")
+        self.attnOut = try buf(cfg.numHeads * cfg.fullHeadDim * fp16, "dsv4.prefill.attnOut")
+        self.oGrouped = try buf(max(ca.oGroups, 1) * ca.oLoraRank * fp16,
+                                "dsv4.prefill.oGrouped")
+        self.oOut = try buf(hiddenStride, "dsv4.prefill.oOut")
+        self.hcPreA = try buf(hcPostStride, "dsv4.prefill.hcPreA")
+        self.hcPostA = try buf(hcPostStride, "dsv4.prefill.hcPostA")
+        self.hcCombA = try buf(hcCombStride, "dsv4.prefill.hcCombA")
+        self.hcPreF = try buf(hcPostStride, "dsv4.prefill.hcPreF")
+        self.denseGate = try buf(cfg.intermediateSize * fp16, "dsv4.prefill.denseGate")
+        self.denseUp = try buf(cfg.intermediateSize * fp16, "dsv4.prefill.denseUp")
+        self.denseAct = try buf(cfg.intermediateSize * fp16, "dsv4.prefill.denseAct")
+        self.selected = try buf(max(ca.indexTopK, 1) * MemoryLayout<UInt32>.stride,
+                                "dsv4.prefill.selected")
+    }
+
+    /// Escape hatch for A/B-ing the batched path against the token-by-token
+    /// decode replay on a real checkpoint: `MFERENCE_DSV4_PREFILL=off` forces
+    /// every chunk down the fallback. Any other value (or unset) keeps the
+    /// batched path.
+    static let batchedPathEnabled: Bool = flag("MFERENCE_DSV4_PREFILL")
+
+    /// Depth-1 tile pipelining: `MFERENCE_DSV4_PREFILL_PIPELINE=off` disables.
+    ///
+    /// Forward `F_RDADVISE` readahead over the tile sweep was tried here and
+    /// removed: the tiles are already fetched by
+    /// `executeExpertCachePlan`'s 8-way `concurrentPerform` of 8 MB `pread`s,
+    /// which is itself a strong sequential-access signal, and advising one to
+    /// two tiles ahead measured flat-to-slightly-worse on both a 33-token and
+    /// an 802-token prompt.
+    static let pipeliningEnabled: Bool = flag("MFERENCE_DSV4_PREFILL_PIPELINE")
+
+    private static func flag(_ name: String) -> Bool {
+        let raw = ProcessInfo.processInfo.environment[name]?.lowercased()
+        return !(raw == "off" || raw == "0" || raw == "false")
+    }
+
+    /// Whether a chunk starting at `startPosition` can run batched.
+    ///
+    /// The lightning indexer selects a top-`indexTopK` subset of compressed
+    /// entries once a CSA layer holds more than `indexTopK` of them, and the
+    /// selection is a CPU top-k over a GPU readback taken *in the middle* of
+    /// the layer. Batching a whole chunk into one command buffer cannot host a
+    /// per-token mid-layer readback, so chunks that reach that context length
+    /// fall back to the token-by-token path.
+    static func supports(config: ArchConfig,
+                         startPosition: Int,
+                         tokenCount: Int,
+                         expertCacheSlots: Int?) -> Bool {
+        guard batchedPathEnabled else { return false }
+        guard config.routerScoringFunc == "sqrtsoftplus",
+              config.topKExperts == MoEDeepseekV4.topK else { return false }
+        if let expertCacheSlots, expertCacheSlots < 1 { return false }
+        let ca = config.compressedAttention
+        guard ca.csaCompressRate > 0 else { return false }
+        let hasCSA = (0..<config.numLayers).contains { config.layerIsCSA($0) }
+        guard hasCSA else { return true }
+        // Compressed entries after the last token of the chunk.
+        let lastPosition = startPosition + tokenCount - 1
+        let entries = (lastPosition + 1) / ca.csaCompressRate
+        return entries <= ca.indexTopK
+    }
+
+    // MARK: - Entry point
+
+    /// Runs one chunk. Returns the greedy token when the fused head ran.
+    @discardableResult
+    func run(tokens: ArraySlice<Int32>,
+             startPosition: Int,
+             emitHead: Bool,
+             outputMode: PrefillOutputMode,
+             logits: MTLBuffer) async throws -> UInt32? {
+        let tokenList = Array(tokens)
+        let T = tokenList.count
+        guard T > 0 else { return nil }
+        guard T <= chunkTokens else {
+            throw PrefillError.chunkedUnsupported(
+                "DSV4 chunk of \(T) tokens exceeds scratch capacity \(chunkTokens)")
+        }
+        guard b.model.routedExpertWeightBits == 2 else {
+            throw PrefillError.prefillCursorMismatch(
+                "DeepSeek-V4 runtime supports 2-bit routed experts; manifest says \(b.model.routedExpertWeightBits)")
+        }
+
+        try encodeEmbedding(tokens: tokenList)
+        for layer in 0..<b.cfg.numLayers {
+            try encodeAttentionSite(layer: layer, tokens: tokenList,
+                                    startPosition: startPosition, count: T)
+            try await runRoutedMoE(layer: layer, count: T)
+            try encodeLayerTail(layer: layer, count: T)
+        }
+        guard emitHead else { return nil }
+        return try encodeHead(lastToken: T - 1, outputMode: outputMode, logits: logits)
+    }
+
+    // MARK: - Stages
+
+    private func encodeEmbedding(tokens: [Int32]) throws {
+        let cfg = b.cfg
+        let emb = b.model.embedding
+        let cb = try makeCommandBuffer()
+        for (t, token) in tokens.enumerated() {
+            b.embed.encode(commandBuffer: cb,
+                           table: emb.buffer, tableOffset: Int(emb.offset),
+                           scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
+                           biases: emb.buffer, biasesOffset: Int(emb.biasOffset),
+                           out: hidden,
+                           tokenId: UInt32(bitPattern: token),
+                           d: UInt32(cfg.hiddenSize),
+                           outScale: 1.0)
+            b.dsv4.encodeBroadcastStreams(commandBuffer: cb,
+                                          x: hidden,
+                                          streams: streams,
+                                          streamsOffset: t * streamStride,
+                                          hcMult: cfg.hyperConnections.mult,
+                                          hidden: cfg.hiddenSize)
+        }
+        cb.commit()
+        try wait(cb)
+    }
+
+    /// Everything from the attention-site mHC through the router and the
+    /// shared expert, for every token of the chunk, in one command buffer.
+    private func encodeAttentionSite(layer L: Int,
+                                     tokens: [Int32],
+                                     startPosition: Int,
+                                     count T: Int) throws {
+        let cfg = b.cfg
+        let ca = cfg.compressedAttention
+        let hc = cfg.hyperConnections
+        let D = UInt32(cfg.hiddenSize)
+        let eps: Float = 1e-6
+        let headDim = cfg.fullHeadDim
+        let numHeads = cfg.numHeads
+        let fp16 = Self.fp16
+        let isCSA = cfg.layerIsCSA(L)
+        let isHCA = cfg.layerIsHCA(L)
+        let isCompressed = isCSA || isHCA
+        let ropeKind: DSV4Kernels.RopeKind = isCompressed ? .compress : .main
+        let isHash = cfg.layerIsHashRouted(L)
+
+        let inNorm = try b.model.inputNorm(layer: L)
+        let postAttn = try b.model.postAttnNorm(layer: L)
+        let qaView = try b.model.dsv4QAProj(layer: L)
+        let qaNormView = try b.model.dsv4QANorm(layer: L)
+        let qbView = try b.model.dsv4QBProj(layer: L)
+        let kvView = try b.model.dsv4KVProj(layer: L)
+        let kvNormView = try b.model.dsv4KVNorm(layer: L)
+        let oaView = try b.model.dsv4OAProj(layer: L)
+        let obView = try b.model.dsv4OBProj(layer: L)
+        let sinksView = try b.model.dsv4Sinks(layer: L)
+        let attnFn = try b.model.dsv4AttnHCFn(layer: L)
+        let attnBase = try b.model.dsv4AttnHCBase(layer: L)
+        let attnScale3 = try b.model.dsv4AttnHCScale(layer: L)
+        let ffnFn = try b.model.dsv4FFNHCFn(layer: L)
+        let ffnBase = try b.model.dsv4FFNHCBase(layer: L)
+        let ffnScale3 = try b.model.dsv4FFNHCScale(layer: L)
+        let routerW = try b.model.router(layer: L)
+        let sharedProj = b.sharedExperts[L]
+        let correctionBias = isHash ? nil : try b.model.dsv4RouterCorrectionBias(layer: L)
+        let hashTable = isHash ? try b.model.dsv4HashTable(layer: L) : nil
+
+        var counters = b.state.counters[L]
+        let cb = try makeCommandBuffer()
+
+        for t in 0..<T {
+            let position = startPosition + t
+            let streamOff = t * streamStride
+
+            b.dsv4.encodeHCWeights(commandBuffer: cb,
+                                   streams: streams, streamsOffset: streamOff,
+                                   fn: attnFn.buffer, fnOffset: Int(attnFn.offset),
+                                   base: attnBase.buffer, baseOffset: Int(attnBase.offset),
+                                   scale: attnScale3.buffer, scaleOffset: Int(attnScale3.offset),
+                                   outPre: hcPreA, outPost: hcPostA, outComb: hcCombA,
+                                   hcMult: hc.mult, hidden: cfg.hiddenSize,
+                                   sinkhornIters: hc.sinkhornIters,
+                                   hcEps: Float(hc.eps), rmsEps: eps)
+            b.dsv4.encodeHCCollapse(commandBuffer: cb,
+                                    streams: streams, streamsOffset: streamOff,
+                                    pre: hcPreA, x: hidden,
+                                    hcMult: hc.mult, hidden: cfg.hiddenSize)
+            b.rms.encodeBF16W(commandBuffer: cb, x: hidden,
+                              weight: inNorm.buffer, weightOffset: Int(inNorm.offset),
+                              out: normed, d: D, eps: eps)
+
+            gemv(cb, qaView, x: normed, y: qaBuf, m: ca.qLoraRank, n: cfg.hiddenSize)
+            b.rms.encodeBF16W(commandBuffer: cb, x: qaBuf,
+                              weight: qaNormView.buffer,
+                              weightOffset: Int(qaNormView.offset),
+                              out: qaBuf, d: UInt32(ca.qLoraRank), eps: eps)
+            gemv(cb, qbView, x: qaBuf, y: qScratch,
+                 m: numHeads * headDim, n: ca.qLoraRank)
+            b.rms.encodeNoScalePerHead(commandBuffer: cb, x: qScratch, out: qScratch,
+                                       headDim: UInt32(headDim),
+                                       numHeads: numHeads, eps: eps)
+            b.dsv4.encodeRope(commandBuffer: cb, x: qScratch,
+                              numHeads: numHeads, headDim: headDim,
+                              ropeDim: ca.ropeHeadDim,
+                              position: position, rope: ropeKind, direction: 1)
+
+            let slot = b.state.windowSlot(position: position)
+            let ring = b.state.windowKV[L]
+            let slotOffset = slot * headDim * fp16
+            gemv(cb, kvView, x: normed, y: ring, yOffset: slotOffset,
+                 m: headDim, n: cfg.hiddenSize)
+            b.rms.encodeBF16W(commandBuffer: cb, x: ring, xOffset: slotOffset,
+                              weight: kvNormView.buffer,
+                              weightOffset: Int(kvNormView.offset),
+                              out: ring, outOffset: slotOffset,
+                              d: UInt32(headDim), eps: eps)
+            b.dsv4.encodeRope(commandBuffer: cb, x: ring, xOffset: slotOffset,
+                              numHeads: 1, headDim: headDim,
+                              ropeDim: ca.ropeHeadDim,
+                              position: position, rope: ropeKind, direction: 1)
+
+            var willEmit = false
+            var willEmitIndexer = false
+            if isCompressed {
+                let rate = isCSA ? ca.csaCompressRate : ca.hcaCompressRate
+                let rowWidth = isCSA ? 2 * headDim : headDim
+                let compKV = try b.model.dsv4CompressorKVProj(layer: L)
+                let compGate = try b.model.dsv4CompressorGateProj(layer: L)
+                let compNorm = try b.model.dsv4CompressorKVNorm(layer: L)
+                let compBias = try b.model.dsv4CompressorPositionBias(layer: L)
+                let rowOffset = counters.pendingRows * rowWidth * fp16
+                gemv(cb, compKV, x: normed,
+                     y: b.state.pendingKV[L]!, yOffset: rowOffset,
+                     m: rowWidth, n: cfg.hiddenSize)
+                gemv(cb, compGate, x: normed,
+                     y: b.state.pendingGate[L]!, yOffset: rowOffset,
+                     m: rowWidth, n: cfg.hiddenSize)
+                willEmit = counters.pendingRows + 1 == rate
+                if willEmit {
+                    let entry = counters.compressedEntries
+                    b.dsv4.encodeCompressEmit(
+                        commandBuffer: cb,
+                        pendingKV: b.state.pendingKV[L]!,
+                        pendingGate: b.state.pendingGate[L]!,
+                        priorCaKV: b.state.priorCaKV[L] ?? b.state.pendingKV[L]!,
+                        priorCaGate: b.state.priorCaGate[L] ?? b.state.pendingGate[L]!,
+                        positionBias: compBias.buffer,
+                        positionBiasOffset: Int(compBias.offset),
+                        normWeight: compNorm.buffer,
+                        normWeightOffset: Int(compNorm.offset),
+                        outEntry: b.state.compressedKV[L]!,
+                        outEntryOffset: entry * headDim * fp16,
+                        nextPriorCaKV: b.state.priorCaKV[L] ?? b.state.pendingKV[L]!,
+                        nextPriorCaGate: b.state.priorCaGate[L] ?? b.state.pendingGate[L]!,
+                        rate: rate, dim: headDim, dual: isCSA,
+                        hasPrior: counters.hasPrior, eps: eps)
+                    b.dsv4.encodeRope(commandBuffer: cb,
+                                      x: b.state.compressedKV[L]!,
+                                      xOffset: entry * headDim * fp16,
+                                      numHeads: 1, headDim: headDim,
+                                      ropeDim: ca.ropeHeadDim,
+                                      position: entry * rate,
+                                      rope: .compress, direction: 1)
+                }
+                if isCSA {
+                    let idxRate = ca.csaCompressRate
+                    let idxDim = ca.indexHeadDim
+                    let idxKV = try b.model.dsv4IndexerKVProj(layer: L)
+                    let idxGate = try b.model.dsv4IndexerGateProj(layer: L)
+                    let idxNorm = try b.model.dsv4IndexerKVNorm(layer: L)
+                    let idxBias = try b.model.dsv4IndexerPositionBias(layer: L)
+                    let idxRowOffset = counters.indexerPendingRows * 2 * idxDim * fp16
+                    gemv(cb, idxKV, x: normed,
+                         y: b.state.indexerPendingKV[L]!, yOffset: idxRowOffset,
+                         m: 2 * idxDim, n: cfg.hiddenSize)
+                    gemv(cb, idxGate, x: normed,
+                         y: b.state.indexerPendingGate[L]!, yOffset: idxRowOffset,
+                         m: 2 * idxDim, n: cfg.hiddenSize)
+                    willEmitIndexer = counters.indexerPendingRows + 1 == idxRate
+                    if willEmitIndexer {
+                        let entry = counters.indexerEntries
+                        b.dsv4.encodeCompressEmit(
+                            commandBuffer: cb,
+                            pendingKV: b.state.indexerPendingKV[L]!,
+                            pendingGate: b.state.indexerPendingGate[L]!,
+                            priorCaKV: b.state.indexerPriorCaKV[L]!,
+                            priorCaGate: b.state.indexerPriorCaGate[L]!,
+                            positionBias: idxBias.buffer,
+                            positionBiasOffset: Int(idxBias.offset),
+                            normWeight: idxNorm.buffer,
+                            normWeightOffset: Int(idxNorm.offset),
+                            outEntry: b.state.indexerKeys[L]!,
+                            outEntryOffset: entry * idxDim * fp16,
+                            nextPriorCaKV: b.state.indexerPriorCaKV[L]!,
+                            nextPriorCaGate: b.state.indexerPriorCaGate[L]!,
+                            rate: idxRate, dim: idxDim, dual: true,
+                            hasPrior: counters.indexerHasPrior, eps: eps)
+                        b.dsv4.encodeRope(commandBuffer: cb,
+                                          x: b.state.indexerKeys[L]!,
+                                          xOffset: entry * idxDim * fp16,
+                                          numHeads: 1, headDim: idxDim,
+                                          ropeDim: ca.ropeHeadDim,
+                                          position: entry * idxRate,
+                                          rope: .compress, direction: 1)
+                    }
+                }
+            }
+
+            let compressedCount = isCompressed
+                ? counters.compressedEntries + (willEmit ? 1 : 0)
+                : 0
+            // `supports` guarantees no token in this chunk needs lightning
+            // selection, so every compressed entry is attended.
+            precondition(!(isCSA && compressedCount > ca.indexTopK),
+                         "DSV4 chunked prefill reached lightning-indexer selection")
+
+            b.dsv4.encodeAttention(
+                commandBuffer: cb, q: qScratch,
+                windowKV: ring,
+                compressedKV: b.state.compressedKV[L] ?? ring,
+                selected: selected,
+                sinks: sinksView.buffer, sinksOffset: Int(sinksView.offset),
+                out: attnOut,
+                headDim: headDim, numHeads: numHeads,
+                windowCount: b.state.windowCount(position: position),
+                windowStartPos: b.state.windowStartPosition(position: position),
+                ringCapacity: b.state.ringCapacity,
+                compressedCount: compressedCount,
+                selectedCount: DSV4Kernels.selectAll,
+                scale: Float(cfg.attentionScale))
+            b.dsv4.encodeRope(commandBuffer: cb, x: attnOut,
+                              numHeads: numHeads, headDim: headDim,
+                              ropeDim: ca.ropeHeadDim,
+                              position: position, rope: ropeKind, direction: -1)
+
+            b.dsv4.encodeOGroupProjection(
+                commandBuffer: cb,
+                weights: oaView.buffer, weightsOffset: Int(oaView.offset),
+                scales: oaView.buffer, scalesOffset: Int(oaView.scaleOffset),
+                biases: oaView.buffer, biasesOffset: Int(oaView.biasOffset),
+                x: attnOut, y: oGrouped,
+                rank: ca.oLoraRank,
+                groupIn: numHeads * headDim / ca.oGroups,
+                groups: ca.oGroups)
+            gemv(cb, obView, x: oGrouped, y: oOut,
+                 m: cfg.hiddenSize, n: ca.oGroups * ca.oLoraRank)
+
+            b.dsv4.encodeHCPlaceMix(commandBuffer: cb,
+                                    streams: streams, streamsOffset: streamOff,
+                                    sub: oOut, post: hcPostA, comb: hcCombA,
+                                    outStreams: streamsAlt, outStreamsOffset: streamOff,
+                                    hcMult: hc.mult, hidden: cfg.hiddenSize)
+
+            b.dsv4.encodeHCWeights(commandBuffer: cb,
+                                   streams: streamsAlt, streamsOffset: streamOff,
+                                   fn: ffnFn.buffer, fnOffset: Int(ffnFn.offset),
+                                   base: ffnBase.buffer, baseOffset: Int(ffnBase.offset),
+                                   scale: ffnScale3.buffer, scaleOffset: Int(ffnScale3.offset),
+                                   outPre: hcPreF,
+                                   outPost: hcPostF, outPostOffset: t * hcPostStride,
+                                   outComb: hcCombF, outCombOffset: t * hcCombStride,
+                                   hcMult: hc.mult, hidden: cfg.hiddenSize,
+                                   sinkhornIters: hc.sinkhornIters,
+                                   hcEps: Float(hc.eps), rmsEps: eps)
+            b.dsv4.encodeHCCollapse(commandBuffer: cb,
+                                    streams: streamsAlt, streamsOffset: streamOff,
+                                    pre: hcPreF, x: hidden,
+                                    hcMult: hc.mult, hidden: cfg.hiddenSize)
+            b.rms.encodeBF16W(commandBuffer: cb, x: hidden,
+                              weight: postAttn.buffer,
+                              weightOffset: Int(postAttn.offset),
+                              out: routedX, outOffset: t * hiddenStride,
+                              d: D, eps: eps)
+
+            if let hashTable {
+                writeHashRoute(table: hashTable, token: tokens[t], tokenIndex: t)
+                encodeRouterGemv(cb, weights: routerW, hiddenOffset: t * hiddenStride,
+                                 onesScale: b.effectiveScales[L])
+                encodeRouterHashWeights(cb, tokenIndex: t)
+            } else {
+                encodeRouterGemv(cb, weights: routerW, hiddenOffset: t * hiddenStride,
+                                 onesScale: b.effectiveScales[L])
+                encodeRouterSelect(cb, correctionBias: correctionBias!, tokenIndex: t)
+            }
+
+            encodeSharedExpert(cb, proj: sharedProj, tokenIndex: t)
+
+            counters.tokens += 1
+            if isCompressed {
+                if willEmit {
+                    counters.pendingRows = 0
+                    counters.compressedEntries += 1
+                    if isCSA { counters.hasPrior = true }
+                } else {
+                    counters.pendingRows += 1
+                }
+                if isCSA {
+                    if willEmitIndexer {
+                        counters.indexerPendingRows = 0
+                        counters.indexerEntries += 1
+                        counters.indexerHasPrior = true
+                    } else {
+                        counters.indexerPendingRows += 1
+                    }
+                }
+            }
+        }
+
+        cb.commit()
+        try wait(cb)
+        b.state.counters[L] = counters
+    }
+
+    /// Pair-major routed MoE: sort the chunk's routes by expert, stream each
+    /// expert tile once, and apply it to every route that lands on it.
+    private func runRoutedMoE(layer L: Int, count T: Int) async throws {
+        let cfg = b.cfg
+        let topK = cfg.topKExperts
+        let routeCount = T * topK
+        let idPtr = routeIndices.contents().bindMemory(to: UInt32.self,
+                                                       capacity: routeCount)
+        var experts = [Int](repeating: 0, count: routeCount)
+        for i in 0..<routeCount {
+            experts[i] = min(Int(idPtr[i]), cfg.numExperts - 1)
+        }
+
+        // Group routes by expert, expert order following the on-disk layout so
+        // each tile is a forward sweep of the expert file.
+        let physical = b.model.routedExpertPhysicalOffsets(layer: L)
+        var byExpert = [Int: [Int]]()
+        byExpert.reserveCapacity(min(cfg.numExperts, routeCount))
+        for i in 0..<routeCount { byExpert[experts[i], default: []].append(i) }
+        let liveExperts = byExpert.keys.sorted {
+            let lhs = $0 < physical.count ? physical[$0] : UInt64($0)
+            let rhs = $1 < physical.count ? physical[$1] : UInt64($1)
+            return lhs == rhs ? $0 < $1 : lhs < rhs
+        }
+
+        let routesPtr = routesBuffer.contents()
+            .bindMemory(to: DSV4PrefillRoute.self, capacity: routeCount)
+        let perTile = tileScheduler.config.tileExperts
+        var tiles: [(experts: [Int], routeStart: Int, routeCount: Int)] = []
+        var written = 0
+        var index = 0
+        while index < liveExperts.count {
+            let slice = Array(liveExperts[index..<min(index + perTile, liveExperts.count)])
+            let start = written
+            for (localSlot, expert) in slice.enumerated() {
+                for route in byExpert[expert]! {
+                    routesPtr[written] = DSV4PrefillRoute(
+                        token: UInt32(route / topK),
+                        rank: UInt32(route % topK),
+                        localSlot: UInt32(localSlot))
+                    written += 1
+                }
+            }
+            tiles.append((slice, start, written - start))
+            index += perTile
+        }
+
+        let routedOffsets = b.model.routedExpertOffsets(layer: L)
+        let gateGroupSize = UInt32(b.model.routedGateGroupSize(layer: L))
+        let liveTiles = tiles.filter { $0.routeCount > 0 }
+
+        var pending: PendingRoutedTile?
+        for (index, tile) in liveTiles.enumerated() {
+            // Plan around the in-flight tile's slots so its GPU work keeps
+            // reading valid blobs while this tile's pread lands.
+            var plan: RoutedExpertFetchPlan?
+            if let inFlight = pending {
+                let candidate = inFlight.assignedSlots.isEmpty
+                    ? nil
+                    : try b.model.planRoutedExpertsIfPossible(
+                        layer: L, experts: tile.experts,
+                        avoidingSlots: Set(inFlight.assignedSlots))
+                let decision = tileScheduler.decide(PrefillRoutedTileSchedulerInput(
+                    hasPendingTile: true,
+                    pendingAssignedSlots: inFlight.assignedSlots,
+                    avoidingSlotPlanAvailable: candidate != nil))
+                switch decision {
+                case .prefetchNext:
+                    plan = candidate
+                case .drainBeforeIssue, .issueWithoutPending:
+                    try wait(inFlight.cb)
+                    pending = nil
+                }
+            }
+            if plan == nil {
+                plan = try b.model.planRoutedExperts(layer: L, experts: tile.experts)
+            }
+            guard let tilePlan = plan else {
+                throw ModelError.routedExpertPlanUnavailable(layer: L)
+            }
+
+            let blobs = try await b.model.fetchRoutedExperts(plan: tilePlan).map(\.buffer)
+            let argBuf = argBuffers[index % argBuffers.count]
+            encodeArguments(into: argBuf, blobs: blobs)
+            let cb = try makeCommandBuffer()
+            encodeRoutedPairs(cb, pso: phase1PSO, argBuffer: argBuf, blobs: blobs,
+                              offsets: routedOffsets, gateGroupSize: gateGroupSize,
+                              routeStart: tile.routeStart, routeCount: tile.routeCount,
+                              rowsPerRoute: cfg.moeIntermediateSize, isPhase1: true)
+            encodeRoutedPairs(cb, pso: downPSO, argBuffer: argBuf, blobs: blobs,
+                              offsets: routedOffsets, gateGroupSize: gateGroupSize,
+                              routeStart: tile.routeStart, routeCount: tile.routeCount,
+                              rowsPerRoute: cfg.hiddenSize, isPhase1: false)
+            cb.commit()
+            if let inFlight = pending { try wait(inFlight.cb) }
+            if pipelineTiles {
+                pending = PendingRoutedTile(cb: cb, assignedSlots: tilePlan.assignedSlots)
+            } else {
+                try wait(cb)
+                pending = nil
+            }
+        }
+        if let inFlight = pending { try wait(inFlight.cb) }
+
+        // Residual-first, rank-ordered reduce: h2 = shared + sum_k w_k * down_k.
+        let reduceCB = try makeCommandBuffer()
+        if let enc = reduceCB.makeComputeCommandEncoder() {
+            enc.setComputePipelineState(reducePSO)
+            enc.setBuffer(partials, offset: 0, index: 0)
+            enc.setBuffer(h1, offset: 0, index: 1)
+            enc.setBuffer(h2, offset: 0, index: 2)
+            var d = UInt32(cfg.hiddenSize)
+            enc.setBytes(&d, length: MemoryLayout<UInt32>.stride, index: 3)
+            enc.dispatchThreads(MTLSize(width: cfg.hiddenSize, height: T, depth: 1),
+                                threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+            enc.endEncoding()
+        }
+        reduceCB.commit()
+        try wait(reduceCB)
+    }
+
+    /// FFN-site placement + residual mix: streamsAlt -> streams.
+    private func encodeLayerTail(layer _: Int, count T: Int) throws {
+        let cfg = b.cfg
+        let hc = cfg.hyperConnections
+        let cb = try makeCommandBuffer()
+        for t in 0..<T {
+            b.dsv4.encodeHCPlaceMix(commandBuffer: cb,
+                                    streams: streamsAlt, streamsOffset: t * streamStride,
+                                    sub: h2, subOffset: t * hiddenStride,
+                                    post: hcPostF, postOffset: t * hcPostStride,
+                                    comb: hcCombF, combOffset: t * hcCombStride,
+                                    outStreams: streams, outStreamsOffset: t * streamStride,
+                                    hcMult: hc.mult, hidden: cfg.hiddenSize)
+        }
+        cb.commit()
+        try wait(cb)
+    }
+
+    private func encodeHead(lastToken t: Int,
+                            outputMode: PrefillOutputMode,
+                            logits: MTLBuffer) throws -> UInt32? {
+        let cfg = b.cfg
+        let hc = cfg.hyperConnections
+        let D = UInt32(cfg.hiddenSize)
+        let eps: Float = 1e-6
+        let hhFn = try b.model.dsv4HyperHeadFn
+        let hhBase = try b.model.dsv4HyperHeadBase
+        let hhScale = try b.model.dsv4HyperHeadScale
+        let fNorm = b.model.finalNorm
+        let lm = b.model.lmHead
+        let cb = try makeCommandBuffer()
+        b.dsv4.encodeHyperHead(commandBuffer: cb,
+                               streams: streams, streamsOffset: t * streamStride,
+                               fn: hhFn.buffer, fnOffset: Int(hhFn.offset),
+                               base: hhBase.buffer, baseOffset: Int(hhBase.offset),
+                               scale: hhScale.buffer, scaleOffset: Int(hhScale.offset),
+                               x: hidden,
+                               hcMult: hc.mult, hidden: cfg.hiddenSize,
+                               hcEps: Float(hc.eps), rmsEps: eps)
+        let fused = b.useFusedGreedyHead && outputMode == .greedyIfAvailable
+        var greedyBuf: MTLBuffer?
+        if fused {
+            guard let out = b.ctx.device.makeBuffer(length: MemoryLayout<UInt32>.stride,
+                                                    options: .storageModeShared) else {
+                throw ModelError.residentBufferWrapFailed
+            }
+            greedyBuf = out
+            b.fusionHead.encodeGreedyDecode(
+                commandBuffer: cb,
+                hidden: hidden,
+                normWeight: fNorm.buffer, normOffset: Int(fNorm.offset),
+                weights: lm.buffer, weightsOffset: Int(lm.offset),
+                scales: lm.buffer, scalesOffset: Int(lm.scaleOffset),
+                biases: lm.buffer, biasesOffset: Int(lm.biasOffset),
+                outToken: out,
+                d: D, vocab: UInt32(cfg.vocabSize),
+                rmsEps: eps)
+        } else {
+            b.rms.encodeBF16W(commandBuffer: cb, x: hidden,
+                              weight: fNorm.buffer, weightOffset: Int(fNorm.offset),
+                              out: normed, d: D, eps: eps)
+            b.int4.encode(commandBuffer: cb,
+                          weights: lm.buffer, weightsOffset: Int(lm.offset),
+                          scales: lm.buffer, scalesOffset: Int(lm.scaleOffset),
+                          biases: lm.buffer, biasesOffset: Int(lm.biasOffset),
+                          x: normed, y: logits,
+                          m: UInt32(cfg.vocabSize), n: D)
+        }
+        cb.commit()
+        try wait(cb)
+        return greedyBuf.map { $0.contents().load(as: UInt32.self) }
+    }
+
+    // MARK: - Encoding helpers
+
+    private func gemv(_ cb: MTLCommandBuffer, _ view: TensorView,
+                      x: MTLBuffer, xOffset: Int = 0,
+                      y: MTLBuffer, yOffset: Int = 0,
+                      m: Int, n: Int) {
+        b.int4.encode(commandBuffer: cb,
+                      weights: view.buffer, weightsOffset: Int(view.offset),
+                      scales: view.buffer, scalesOffset: Int(view.scaleOffset),
+                      biases: view.buffer, biasesOffset: Int(view.biasOffset),
+                      x: x, xOffset: xOffset,
+                      y: y, yOffset: yOffset,
+                      m: UInt32(m), n: UInt32(n))
+    }
+
+    private func encodeSharedExpert(_ cb: MTLCommandBuffer,
+                                    proj: DSV4PrefillSharedExpert,
+                                    tokenIndex t: Int) {
+        let cfg = b.cfg
+        let D = UInt32(cfg.hiddenSize)
+        let F = UInt32(cfg.intermediateSize)
+        let xOff = t * hiddenStride
+        b.int4.encode(commandBuffer: cb,
+                      weights: proj.gate.weights, weightsOffset: proj.gate.weightsOffset,
+                      scales: proj.gate.scales, scalesOffset: proj.gate.scalesOffset,
+                      biases: proj.gate.biases, biasesOffset: proj.gate.biasesOffset,
+                      x: routedX, xOffset: xOff, y: denseGate, m: F, n: D)
+        b.int4.encode(commandBuffer: cb,
+                      weights: proj.up.weights, weightsOffset: proj.up.weightsOffset,
+                      scales: proj.up.scales, scalesOffset: proj.up.scalesOffset,
+                      biases: proj.up.biases, biasesOffset: proj.up.biasesOffset,
+                      x: routedX, xOffset: xOff, y: denseUp, m: F, n: D)
+        b.dsv4.encodeSwigluClampMul(commandBuffer: cb,
+                                    gate: denseGate, up: denseUp, out: denseAct,
+                                    n: cfg.intermediateSize,
+                                    limit: Float(cfg.swigluLimit))
+        b.int4.encode(commandBuffer: cb,
+                      weights: proj.down.weights, weightsOffset: proj.down.weightsOffset,
+                      scales: proj.down.scales, scalesOffset: proj.down.scalesOffset,
+                      biases: proj.down.biases, biasesOffset: proj.down.biasesOffset,
+                      x: denseAct, y: h1, yOffset: t * hiddenStride, m: D, n: F)
+    }
+
+    private func writeHashRoute(table: TensorView, token: Int32, tokenIndex t: Int) {
+        let cfg = b.cfg
+        let base = table.buffer.contents().advanced(by: Int(table.offset))
+        let row = min(max(Int(token), 0), cfg.vocabSize - 1) * cfg.topKExperts
+        let idxPtr = routeIndices.contents().assumingMemoryBound(to: UInt32.self)
+        let expertCap = UInt32(cfg.numExperts - 1)
+        let out = t * cfg.topKExperts
+        if table.dtype == 4 {
+            let tPtr = base.assumingMemoryBound(to: Int64.self)
+            for i in 0..<cfg.topKExperts {
+                idxPtr[out + i] = min(UInt32(clamping: max(0, tPtr[row + i])), expertCap)
+            }
+        } else {
+            let tPtr = base.assumingMemoryBound(to: UInt32.self)
+            for i in 0..<cfg.topKExperts {
+                idxPtr[out + i] = min(tPtr[row + i], expertCap)
+            }
+        }
+    }
+
+    private func encodeRouterGemv(_ cb: MTLCommandBuffer,
+                                  weights: TensorView,
+                                  hiddenOffset: Int,
+                                  onesScale: MTLBuffer) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var expertCount = UInt32(b.cfg.numExperts)
+        var dimension = UInt32(b.cfg.hiddenSize)
+        enc.setComputePipelineState(routerGemvPSO)
+        enc.setBuffer(weights.buffer, offset: Int(weights.offset), index: 0)
+        enc.setBuffer(routedX, offset: hiddenOffset, index: 1)
+        enc.setBuffer(onesScale, offset: 0, index: 2)
+        enc.setBuffer(routerLogits, offset: 0, index: 3)
+        enc.setBytes(&expertCount, length: MemoryLayout<UInt32>.stride, index: 4)
+        enc.setBytes(&dimension, length: MemoryLayout<UInt32>.stride, index: 5)
+        enc.dispatchThreadgroups(
+            MTLSize(width: (b.cfg.numExperts + 3) / 4, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    private func encodeRouterSelect(_ cb: MTLCommandBuffer,
+                                    correctionBias: TensorView,
+                                    tokenIndex t: Int) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var expertCount = UInt32(b.cfg.numExperts)
+        var scale = Float(b.cfg.routedScalingFactor)
+        enc.setComputePipelineState(routerSelectPSO)
+        enc.setBuffer(routerLogits, offset: 0, index: 0)
+        enc.setBuffer(correctionBias.buffer, offset: Int(correctionBias.offset), index: 1)
+        enc.setBuffer(routeIndices,
+                      offset: t * b.cfg.topKExperts * MemoryLayout<UInt32>.stride, index: 2)
+        enc.setBuffer(routeWeights, offset: t * b.cfg.topKExperts * Self.fp16, index: 3)
+        enc.setBytes(&expertCount, length: MemoryLayout<UInt32>.stride, index: 4)
+        enc.setBytes(&scale, length: MemoryLayout<Float>.stride, index: 5)
+        enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    private func encodeRouterHashWeights(_ cb: MTLCommandBuffer, tokenIndex t: Int) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var scale = Float(b.cfg.routedScalingFactor)
+        enc.setComputePipelineState(routerHashPSO)
+        enc.setBuffer(routerLogits, offset: 0, index: 0)
+        enc.setBuffer(routeIndices,
+                      offset: t * b.cfg.topKExperts * MemoryLayout<UInt32>.stride, index: 1)
+        enc.setBuffer(routeWeights, offset: t * b.cfg.topKExperts * Self.fp16, index: 2)
+        enc.setBytes(&scale, length: MemoryLayout<Float>.stride, index: 3)
+        enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    private func encodeArguments(into argBuffer: MTLBuffer, blobs: [MTLBuffer]) {
+        argEncoder.setArgumentBuffer(argBuffer, offset: 0)
+        for (index, blob) in blobs.enumerated() where index < Self.tileExpertCapacity {
+            argEncoder.setBuffer(blob, offset: 0, index: index)
+        }
+        // Never leave a dangling pointer in an unused slot.
+        if let first = blobs.first {
+            for index in blobs.count..<Self.tileExpertCapacity {
+                argEncoder.setBuffer(first, offset: 0, index: index)
+            }
+        }
+    }
+
+    private func encodeRoutedPairs(_ cb: MTLCommandBuffer,
+                                   pso: MTLComputePipelineState,
+                                   argBuffer: MTLBuffer,
+                                   blobs: [MTLBuffer],
+                                   offsets: MoEExpertOffsets,
+                                   gateGroupSize: UInt32,
+                                   routeStart: Int,
+                                   routeCount: Int,
+                                   rowsPerRoute: Int,
+                                   isPhase1: Bool) {
+        guard routeCount > 0, let enc = cb.makeComputeCommandEncoder() else { return }
+        enc.setComputePipelineState(pso)
+        enc.setBuffer(argBuffer, offset: 0, index: 0)
+        for blob in blobs { enc.useResource(blob, usage: .read) }
+        var routedOffsets = offsets
+        enc.setBytes(&routedOffsets, length: MemoryLayout<MoEExpertOffsets>.stride, index: 1)
+        var d = UInt32(b.cfg.hiddenSize)
+        var f = UInt32(b.cfg.moeIntermediateSize)
+        var topK = UInt32(b.cfg.topKExperts)
+        var start = UInt32(routeStart)
+        var count = UInt32(routeCount)
+        if isPhase1 {
+            enc.setBuffer(routedX, offset: 0, index: 2)
+            enc.setBuffer(acts, offset: 0, index: 3)
+            enc.setBytes(&d, length: MemoryLayout<UInt32>.stride, index: 4)
+            enc.setBytes(&f, length: MemoryLayout<UInt32>.stride, index: 5)
+            enc.setBytes(&topK, length: MemoryLayout<UInt32>.stride, index: 6)
+            var gateGroup = gateGroupSize
+            enc.setBytes(&gateGroup, length: MemoryLayout<UInt32>.stride, index: 7)
+        } else {
+            enc.setBuffer(acts, offset: 0, index: 2)
+            enc.setBuffer(routeWeights, offset: 0, index: 3)
+            enc.setBuffer(partials, offset: 0, index: 4)
+            enc.setBytes(&d, length: MemoryLayout<UInt32>.stride, index: 5)
+            enc.setBytes(&f, length: MemoryLayout<UInt32>.stride, index: 6)
+            enc.setBytes(&topK, length: MemoryLayout<UInt32>.stride, index: 7)
+        }
+        enc.setBuffer(routesBuffer, offset: 0, index: 8)
+        enc.setBytes(&start, length: MemoryLayout<UInt32>.stride, index: 9)
+        enc.setBytes(&count, length: MemoryLayout<UInt32>.stride, index: 10)
+        let rows = routeCount * rowsPerRoute
+        enc.dispatchThreadgroups(
+            MTLSize(width: (rows + 7) / 8, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    private func makeCommandBuffer() throws -> MTLCommandBuffer {
+        guard let cb = b.ctx.queue.makeCommandBuffer() else {
+            throw ModelError.residentBufferWrapFailed
+        }
+        return cb
+    }
+
+    private func wait(_ cb: MTLCommandBuffer) throws {
+        cb.waitUntilCompleted()
+        if let error = cb.error { throw error }
+    }
+}

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -1050,15 +1050,19 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             var pos = startPosition
             var done = 0
             for (spanIndex, span) in spans.enumerated() {
-                let lower = tokens.index(tokens.startIndex, offsetBy: span.tokenOffset)
-                let upper = tokens.index(lower, offsetBy: span.tokenCount)
                 let isLastSpan = spanIndex == spans.count - 1
-                let batched = DSV4ChunkedPrefill.supports(
+                // A span crossing the lightning-selection cutover keeps its
+                // eligible prefix batched; only the remainder replays
+                // token-by-token.
+                var batchedCount = DSV4ChunkedPrefill.batchedTokenPrefix(
                     config: cfg,
                     startPosition: span.startPosition,
                     tokenCount: span.tokenCount,
                     expertCacheSlots: expertSlots)
-                if batched, let dsv4, let moeDSV4, let dsv4State {
+                if dsv4 == nil || moeDSV4 == nil || dsv4State == nil {
+                    batchedCount = 0
+                }
+                if batchedCount > 0, let dsv4, let moeDSV4, let dsv4State {
                     let bindings = DSV4PrefillBindings(
                         model: model, ctx: ctx, cfg: cfg,
                         dsv4: dsv4, moeDSV4: moeDSV4, state: dsv4State,
@@ -1070,26 +1074,40 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                         effectiveScales: effectiveScaleBuffers,
                         useFusedGreedyHead: useFusedGreedyHead)
                     let runner: DSV4ChunkedPrefill
-                    if let cached = dsv4Prefill, cached.chunkCapacity >= span.tokenCount {
+                    if let cached = dsv4Prefill, cached.chunkCapacity >= batchedCount {
                         runner = cached
                     } else {
                         runner = try DSV4ChunkedPrefill(
                             bindings: bindings,
-                            chunkTokens: max(config.chunkTokens, span.tokenCount))
+                            chunkTokens: max(config.chunkTokens, batchedCount))
                         dsv4Prefill = runner
                     }
+                    let lower = tokens.index(tokens.startIndex, offsetBy: span.tokenOffset)
+                    let upper = tokens.index(lower, offsetBy: batchedCount)
+                    // The batched runner advances DSV4 layer state as it
+                    // encodes; if it throws partway the layer state is ahead
+                    // of the KV cursor, so the runner must reject further use
+                    // until reset() — same discipline as executePrefillChunk.
+                    prefillChunkState.markDirty(startPosition: span.startPosition,
+                                                tokenCount: batchedCount)
                     let greedy = try await runner.run(tokens: tokens[lower..<upper],
                                                       startPosition: span.startPosition,
-                                                      emitHead: isLastSpan,
+                                                      emitHead: isLastSpan && batchedCount == span.tokenCount,
                                                       outputMode: outputMode,
                                                       logits: logits)
                     if let greedy { lastGreedyToken = greedy }
-                    for _ in 0..<span.tokenCount { kv?.advance() }
-                    pos += span.tokenCount
-                } else {
+                    for _ in 0..<batchedCount { kv?.advance() }
+                    pos += batchedCount
+                    prefillChunkState.markCommitted()
+                }
+                if batchedCount < span.tokenCount {
+                    let remainder = span.tokenCount - batchedCount
+                    let lower = tokens.index(tokens.startIndex,
+                                             offsetBy: span.tokenOffset + batchedCount)
+                    let upper = tokens.index(lower, offsetBy: remainder)
                     var index = 0
                     for t in tokens[lower..<upper] {
-                        let isLast = isLastSpan && index == span.tokenCount - 1
+                        let isLast = isLastSpan && index == remainder - 1
                         try await produceTokenDSV4(token: t, position: pos,
                                                    into: logits,
                                                    emitHead: isLast,

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -237,10 +237,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     private let dsv4HCPreF: MTLBuffer?           // [mult] FP32, FFN site
     private let dsv4HCPostF: MTLBuffer?          // [mult] FP32
     private let dsv4HCCombF: MTLBuffer?          // [mult * mult] FP32
-    private let dsv4CompKVRow: MTLBuffer?        // [2 * headDim] FP16
-    private let dsv4CompGateRow: MTLBuffer?      // [2 * headDim] FP16
-    private let dsv4IdxKVRow: MTLBuffer?         // [2 * indexHeadDim] FP16
-    private let dsv4IdxGateRow: MTLBuffer?       // [2 * indexHeadDim] FP16
     private let dsv4IndexerQ: MTLBuffer?         // [indexNHeads * indexHeadDim]
     private let dsv4IndexerW: MTLBuffer?         // [indexNHeads] FP16
     private let dsv4IndexerScores: MTLBuffer?    // [maxContext / csaRate] FP32
@@ -250,6 +246,9 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     private let onesPerExpertScale: MTLBuffer?
     private var prefillChunkState = PrefillChunkCommitState()
     private var prefillScratch: PrefillChunkScratchBuffers?
+    /// Lazily built layer-major DeepSeek-V4 prefill; see
+    /// `RealForwardRunner+DSV4Prefill.swift`.
+    private var dsv4Prefill: DSV4ChunkedPrefill?
 
     private static let rdadviseBoundedMissCap = 12
     private static let rdadviseBoundedMaxCallNanos: UInt64 = 250_000
@@ -278,11 +277,95 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     private var rdadviseAdaptiveState: RDAdviceAdaptivePolicyState
     private var rdadviseAdaptivePosition: Int = -1
     private var rdadviseAdaptivePositionBytes: UInt64 = 0
+
+    /// Router-readback synchronization. The layer's first command buffer
+    /// signals this event immediately after the router top-k has written
+    /// `outIndices`, and encodes the shared-expert FFN *after* the signal. The
+    /// CPU wakes on the signal, plans slots and starts the routed-expert pread
+    /// while that shared-expert work is still executing, so expert I/O overlaps
+    /// GPU work instead of following it. Nil when the device cannot vend a
+    /// shared event; the code then falls back to waiting on the whole buffer.
+    private let routerEvent: MTLSharedEvent?
+    private var routerEventValue: UInt64 = 0
+    private static let routerEventTimeoutMS: UInt64 = 60_000
+    /// Phase probes cost a completion handler per command buffer, so they are
+    /// only wired up when the phase report is going to be printed.
+    private static let phaseInstrumentationEnabled =
+        ProcessInfo.processInfo.environment["MFERENCE_PHASES"] == "1"
+    private static let routerEventWaitDefault =
+        ProcessInfo.processInfo.environment["MFERENCE_ROUTER_EVENT"] != "0"
+    /// Escape hatch and test seam for the early router readback. When false the
+    /// CPU waits for the whole attention buffer instead of the mid-buffer
+    /// signal, which serializes the shared expert ahead of the pread again.
+    /// Both settings encode the same kernels in the same order, so decode
+    /// output is identical either way. `MFERENCE_ROUTER_EVENT=0` flips the
+    /// default for A/B benchmarking.
+    var routerEventWaitEnabled = RealForwardRunner.routerEventWaitDefault
+
+    /// Speculative cross-layer expert prefetch. The predictor is the *previous
+    /// token's* routing for the same layer — free (the indices are already on
+    /// the CPU), and unlike an LFU-top-k guess it predicts the experts that
+    /// actually miss: LFU is already the eviction policy, so the resident slots
+    /// are by construction the LFU favourites and a miss is by definition a
+    /// non-favourite.
+    enum SpeculativePrefetchMode: String {
+        /// No speculation at all (default).
+        case off
+        /// Real preads into the next layer's slots, driven by the previous
+        /// token's routing. Measured to be a no-op — see
+        /// `previousTokenExperts`.
+        case prefetch
+        /// F_RDADVISE only: warms the page cache, writes no slots, needs no
+        /// join. The low-risk fallback if the slot-write mode misbehaves.
+        case advise
+        /// PILOT: layer L+1's router run against layer L's post-attention
+        /// state inside layer L's command buffer, feeding real preads. The
+        /// only mode whose predictor knows anything about the current token.
+        case pilot
+
+        static func parse(_ raw: String?) -> SpeculativePrefetchMode {
+            switch raw?.lowercased() {
+            case "1", "on", "prefetch": return .prefetch
+            case "advise": return .advise
+            case "pilot": return .pilot
+            default: return .off
+            }
+        }
+    }
+    var speculativePrefetchMode = SpeculativePrefetchMode.parse(
+        ProcessInfo.processInfo.environment["MFERENCE_SPEC_PREFETCH"])
+    /// Last token's routed expert ids per layer; empty until a layer has been
+    /// routed at least once. This is the default predictor.
+    ///
+    /// NOTE (measured): on its own this predictor can never issue a read. Each
+    /// layer owns a private slot cache that only that layer's plans touch, so
+    /// between token t and token t+1 nothing evicts layer L's slots — last
+    /// token's experts are *always* still resident when we would predict them.
+    /// "Same experts as last token" is a statement about the cache hit rate the
+    /// LRU/LFU cache already delivers for free; a prefetch has to predict the
+    /// complement (the experts that changed), about which last token's routing
+    /// says nothing. Substituting a predictor with real information about the
+    /// *current* token (PILOT router-lookahead) is the only way this pays, and
+    /// `speculativeExpertPredictor` is where it plugs in.
+    private var previousTokenExperts: [[Int]] = []
+    private var pendingSpeculation: SpeculativeExpertPrefetch?
+    /// Overrides the predictor for a layer. The seam a real predictor plugs
+    /// into, and what lets tests drive the reserve/read/join/confirm machinery
+    /// without depending on a fixture whose routing happens to churn the cache.
+    var speculativeExpertPredictor: (@Sendable (Int) -> [Int])?
+    /// PILOT lookahead kernels, built on first use so `off` pays nothing and
+    /// the (concurrently edited) DSV4 init block stays untouched.
+    private var pilotRouter: SpeculativeRouterDSV4?
+    /// The prediction read out of `pilotRouter` (or the hash table) at the
+    /// current layer's router wake, consumed by `issueSpeculativePrefetch`.
+    private var pilotPrediction: (layer: Int, experts: [Int])?
+
     public init(model: Model, context: MetalContext, maxContext: Int,
                 runtimeConfiguration: RuntimeConfiguration = .production) throws {
         self.model = model
         self.ctx = context
         self.cfg = model.config
+        self.routerEvent = context.device.makeSharedEvent()
         self.maxContext = maxContext
         self.useFusedGreedyHead = runtimeConfiguration.headPath == .fusedRows
         self.prefillAttentionPath = runtimeConfiguration.prefillAttentionPath
@@ -466,10 +549,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.dsv4HCPreF = try buf(mult, MemoryLayout<Float>.size)
             self.dsv4HCPostF = try buf(mult, MemoryLayout<Float>.size)
             self.dsv4HCCombF = try buf(mult * mult, MemoryLayout<Float>.size)
-            self.dsv4CompKVRow = try buf(2 * cfg.fullHeadDim)
-            self.dsv4CompGateRow = try buf(2 * cfg.fullHeadDim)
-            self.dsv4IdxKVRow = try buf(2 * ca.indexHeadDim)
-            self.dsv4IdxGateRow = try buf(2 * ca.indexHeadDim)
             self.dsv4IndexerQ = try buf(ca.indexNHeads * ca.indexHeadDim)
             self.dsv4IndexerW = try buf(ca.indexNHeads)
             self.dsv4IndexerScores = try buf(
@@ -490,10 +569,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.dsv4HCPreF = nil
             self.dsv4HCPostF = nil
             self.dsv4HCCombF = nil
-            self.dsv4CompKVRow = nil
-            self.dsv4CompGateRow = nil
-            self.dsv4IdxKVRow = nil
-            self.dsv4IdxGateRow = nil
             self.dsv4IndexerQ = nil
             self.dsv4IndexerW = nil
             self.dsv4IndexerScores = nil
@@ -602,6 +677,8 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     }
 
     private func resetTransientState() {
+        joinPendingSpeculation()
+        previousTokenExperts = []
         prefillChunkState.reset()
         rdadviseSkipUntilPosition = -1
         rdadviseAdaptiveState.reset()
@@ -614,6 +691,245 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     public private(set) var totalCb2Nanos: UInt64 = 0
     public private(set) var totalHeadNanos: UInt64 = 0
     public private(set) var totalHeadFusedNanos: UInt64 = 0
+    /// Split of `totalIoNanos`: the part of each layer's expert pread that ran
+    /// while GPU work was still in flight versus the part that ran with an idle
+    /// GPU. Only populated when `MFERENCE_PHASES=1`.
+    public private(set) var totalIoOverlappedNanos: UInt64 = 0
+    public private(set) var totalIoExposedNanos: UInt64 = 0
+    /// Speculative prefetch accounting: experts speculatively read (or advised)
+    /// and how many of those the following real plan actually asked for. The
+    /// ratio is the predictor's recall and is what makes an A/B interpretable.
+    /// Experts named by the predictor. `confirmed / predicted` is realized
+    /// recall — the number that decides whether PILOT is worth its GEMV.
+    public private(set) var totalSpecPrefetchPredicted: UInt64 = 0
+    public private(set) var totalSpecPrefetchIssued: UInt64 = 0
+    public private(set) var totalSpecPrefetchConfirmed: UInt64 = 0
+    public private(set) var totalSpecPrefetchBytes: UInt64 = 0
+
+    /// Zeroes the per-phase counters. Prompt prefill runs through the same
+    /// per-token code paths (DeepSeek-V4 prefill *is* a decode loop), so
+    /// without a reset at the prefill/decode boundary the phase report prints
+    /// prompt-time nanoseconds against a decode-only wall clock and the
+    /// unaccounted remainder goes negative.
+    public func beginDecodePhaseWindow() {
+        totalIoNanos = 0
+        totalCb1Nanos = 0
+        totalCb2Nanos = 0
+        totalHeadNanos = 0
+        totalHeadFusedNanos = 0
+        totalIoOverlappedNanos = 0
+        totalIoExposedNanos = 0
+        totalSpecPrefetchPredicted = 0
+        totalSpecPrefetchIssued = 0
+        totalSpecPrefetchConfirmed = 0
+        totalSpecPrefetchBytes = 0
+    }
+
+    /// One outstanding speculative read set. The runner keeps at most one alive
+    /// (issued for layer L+1 while layer L finishes), and every real plan joins
+    /// whatever is pending before it plans, so a speculative write and a real
+    /// plan never touch the same streamer concurrently.
+    private final class SpeculativeExpertPrefetch: @unchecked Sendable {
+        let layer: Int
+        /// Everything the predictor named — the denominator of recall. A subset
+        /// of these is actually read (the non-resident ones).
+        let predicted: Set<Int>
+        private let finished = DispatchSemaphore(value: 0)
+        private let lock = NSLock()
+        private var bytes: UInt64 = 0
+        private var joined = false
+
+        init(layer: Int, predicted: Set<Int>) {
+            self.layer = layer
+            self.predicted = predicted
+        }
+
+        func complete(bytes value: UInt64) {
+            lock.lock()
+            bytes = value
+            lock.unlock()
+            finished.signal()
+        }
+
+        /// Blocks until the background reads land. Idempotent.
+        @discardableResult
+        func join() -> UInt64 {
+            lock.lock()
+            let alreadyJoined = joined
+            joined = true
+            lock.unlock()
+            if !alreadyJoined { finished.wait() }
+            lock.lock()
+            defer { lock.unlock() }
+            return bytes
+        }
+    }
+
+    /// Drains any outstanding speculation. Called before every real plan (so no
+    /// slot is replanned while a background read is filling it) and on reset.
+    /// Returns the joined record so the caller can score its prediction.
+    @discardableResult
+    private func joinPendingSpeculation() -> (layer: Int, predicted: Set<Int>)? {
+        guard let pending = pendingSpeculation else { return nil }
+        pendingSpeculation = nil
+        totalSpecPrefetchBytes &+= pending.join()
+        return (pending.layer, pending.predicted)
+    }
+
+    /// Joins outstanding speculation and credits it against the experts the
+    /// real plan turned out to need.
+    private func settleSpeculation(layer: Int, actualExperts: [Int]) {
+        guard let joined = joinPendingSpeculation(), joined.layer == layer else { return }
+        var counted = Set<Int>()
+        for expert in actualExperts
+            where joined.predicted.contains(expert) && counted.insert(expert).inserted {
+            totalSpecPrefetchConfirmed &+= 1
+        }
+    }
+
+    /// Speculatively fetches the experts `layer` used on the previous token.
+    /// Issued after the current layer's routed command buffer is committed —
+    /// the window where the GPU is busy with routed work plus the next layer's
+    /// attention and the CPU has nothing to do — so it never competes with the
+    /// critical-path pread for SSD bandwidth.
+    private func issueSpeculativePrefetch(layer: Int) {
+        guard speculativePrefetchMode != .off,
+              pendingSpeculation == nil,
+              layer >= 0, layer < cfg.numLayers else { return }
+        let predicted = predictedExperts(for: layer)
+        guard !predicted.isEmpty else { return }
+
+        // The record is created even when nothing needs reading, so recall is
+        // still scored at full residency.
+        let record = SpeculativeExpertPrefetch(layer: layer, predicted: Set(predicted))
+        pendingSpeculation = record
+        totalSpecPrefetchPredicted &+= UInt64(record.predicted.count)
+
+        guard let streamer = try? model.routedExpertStreamer(layer: layer) else {
+            record.complete(bytes: 0)
+            return
+        }
+        let missing = streamer.nonResidentExperts(predicted)
+        guard !missing.isEmpty else {
+            record.complete(bytes: 0)
+            return
+        }
+
+        if speculativePrefetchMode == .advise {
+            // Page-cache warming only: no slot writes, nothing to join.
+            totalSpecPrefetchIssued &+= UInt64(missing.count)
+            DispatchQueue.global(qos: .utility).async {
+                record.complete(bytes: streamer.adviseExperts(experts: missing).bytes)
+            }
+            return
+        }
+
+        // Leave the next real plan room for a full top-k of its own misses, so
+        // a wrong guess can never make it unplaceable.
+        let reservation = streamer.reserveSpeculativeSlots(experts: missing,
+                                                           keepEvictable: cfg.topKExperts)
+        guard !reservation.isEmpty else {
+            record.complete(bytes: 0)
+            return
+        }
+        totalSpecPrefetchIssued &+= UInt64(reservation.count)
+        DispatchQueue.global(qos: .utility).async {
+            record.complete(bytes: streamer.executeSpeculativeReservation(reservation))
+        }
+    }
+
+    private func predictedExperts(for layer: Int) -> [Int] {
+        if let speculativeExpertPredictor { return speculativeExpertPredictor(layer) }
+        switch speculativePrefetchMode {
+        case .pilot:
+            guard let pilotPrediction, pilotPrediction.layer == layer else { return [] }
+            return pilotPrediction.experts
+        case .prefetch, .advise:
+            guard layer < previousTokenExperts.count else { return [] }
+            return previousTokenExperts[layer]
+        case .off:
+            return []
+        }
+    }
+
+    /// Hash-routed layers select experts as a pure function of the token id, so
+    /// the "prediction" for such a layer is exact and needs no GEMV at all.
+    private func hashRoutedExperts(layer: Int, token: Int32) -> [Int]? {
+        guard cfg.layerIsHashRouted(layer),
+              let table = try? model.dsv4HashTable(layer: layer) else { return nil }
+        let base = table.buffer.contents().advanced(by: Int(table.offset))
+        let row = min(max(Int(token), 0), cfg.vocabSize - 1) * cfg.topKExperts
+        let cap = cfg.numExperts - 1
+        if table.dtype == 4 {
+            let ptr = base.assumingMemoryBound(to: Int64.self)
+            return (0..<cfg.topKExperts).map { min(max(0, Int(ptr[row + $0])), cap) }
+        }
+        let ptr = base.assumingMemoryBound(to: UInt32.self)
+        return (0..<cfg.topKExperts).map { min(Int(ptr[row + $0]), cap) }
+    }
+
+    /// True when a lookahead GEMV should be encoded for `layer` — i.e. pilot is
+    /// on, the layer exists, and its expert set is not already exactly known
+    /// from the hash table.
+    private func shouldEncodePilotGemv(nextLayer: Int) -> Bool {
+        speculativePrefetchMode == .pilot
+            && speculativeExpertPredictor == nil
+            && nextLayer < cfg.numLayers
+            && !cfg.layerIsHashRouted(nextLayer)
+    }
+
+    /// Reads the lookahead result at the router wake. Hash-routed next layers
+    /// bypass the GEMV entirely (exact from the token id).
+    private func capturePilotPrediction(nextLayer: Int, token: Int32, gemvEncoded: Bool) {
+        pilotPrediction = nil
+        guard speculativePrefetchMode == .pilot, nextLayer < cfg.numLayers else { return }
+        if let hashed = hashRoutedExperts(layer: nextLayer, token: token) {
+            pilotPrediction = (nextLayer, hashed)
+            return
+        }
+        guard gemvEncoded, let buffer = pilotRouter?.predictedIndices else { return }
+        let ptr = buffer.contents().assumingMemoryBound(to: UInt32.self)
+        let cap = cfg.numExperts - 1
+        pilotPrediction = (nextLayer, (0..<cfg.topKExperts).map { min(Int(ptr[$0]), cap) })
+    }
+
+    private func ensurePilotRouter() -> SpeculativeRouterDSV4? {
+        if let pilotRouter { return pilotRouter }
+        pilotRouter = try? SpeculativeRouterDSV4(context: ctx,
+                                                 numExperts: UInt32(cfg.numExperts),
+                                                 d: UInt32(cfg.hiddenSize),
+                                                 topK: UInt32(cfg.topKExperts))
+        return pilotRouter
+    }
+
+    /// Records this layer's routing for the next token's predictor.
+    private func recordRoutedExperts(_ experts: [Int], layer: Int) {
+        if previousTokenExperts.count != cfg.numLayers {
+            previousTokenExperts = [[Int]](repeating: [], count: cfg.numLayers)
+        }
+        previousTokenExperts[layer] = experts
+    }
+
+    /// Attributes one layer's expert-I/O window against the GPU work that was
+    /// meant to hide it. `probe` tracks the command buffers committed before
+    /// the pread started; a nil completion time means they were still running
+    /// when the pread returned, i.e. the I/O was fully hidden.
+    private func recordExpertIOOverlap(probe: GPUOverlapProbe?,
+                                       startNanos: UInt64,
+                                       endNanos: UInt64) {
+        guard let probe, endNanos > startNanos else { return }
+        let span = endNanos - startNanos
+        guard let finished = probe.finishedNanos else {
+            totalIoOverlappedNanos &+= span
+            return
+        }
+        if finished <= startNanos {
+            totalIoExposedNanos &+= span
+        } else {
+            totalIoOverlappedNanos &+= min(finished, endNanos) - startNanos
+            totalIoExposedNanos &+= finished < endNanos ? endNanos - finished : 0
+        }
+    }
     public private(set) var lastGreedyToken: UInt32 = 0
     public var usesFusedGreedyHead: Bool { useFusedGreedyHead }
     public private(set) var totalRDAdviseNanos: UInt64 = 0
@@ -695,6 +1011,9 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                into logits: MTLBuffer,
                                onProgress: (Int) -> Void) async throws -> PrefillResult {
         try prefillChunkState.requireClean(operation: "prefillChunked")
+        // Prompt prefill and decode share these counters; drop the prompt's
+        // contribution on the way out so the phase report describes decode.
+        defer { beginDecodePhaseWindow() }
         guard config.mode == .chunked else {
             throw PrefillError.chunkedUnsupported(
                 "prefillChunked requires PrefillRuntimeConfig.mode == .chunked")
@@ -717,20 +1036,69 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         }
 
         if cfg.hasCompressedAttentionLayers {
-            // DeepSeek-V4 v1 prefill runs the decode path token-by-token.
-            // The correctness contract is prefill(T) == T sequential decode
-            // steps (the Qwen port's chunked-prefill guarantee); the chunked
-            // implementation is follow-up work.
+            // DeepSeek-V4 prefill runs layer-major over each chunk (see
+            // `RealForwardRunner+DSV4Prefill.swift`), which amortizes the
+            // routed-expert reads over the chunk instead of paying them per
+            // token. Spans that the batched path cannot serve — currently only
+            // those long enough to trigger lightning-indexer selection — fall
+            // back to the token-by-token decode replay, which is the
+            // correctness reference for both.
+            let spans = PrefillChunkPlanner.spans(tokenCount: tokens.count,
+                                                  startPosition: startPosition,
+                                                  config: config)
+            let expertSlots = model.routedExpertCacheSlotCount(layer: 0)
             var pos = startPosition
             var done = 0
-            for t in tokens {
-                let isLast = done == tokens.count - 1
-                try await produceTokenDSV4(token: t, position: pos,
-                                           into: logits,
-                                           emitHead: isLast,
-                                           outputMode: outputMode)
-                pos += 1
-                done += 1
+            for (spanIndex, span) in spans.enumerated() {
+                let lower = tokens.index(tokens.startIndex, offsetBy: span.tokenOffset)
+                let upper = tokens.index(lower, offsetBy: span.tokenCount)
+                let isLastSpan = spanIndex == spans.count - 1
+                let batched = DSV4ChunkedPrefill.supports(
+                    config: cfg,
+                    startPosition: span.startPosition,
+                    tokenCount: span.tokenCount,
+                    expertCacheSlots: expertSlots)
+                if batched, let dsv4, let moeDSV4, let dsv4State {
+                    let bindings = DSV4PrefillBindings(
+                        model: model, ctx: ctx, cfg: cfg,
+                        dsv4: dsv4, moeDSV4: moeDSV4, state: dsv4State,
+                        int4: int4, rms: rms, embed: embedInt4,
+                        fusionHead: fusionHead,
+                        sharedExperts: sharedExpertProjections.map {
+                            DSV4PrefillSharedExpert(gate: $0.gate, up: $0.up, down: $0.down)
+                        },
+                        effectiveScales: effectiveScaleBuffers,
+                        useFusedGreedyHead: useFusedGreedyHead)
+                    let runner: DSV4ChunkedPrefill
+                    if let cached = dsv4Prefill, cached.chunkCapacity >= span.tokenCount {
+                        runner = cached
+                    } else {
+                        runner = try DSV4ChunkedPrefill(
+                            bindings: bindings,
+                            chunkTokens: max(config.chunkTokens, span.tokenCount))
+                        dsv4Prefill = runner
+                    }
+                    let greedy = try await runner.run(tokens: tokens[lower..<upper],
+                                                      startPosition: span.startPosition,
+                                                      emitHead: isLastSpan,
+                                                      outputMode: outputMode,
+                                                      logits: logits)
+                    if let greedy { lastGreedyToken = greedy }
+                    for _ in 0..<span.tokenCount { kv?.advance() }
+                    pos += span.tokenCount
+                } else {
+                    var index = 0
+                    for t in tokens[lower..<upper] {
+                        let isLast = isLastSpan && index == span.tokenCount - 1
+                        try await produceTokenDSV4(token: t, position: pos,
+                                                   into: logits,
+                                                   emitHead: isLast,
+                                                   outputMode: outputMode)
+                        pos += 1
+                        index += 1
+                    }
+                }
+                done += span.tokenCount
                 onProgress(done)
             }
             if outputMode == .greedyIfAvailable, useFusedGreedyHead {
@@ -1754,7 +2122,10 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             : 1.0
         struct PendingRoutedCommand {
             let cb: MTLCommandBuffer
-            let sharedCB: MTLCommandBuffer?
+            /// The layer's attention+router+shared-expert buffer. Always
+            /// completed before `cb` (same queue, committed first); retained
+            /// only so its error surfaces.
+            let attentionCB: MTLCommandBuffer?
             let phase1HitCB: MTLCommandBuffer?
             let encodeAndCommitNanos: UInt64
         }
@@ -1766,8 +2137,8 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                 func wait(_ cb: MTLCommandBuffer) {
                     waitForCompletion(cb)
                 }
-                if let sharedCB = pending.sharedCB {
-                    wait(sharedCB)
+                if let attentionCB = pending.attentionCB {
+                    wait(attentionCB)
                 }
                 if let phase1HitCB = pending.phase1HitCB {
                     wait(phase1HitCB)
@@ -1776,8 +2147,8 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             } else if let err = pending.cb.error {
                 print("CB error: \(err)")
             }
-            if let sharedCB = pending.sharedCB {
-                if let err = sharedCB.error {
+            if let attentionCB = pending.attentionCB {
+                if let err = attentionCB.error {
                     print("CB error: \(err)")
                 }
             }
@@ -1983,9 +2354,51 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                 perExpertScaleOffset: perExpertScale.offset,
                 outIndices: outIndices, outWeights: outWeights,
                 numExperts: UInt32(cfg.numExperts), d: D, topK: UInt32(cfg.topKExperts))
+
+            // The router indices are written at this point in the buffer, so
+            // signal the CPU here and keep encoding into the SAME buffer. The
+            // shared dense MLP depends only on the post-attention norm, never
+            // on the routed experts, so the GPU runs it while the CPU wakes,
+            // plans slots and preads the routed-expert blobs.
+            let routerSignal = encodeRouterSignal(cb)
+            try! shared.encode(commandBuffer: cb,
+                               x: cfg.ffnSandwichNorms ? denseX : routedX,
+                               gate: sharedProj.gate,
+                               up: sharedProj.up,
+                               down: sharedProj.down,
+                               y: h1Buf,
+                               scratchGate: denseScratchGate,
+                               scratchUp: denseScratchUp,
+                               scratchAct: denseScratchAct)
+            if cfg.ffnSandwichNorms {
+                let postF1 = sharedProj.postF1!
+                rms.encodeBF16W(commandBuffer: cb, x: h1Buf,
+                                weight: postF1.buffer,
+                                weightOffset: Int(postF1.offset),
+                                out: h1Buf, d: D, eps: eps)
+            } else if cfg.sharedExpertGated {
+                // out = sigmoid(shared_expert_gate(moeX)) * shared_mlp(moeX)
+                let gateView = sharedProj.scalarGate!
+                int8ScalarGate!.encode(commandBuffer: cb,
+                                       weights: gateView.buffer,
+                                       weightsOffset: Int(gateView.offset),
+                                       scales: gateView.buffer,
+                                       scalesOffset: Int(gateView.scaleOffset),
+                                       biases: gateView.buffer,
+                                       biasesOffset: Int(gateView.biasOffset),
+                                       x: routedX,
+                                       y: sharedScalarGateBuf!,
+                                       m: 1, n: D)
+                elementwise!.encodeSigmoidScalarMul(commandBuffer: cb,
+                                                    y: h1Buf,
+                                                    gate: sharedScalarGateBuf!,
+                                                    count: cfg.hiddenSize)
+            }
+            let overlapProbe = Self.phaseInstrumentationEnabled ? GPUOverlapProbe() : nil
+            overlapProbe?.track(cb)
             cb.commit()
             let tWait = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
-            waitForCompletion(cb)
+            waitForRouterSignal(routerSignal, fallback: cb)
             let waitNanos = clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tWait
             if let pending = pendingRoutedCommand {
                 finishPendingRoutedCommand(pending, waitIfNeeded: false)
@@ -2000,6 +2413,13 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             for i in 0..<cfg.topKExperts {
                 experts[i] = min(Int(idxPtr[i]), cfg.numExperts - 1)
             }
+
+            // Join any speculative read aimed at this layer before planning —
+            // the plan must not evict a slot a background pread is filling —
+            // and score the prediction. Then this layer's routing becomes the
+            // next token's prediction for the same layer.
+            settleSpeculation(layer: L, actualExperts: experts)
+            recordRoutedExperts(experts, layer: L)
 
             let routedOffsets = model.routedExpertOffsets(layer: L)
             let topK = UInt32(cfg.topKExperts)
@@ -2082,47 +2502,12 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                 }
             }
 
-            // The shared dense MLP depends only on its normed input, not on
-            // the routed experts. Commit it without waiting so its GPU work
-            // overlaps the routed-expert pread. The routed CB follows it on
-            // the same queue, so the combine sees h1Buf.
-            let sharedCB = ctx.queue.makeCommandBuffer()!
-            try! shared.encode(commandBuffer: sharedCB,
-                               x: cfg.ffnSandwichNorms ? denseX : routedX,
-                               gate: sharedProj.gate,
-                               up: sharedProj.up,
-                               down: sharedProj.down,
-                               y: h1Buf,
-                               scratchGate: denseScratchGate,
-                               scratchUp: denseScratchUp,
-                               scratchAct: denseScratchAct)
-            if cfg.ffnSandwichNorms {
-                let postF1 = sharedProj.postF1!
-                rms.encodeBF16W(commandBuffer: sharedCB, x: h1Buf,
-                                weight: postF1.buffer,
-                                weightOffset: Int(postF1.offset),
-                                out: h1Buf, d: D, eps: eps)
-            } else if cfg.sharedExpertGated {
-                // out = sigmoid(shared_expert_gate(moeX)) * shared_mlp(moeX)
-                let gateView = sharedProj.scalarGate!
-                int8ScalarGate!.encode(commandBuffer: sharedCB,
-                                       weights: gateView.buffer,
-                                       weightsOffset: Int(gateView.offset),
-                                       scales: gateView.buffer,
-                                       scalesOffset: Int(gateView.scaleOffset),
-                                       biases: gateView.buffer,
-                                       biasesOffset: Int(gateView.biasOffset),
-                                       x: routedX,
-                                       y: sharedScalarGateBuf!,
-                                       m: 1, n: D)
-                elementwise!.encodeSigmoidScalarMul(commandBuffer: sharedCB,
-                                                    y: h1Buf,
-                                                    gate: sharedScalarGateBuf!,
-                                                    count: cfg.hiddenSize)
-            }
-            sharedCB.commit()
-            if let cb = phase1HitCB {
-                cb.commit()
+            // Phase-1 for the resident (hit) experts needs no I/O, so it goes
+            // to the GPU immediately, extending the window the pread hides
+            // behind. It follows the shared MLP on the same queue.
+            if let hitCB = phase1HitCB {
+                overlapProbe?.track(hitCB)
+                hitCB.commit()
             }
             if rdadviseEnabled && rdadvisePolicyMode != .off {
                 let requestedMisses = plannedFetch?.misses.count ?? experts.count
@@ -2148,7 +2533,8 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                 }
             }
 
-            // Routed-expert pread — overlaps the shared MLP GPU work above.
+            // Routed-expert pread — overlaps the shared MLP still running in
+            // CB1 plus the phase-1 hit work committed above.
             let tIoStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
             let blobs: [TensorView]
             if let plannedFetch {
@@ -2156,8 +2542,11 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             } else {
                 blobs = try await model.fetchRoutedExperts(layer: L, experts: experts)
             }
-            let layerIo = clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tIoStart
-            totalIoNanos &+= layerIo
+            let tIoEnd = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+            totalIoNanos &+= tIoEnd - tIoStart
+            recordExpertIOOverlap(probe: overlapProbe,
+                                  startNanos: tIoStart,
+                                  endNanos: tIoEnd)
             let routedBufs = blobs.map { $0.buffer }
             let tCb2Start = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
             let gTail: (MTLCommandBuffer) -> Void
@@ -2226,11 +2615,14 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                                    topK: topK)
             gTail(routedCB)
             routedCB.commit()
+            // GPU is busy with routed work and the next layer's attention, CPU
+            // is idle: the natural window for the speculative read.
+            issueSpeculativePrefetch(layer: L + 1)
             precondition(pendingRoutedCommand == nil,
                          "routed command-buffer pipeline drained before queuing the next layer")
             pendingRoutedCommand = PendingRoutedCommand(
                 cb: routedCB,
-                sharedCB: sharedCB,
+                attentionCB: cb,
                 phase1HitCB: phase1HitCB,
                 encodeAndCommitNanos: clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tCb2Start)
             continue
@@ -2467,8 +2859,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
               let hcCombA = dsv4HCCombA,
               let hcPreF = dsv4HCPreF, let hcPostF = dsv4HCPostF,
               let hcCombF = dsv4HCCombF,
-              let compKVRow = dsv4CompKVRow, let compGateRow = dsv4CompGateRow,
-              let idxKVRow = dsv4IdxKVRow, let idxGateRow = dsv4IdxGateRow,
               let indexerQ = dsv4IndexerQ, let indexerW = dsv4IndexerW,
               let indexerScores = dsv4IndexerScores,
               let selected = dsv4Selected else {
@@ -2490,14 +2880,17 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
 
         struct PendingRoutedCommand {
             let cb: MTLCommandBuffer
-            let sharedCB: MTLCommandBuffer?
+            /// The layer's attention+router+shared-expert buffer. Always
+            /// completed before `cb` (same queue, committed first); retained
+            /// only so its error surfaces.
+            let attentionCB: MTLCommandBuffer?
             let phase1HitCB: MTLCommandBuffer?
             let encodeAndCommitNanos: UInt64
         }
         var pendingRouted: PendingRoutedCommand?
         func finishPending(_ pending: PendingRoutedCommand, waitIfNeeded: Bool) {
             if waitIfNeeded {
-                if let sharedCB = pending.sharedCB { waitForCompletion(sharedCB) }
+                if let attentionCB = pending.attentionCB { waitForCompletion(attentionCB) }
                 if let hitCB = pending.phase1HitCB { waitForCompletion(hitCB) }
                 waitForCompletion(pending.cb)
             } else if let err = pending.cb.error {
@@ -2508,14 +2901,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         func writeActiveSlots(_ slots: [UInt32], into buffer: MTLBuffer) {
             let ptr = buffer.contents().assumingMemoryBound(to: UInt32.self)
             for i in 0..<slots.count { ptr[i] = slots[i] }
-        }
-        func blitCopy(_ cb: MTLCommandBuffer,
-                      from src: MTLBuffer, srcOffset: Int,
-                      to dst: MTLBuffer, dstOffset: Int, bytes: Int) {
-            guard let blit = cb.makeBlitCommandEncoder() else { return }
-            blit.copy(from: src, sourceOffset: srcOffset,
-                      to: dst, destinationOffset: dstOffset, size: bytes)
-            blit.endEncoding()
         }
         func gemv(_ cb: MTLCommandBuffer, _ view: TensorView,
                   x: MTLBuffer, xOffset: Int = 0,
@@ -2639,17 +3024,15 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                 let compGate = try model.dsv4CompressorGateProj(layer: L)
                 let compNorm = try model.dsv4CompressorKVNorm(layer: L)
                 let compBias = try model.dsv4CompressorPositionBias(layer: L)
-                gemv(cb, compKV, x: normed, y: compKVRow,
-                     m: rowWidth, n: cfg.hiddenSize)
-                gemv(cb, compGate, x: normed, y: compGateRow,
-                     m: rowWidth, n: cfg.hiddenSize)
+                // The GEMVs land directly in the pending window at this
+                // token's row offset — no staging row, no blit.
                 let rowOffset = counters.pendingRows * rowWidth * fp16
-                blitCopy(cb, from: compKVRow, srcOffset: 0,
-                         to: dsv4State.pendingKV[L]!, dstOffset: rowOffset,
-                         bytes: rowWidth * fp16)
-                blitCopy(cb, from: compGateRow, srcOffset: 0,
-                         to: dsv4State.pendingGate[L]!, dstOffset: rowOffset,
-                         bytes: rowWidth * fp16)
+                gemv(cb, compKV, x: normed,
+                     y: dsv4State.pendingKV[L]!, yOffset: rowOffset,
+                     m: rowWidth, n: cfg.hiddenSize)
+                gemv(cb, compGate, x: normed,
+                     y: dsv4State.pendingGate[L]!, yOffset: rowOffset,
+                     m: rowWidth, n: cfg.hiddenSize)
                 willEmit = counters.pendingRows + 1 == rate
                 if willEmit {
                     let entry = counters.compressedEntries
@@ -2685,17 +3068,13 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                     let idxGate = try model.dsv4IndexerGateProj(layer: L)
                     let idxNorm = try model.dsv4IndexerKVNorm(layer: L)
                     let idxBias = try model.dsv4IndexerPositionBias(layer: L)
-                    gemv(cb, idxKV, x: normed, y: idxKVRow,
-                         m: 2 * idxDim, n: cfg.hiddenSize)
-                    gemv(cb, idxGate, x: normed, y: idxGateRow,
-                         m: 2 * idxDim, n: cfg.hiddenSize)
                     let idxRowOffset = counters.indexerPendingRows * 2 * idxDim * fp16
-                    blitCopy(cb, from: idxKVRow, srcOffset: 0,
-                             to: dsv4State.indexerPendingKV[L]!,
-                             dstOffset: idxRowOffset, bytes: 2 * idxDim * fp16)
-                    blitCopy(cb, from: idxGateRow, srcOffset: 0,
-                             to: dsv4State.indexerPendingGate[L]!,
-                             dstOffset: idxRowOffset, bytes: 2 * idxDim * fp16)
+                    gemv(cb, idxKV, x: normed,
+                         y: dsv4State.indexerPendingKV[L]!, yOffset: idxRowOffset,
+                         m: 2 * idxDim, n: cfg.hiddenSize)
+                    gemv(cb, idxGate, x: normed,
+                         y: dsv4State.indexerPendingGate[L]!, yOffset: idxRowOffset,
+                         m: 2 * idxDim, n: cfg.hiddenSize)
                     willEmitIndexer = counters.indexerPendingRows + 1 == idxRate
                     if willEmitIndexer {
                         let entry = counters.indexerEntries
@@ -2796,24 +3175,18 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                             ropeDim: ca.ropeHeadDim,
                             position: position, rope: ropeKind, direction: -1)
 
-            // Grouped low-rank output projection: one GEMV per head group,
-            // then the mixing projection.
-            let groupIn = numHeads * headDim / ca.oGroups
-            let oaRowBytes = groupIn / 2
-            let oaGroupsPerRow = groupIn / Quantization.groupSize
-            for g in 0..<ca.oGroups {
-                let rowBase = g * ca.oLoraRank
-                int4.encode(commandBuffer: cb,
-                            weights: oaView.buffer,
-                            weightsOffset: Int(oaView.offset) + rowBase * oaRowBytes,
-                            scales: oaView.buffer,
-                            scalesOffset: Int(oaView.scaleOffset) + rowBase * oaGroupsPerRow * 2,
-                            biases: oaView.buffer,
-                            biasesOffset: Int(oaView.biasOffset) + rowBase * oaGroupsPerRow * 2,
-                            x: attnOut, xOffset: g * groupIn * fp16,
-                            y: oGrouped, yOffset: g * ca.oLoraRank * fp16,
-                            m: UInt32(ca.oLoraRank), n: UInt32(groupIn))
-            }
+            // Grouped low-rank output projection: one dispatch covering every
+            // head group (the output row index selects both the weight block
+            // and the activation slice), then the mixing projection.
+            dsv4.encodeOGroupProjection(
+                commandBuffer: cb,
+                weights: oaView.buffer, weightsOffset: Int(oaView.offset),
+                scales: oaView.buffer, scalesOffset: Int(oaView.scaleOffset),
+                biases: oaView.buffer, biasesOffset: Int(oaView.biasOffset),
+                x: attnOut, y: oGrouped,
+                rank: ca.oLoraRank,
+                groupIn: numHeads * headDim / ca.oGroups,
+                groups: ca.oGroups)
             gemv(cb, obView, x: oGrouped, y: oOut,
                  m: cfg.hiddenSize, n: ca.oGroups * ca.oLoraRank)
 
@@ -2883,9 +3256,75 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                     outWeights: outWeights,
                     numExperts: UInt32(cfg.numExperts), d: D)
             }
+
+            // PILOT lookahead: run layer L+1's router against *this* layer's
+            // post-attention state, into private buffers, before the signal.
+            // The CPU then reads the real L indices and the speculative L+1
+            // indices at one wake — no extra command buffer, no extra sync.
+            // The mHC streams mean L+1's true router input also carries this
+            // layer's FFN contribution, so this is an approximation whose
+            // recall the predicted/confirmed counters measure.
+            var pilotGemvEncoded = false
+            if shouldEncodePilotGemv(nextLayer: L + 1),
+               let pilot = ensurePilotRouter(),
+               let nextRouter = try? model.router(layer: L + 1),
+               let nextBias = try? model.dsv4RouterCorrectionBias(layer: L + 1) {
+                pilot.encodePrediction(
+                    commandBuffer: cb,
+                    weights: nextRouter.buffer, weightsOffset: Int(nextRouter.offset),
+                    hidden: routedX,
+                    onesScale: effectiveScaleBuffers[L + 1],
+                    correctionBias: nextBias.buffer,
+                    correctionBiasOffset: Int(nextBias.offset),
+                    numExperts: UInt32(cfg.numExperts), d: D,
+                    routeScale: Float(cfg.routedScalingFactor))
+                pilotGemvEncoded = true
+            }
+
+            // The router indices are written at this point in the buffer, so
+            // signal the CPU here and keep encoding into the SAME buffer: the
+            // shared expert (clamped SwiGLU) depends only on `routedX`, never
+            // on the routed experts, so the GPU runs it while the CPU wakes,
+            // plans slots and preads the routed-expert blobs.
+            let routerSignal = encodeRouterSignal(cb)
+            int4.encode(commandBuffer: cb,
+                        weights: sharedProj.gate.weights,
+                        weightsOffset: sharedProj.gate.weightsOffset,
+                        scales: sharedProj.gate.scales,
+                        scalesOffset: sharedProj.gate.scalesOffset,
+                        biases: sharedProj.gate.biases,
+                        biasesOffset: sharedProj.gate.biasesOffset,
+                        x: routedX, y: denseScratchGate,
+                        m: FShared, n: D)
+            int4.encode(commandBuffer: cb,
+                        weights: sharedProj.up.weights,
+                        weightsOffset: sharedProj.up.weightsOffset,
+                        scales: sharedProj.up.scales,
+                        scalesOffset: sharedProj.up.scalesOffset,
+                        biases: sharedProj.up.biases,
+                        biasesOffset: sharedProj.up.biasesOffset,
+                        x: routedX, y: denseScratchUp,
+                        m: FShared, n: D)
+            dsv4.encodeSwigluClampMul(commandBuffer: cb,
+                                      gate: denseScratchGate,
+                                      up: denseScratchUp,
+                                      out: denseScratchAct,
+                                      n: cfg.intermediateSize,
+                                      limit: Float(cfg.swigluLimit))
+            int4.encode(commandBuffer: cb,
+                        weights: sharedProj.down.weights,
+                        weightsOffset: sharedProj.down.weightsOffset,
+                        scales: sharedProj.down.scales,
+                        scalesOffset: sharedProj.down.scalesOffset,
+                        biases: sharedProj.down.biases,
+                        biasesOffset: sharedProj.down.biasesOffset,
+                        x: denseScratchAct, y: h1Buf,
+                        m: D, n: FShared)
+            let overlapProbe = Self.phaseInstrumentationEnabled ? GPUOverlapProbe() : nil
+            overlapProbe?.track(cb)
             cb.commit()
             let tWait = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
-            waitForCompletion(cb)
+            waitForRouterSignal(routerSignal, fallback: cb)
             let waitNanos = clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tWait
             if let pending = pendingRouted {
                 finishPending(pending, waitIfNeeded: false)
@@ -2923,6 +3362,16 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             for i in 0..<cfg.topKExperts {
                 experts[i] = min(Int(idxPtr[i]), cfg.numExperts - 1)
             }
+            // Join any speculative read aimed at this layer before planning —
+            // the plan must not evict a slot a background pread is filling —
+            // and score the prediction. Then this layer's routing becomes the
+            // next token's prediction for the same layer.
+            settleSpeculation(layer: L, actualExperts: experts)
+            recordRoutedExperts(experts, layer: L)
+            capturePilotPrediction(nextLayer: L + 1,
+                                   token: token,
+                                   gemvEncoded: pilotGemvEncoded)
+
             let routedOffsets = model.routedExpertOffsets(layer: L)
             let gateGroupSize = UInt32(model.routedGateGroupSize(layer: L))
             guard let plannedFetch = try model.planRoutedExperts(layer: L, experts: experts)
@@ -2960,44 +3409,13 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                 phase1HitCB = hitCB
             }
 
-            // Shared expert (clamped SwiGLU) on its own CB so its GPU work
-            // overlaps the expert pread.
-            let sharedCB = ctx.queue.makeCommandBuffer()!
-            int4.encode(commandBuffer: sharedCB,
-                        weights: sharedProj.gate.weights,
-                        weightsOffset: sharedProj.gate.weightsOffset,
-                        scales: sharedProj.gate.scales,
-                        scalesOffset: sharedProj.gate.scalesOffset,
-                        biases: sharedProj.gate.biases,
-                        biasesOffset: sharedProj.gate.biasesOffset,
-                        x: routedX, y: denseScratchGate,
-                        m: FShared, n: D)
-            int4.encode(commandBuffer: sharedCB,
-                        weights: sharedProj.up.weights,
-                        weightsOffset: sharedProj.up.weightsOffset,
-                        scales: sharedProj.up.scales,
-                        scalesOffset: sharedProj.up.scalesOffset,
-                        biases: sharedProj.up.biases,
-                        biasesOffset: sharedProj.up.biasesOffset,
-                        x: routedX, y: denseScratchUp,
-                        m: FShared, n: D)
-            dsv4.encodeSwigluClampMul(commandBuffer: sharedCB,
-                                      gate: denseScratchGate,
-                                      up: denseScratchUp,
-                                      out: denseScratchAct,
-                                      n: cfg.intermediateSize,
-                                      limit: Float(cfg.swigluLimit))
-            int4.encode(commandBuffer: sharedCB,
-                        weights: sharedProj.down.weights,
-                        weightsOffset: sharedProj.down.weightsOffset,
-                        scales: sharedProj.down.scales,
-                        scalesOffset: sharedProj.down.scalesOffset,
-                        biases: sharedProj.down.biases,
-                        biasesOffset: sharedProj.down.biasesOffset,
-                        x: denseScratchAct, y: h1Buf,
-                        m: D, n: FShared)
-            sharedCB.commit()
-            if let hitCB = phase1HitCB { hitCB.commit() }
+            // Phase-1 for the resident (hit) experts needs no I/O, so it goes
+            // to the GPU immediately, extending the window the pread hides
+            // behind. It follows the shared expert on the same queue.
+            if let hitCB = phase1HitCB {
+                overlapProbe?.track(hitCB)
+                hitCB.commit()
+            }
 
             if rdadviseEnabled && rdadvisePolicyMode != .off {
                 let requestedMisses = plannedFetch.misses.count
@@ -3019,7 +3437,11 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
 
             let tIoStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
             let blobs = try await model.fetchRoutedExperts(plan: plannedFetch)
-            totalIoNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tIoStart
+            let tIoEnd = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+            totalIoNanos &+= tIoEnd - tIoStart
+            recordExpertIOOverlap(probe: overlapProbe,
+                                  startNanos: tIoStart,
+                                  endNanos: tIoEnd)
             let routedBufs = blobs.map { $0.buffer }
 
             let tCb2Start = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
@@ -3068,11 +3490,14 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                   outStreams: streams,
                                   hcMult: hc.mult, hidden: cfg.hiddenSize)
             routedCB.commit()
+            // GPU is busy with routed work and the next layer's attention, CPU
+            // is idle: the natural window for the speculative read.
+            issueSpeculativePrefetch(layer: L + 1)
             precondition(pendingRouted == nil,
                          "routed command-buffer pipeline drained before queuing the next layer")
             pendingRouted = PendingRoutedCommand(
                 cb: routedCB,
-                sharedCB: sharedCB,
+                attentionCB: cb,
                 phase1HitCB: phase1HitCB,
                 encodeAndCommitNanos: clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tCb2Start)
         }
@@ -3148,6 +3573,69 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         cb.waitUntilCompleted()
         if let err = cb.error {
             print("CB error: \(err)")
+        }
+    }
+
+    /// Encodes the router-readback signal at the current point in `cb`. Must be
+    /// called with no encoder open and immediately after the kernel that writes
+    /// `outIndices`, so that the GPU write is complete when the CPU wakes.
+    /// Returns nil when no shared event exists (fall back to a full wait).
+    private func encodeRouterSignal(_ cb: MTLCommandBuffer) -> UInt64? {
+        guard let routerEvent else { return nil }
+        routerEventValue &+= 1
+        cb.encodeSignalEvent(routerEvent, value: routerEventValue)
+        return routerEventValue
+    }
+
+    /// Passive wait for the router signal, never a spin loop: a busy CPU steals
+    /// the shared SoC power budget and throttles the GPU on Apple silicon.
+    /// Because command buffers on one queue execute in commit order, reaching
+    /// this signal also proves every previously committed buffer has finished —
+    /// which is what makes it safe for the caller to pread into expert slots.
+    private func waitForRouterSignal(_ value: UInt64?, fallback cb: MTLCommandBuffer) {
+        guard routerEventWaitEnabled else {
+            waitForCompletion(cb)
+            return
+        }
+        guard let routerEvent, let value else {
+            waitForCompletion(cb)
+            return
+        }
+        if routerEvent.signaledValue >= value { return }
+        if !routerEvent.wait(untilSignaledValue: value,
+                             timeoutMS: Self.routerEventTimeoutMS) {
+            waitForCompletion(cb)
+        }
+    }
+
+    /// Tracks when the command buffers that are supposed to hide a pread
+    /// actually finished. Completion handlers run on a Metal thread, so the
+    /// bookkeeping is lock-guarded.
+    final class GPUOverlapProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var remaining = 0
+        private var lastNanos: UInt64 = 0
+
+        /// Register a command buffer; call before committing it.
+        func track(_ cb: MTLCommandBuffer) {
+            lock.lock()
+            remaining += 1
+            lock.unlock()
+            cb.addCompletedHandler { [self] _ in
+                let now = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+                lock.lock()
+                remaining -= 1
+                lastNanos = max(lastNanos, now)
+                lock.unlock()
+            }
+        }
+
+        /// When every tracked buffer has finished, the time the last one
+        /// finished; nil while any is still running.
+        var finishedNanos: UInt64? {
+            lock.lock()
+            defer { lock.unlock() }
+            return remaining == 0 ? lastNanos : nil
         }
     }
 

--- a/Sources/MferenceCLI/Run.swift
+++ b/Sources/MferenceCLI/Run.swift
@@ -119,7 +119,21 @@ public func run(args: Args,
             lines += String(format: "%.0f", total) + " ms]\n"
             lines += "  cb1 encode+commit: " + ms(runner.totalCb1Nanos) + " ms\n"
             lines += "  expert io await:   " + ms(runner.totalIoNanos) + " ms\n"
+            lines += "    io overlapped w/ GPU: "
+            lines += ms(runner.totalIoOverlappedNanos) + " ms\n"
+            lines += "    io exposed (GPU idle): "
+            lines += ms(runner.totalIoExposedNanos) + " ms\n"
             lines += "  cb2 encode+commit: " + ms(runner.totalCb2Nanos) + " ms\n"
+            let predicted = runner.totalSpecPrefetchPredicted
+            let recall = predicted > 0
+                ? Double(runner.totalSpecPrefetchConfirmed) / Double(predicted)
+                : 0
+            lines += "  spec prefetch: predicted \(predicted)"
+            lines += ", issued \(runner.totalSpecPrefetchIssued)"
+            lines += ", confirmed \(runner.totalSpecPrefetchConfirmed)"
+            lines += String(format: " (recall %.1f%%, %.1f MB)\n",
+                            recall * 100,
+                            Double(runner.totalSpecPrefetchBytes) / 1_048_576)
             lines += "  unaccounted (GPU waits): "
             lines += String(format: "%.1f", total - accounted) + " ms\n"
             stderr.write(Data(lines.utf8))

--- a/Tests/Mference/Core/Infrastructure/Streaming/PreadExpertStreamerTests+Speculative.swift
+++ b/Tests/Mference/Core/Infrastructure/Streaming/PreadExpertStreamerTests+Speculative.swift
@@ -1,0 +1,159 @@
+import Darwin
+import Foundation
+import Metal
+import Testing
+
+@testable import Mference
+
+/// Speculative cross-layer prefetch primitives. The contract these pin down:
+/// a guess may waste a slot and some bandwidth, but it must never corrupt a
+/// slot the real plan is using, never make the real plan unplaceable, and
+/// never shift the eviction statistics in favour of an unconfirmed expert.
+extension PreadExpertStreamerTests {
+
+    private func makeStreamer(_ url: URL, slots: Int = 4) throws -> PreadExpertStreamer {
+        let device = try MetalContext().device
+        return try PreadExpertStreamer(layout: Self.makeLayout(path: url.path),
+                                       device: device,
+                                       slotCount: slots)
+    }
+
+    /// The residency probe is read-only: it reports the non-resident subset and
+    /// leaves the LFU counters alone, so probing cannot make a guessed expert
+    /// look popular. Proof: after probing expert 3 many times, expert 3 is
+    /// still the first slot evicted — a `planExpertsCached` bump would have
+    /// protected it.
+    @Test func nonResidentExpertsProbeDoesNotBumpUseCounts() throws {
+        let url = try Self.writeSyntheticLayer()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let streamer = try makeStreamer(url, slots: 2)
+
+        _ = try streamer.loadExpertsCached(experts: [0])
+        #expect(streamer.nonResidentExperts([0, 1, 2]) == [1, 2])
+        // Duplicates collapse, negatives are dropped, order is preserved.
+        #expect(streamer.nonResidentExperts([2, 2, 1, 0]) == [2, 1])
+
+        for _ in 0..<20 { _ = streamer.nonResidentExperts([3]) }
+        // Fill both slots: 0 (used once) and 3 (probed, never used).
+        let reservation = streamer.reserveSpeculativeSlots(experts: [3], keepEvictable: 0)
+        streamer.executeSpeculativeReservation(reservation)
+        // The real plan needs a new expert; the probed-but-unconfirmed 3 must
+        // be the victim, not the confirmed 0.
+        let plan = streamer.planExpertsCached(experts: [1])
+        #expect(plan.misses == [0])
+        #expect(streamer.residentExpertsSnapshot().contains(0))
+        #expect(!streamer.residentExpertsSnapshot().contains(3))
+    }
+
+    /// A confirmed prediction turns into a free hit: the speculative read lands
+    /// the right bytes in a slot, and the following real plan reports zero
+    /// misses for that expert.
+    @Test func confirmedSpeculativeLoadBecomesAHit() throws {
+        let url = try Self.writeSyntheticLayer()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let streamer = try makeStreamer(url)
+
+        let missing = streamer.nonResidentExperts([2, 3])
+        #expect(missing == [2, 3])
+        let reservation = streamer.reserveSpeculativeSlots(experts: missing, keepEvictable: 0)
+        #expect(reservation.count == 2)
+        let bytes = streamer.executeSpeculativeReservation(reservation)
+        #expect(bytes == UInt64(2 * Self.expertStride))
+
+        // Real plan asks for exactly what was predicted: all hits, no I/O.
+        let plan = streamer.planExpertsCached(experts: [2, 3])
+        #expect(plan.misses.isEmpty)
+        #expect(plan.hits == 2)
+        let buffers = try streamer.executeExpertCachePlan(plan)
+        for (index, expert) in [2, 3].enumerated() {
+            let got = Self.bytes(of: buffers[index].buffer, offset: 0, count: Self.expertStride)
+            #expect(got.allSatisfy { $0 == Self.tagByte(expert) })
+        }
+    }
+
+    /// A misprediction is harmless: the wrong expert occupies a slot, the real
+    /// plan evicts it, and the bytes the real plan hands back are still the
+    /// bytes it asked for.
+    @Test func mispredictedSpeculativeLoadIsHarmless() throws {
+        let url = try Self.writeSyntheticLayer()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let streamer = try makeStreamer(url, slots: 2)
+
+        let reservation = streamer.reserveSpeculativeSlots(experts: [3], keepEvictable: 0)
+        streamer.executeSpeculativeReservation(reservation)
+        #expect(streamer.residentExpertsSnapshot().contains(3))
+
+        // Nobody asks for 3. The real plan proceeds normally.
+        let plan = streamer.planExpertsCached(experts: [0, 1])
+        let buffers = try streamer.executeExpertCachePlan(plan)
+        for (index, expert) in [0, 1].enumerated() {
+            let got = Self.bytes(of: buffers[index].buffer, offset: 0, count: Self.expertStride)
+            #expect(got.allSatisfy { $0 == Self.tagByte(expert) })
+        }
+        #expect(!streamer.residentExpertsSnapshot().contains(3))
+    }
+
+    /// Eviction protection: `keepEvictable` slots are always left for the real
+    /// plan, so speculation can never starve it. With every slot reserved for
+    /// the real plan, speculation declines to run at all.
+    @Test func keepEvictableBoundsSpeculativeReservation() throws {
+        let url = try Self.writeSyntheticLayer()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let streamer = try makeStreamer(url)
+
+        #expect(streamer.reserveSpeculativeSlots(experts: [0, 1, 2, 3],
+                                                 keepEvictable: 4).isEmpty)
+        let bounded = streamer.reserveSpeculativeSlots(experts: [0, 1, 2, 3],
+                                                       keepEvictable: 3)
+        #expect(bounded.count == 1)
+        streamer.executeSpeculativeReservation(bounded)
+
+        // Whatever speculation took, a full top-k real plan still places.
+        let plan = streamer.planExpertsCachedIfPossible(experts: [0, 1, 2, 3])
+        #expect(plan != nil)
+    }
+
+    /// The join contract, from the streamer's side: while a speculative read is
+    /// outstanding its slots are neither matchable nor evictable, so a real
+    /// plan that forgot to join still cannot hand out a buffer being written.
+    @Test func inFlightSlotsAreInvisibleToTheRealPlan() throws {
+        let url = try Self.writeSyntheticLayer()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let streamer = try makeStreamer(url)
+
+        // Reserve but deliberately do not execute: the slots stay in flight.
+        let reservation = streamer.reserveSpeculativeSlots(experts: [2, 3], keepEvictable: 0)
+        #expect(reservation.count == 2)
+        let inFlight = Set(reservation.map(\.slot))
+
+        // Two slots remain, so a two-expert plan fits and must avoid them.
+        let plan = streamer.planExpertsCachedIfPossible(experts: [0, 1])
+        #expect(plan != nil)
+        #expect(plan!.assignedSlots.allSatisfy { !inFlight.contains($0) })
+        // A third expert cannot be placed while the speculation holds two slots.
+        #expect(streamer.planExpertsCachedIfPossible(experts: [0, 1, 2]) == nil)
+
+        // Completing the read releases the reservation.
+        streamer.executeSpeculativeReservation(reservation)
+        #expect(streamer.planExpertsCachedIfPossible(experts: [0, 1, 2]) != nil)
+    }
+
+    /// A speculative read that fails leaves the slot empty rather than claiming
+    /// to hold an expert whose bytes never arrived.
+    @Test func failedSpeculativeReadLeavesSlotEmpty() throws {
+        let url = try Self.writeSyntheticLayer()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let streamer = try makeStreamer(url)
+
+        // Expert index past the layer's expert count: the offset check rejects
+        // it, so the read throws inside the concurrent block.
+        let reservation = streamer.reserveSpeculativeSlots(experts: [Self.numExperts + 5],
+                                                           keepEvictable: 0)
+        #expect(reservation.count == 1)
+        let bytes = streamer.executeSpeculativeReservation(reservation)
+        #expect(bytes == 0)
+        #expect(streamer.residentExpertsSnapshot()[reservation[0].slot] == -1)
+        // And the slot is usable again.
+        #expect(streamer.planExpertsCachedIfPossible(experts: [0, 1, 2, 3]) != nil)
+    }
+}

--- a/Tests/Mference/Core/Kernels/DSV4/DSV4AttentionParityTests.swift
+++ b/Tests/Mference/Core/Kernels/DSV4/DSV4AttentionParityTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Metal
+import Testing
+
+@testable import Mference
+import MferenceValidationSupport
+
+/// `dsv4_attention_decode` was restructured from a two-pass kernel — one
+/// threadgroup per query head, every logit materialized in a fixed-size
+/// threadgroup array, every thread re-walking all rows for the value sum —
+/// into an online-softmax kernel where one threadgroup services eight heads
+/// and stages each shared K=V row into threadgroup memory once for all of
+/// them. The pre-restructuring kernel survives in the shader source as
+/// `dsv4_attention_decode_reference`; these tests pin the new kernel to it
+/// over randomized inputs across the window-only, dense-compressed,
+/// indexer-selected, and ragged-head-count shapes.
+@Suite struct DSV4AttentionParityTests {
+
+    /// The two kernels differ only in reduction order (sequential dot and a
+    /// materialized two-pass softmax versus a simdgroup dot and an online
+    /// one), so the FP16 outputs land within a couple of ulps. Measured max
+    /// over these shapes: 1.2e-4.
+    private static let tolerance: Float = 5e-4
+
+    struct Shape: Sendable {
+        let name: String
+        let numHeads: Int
+        let windowCount: Int
+        let windowStartPos: Int
+        let compressedCount: Int
+        /// Selected-entry count, or `nil` for "attend to all compressed".
+        let selectedCount: Int?
+    }
+
+    private static let shapes: [Shape] = [
+        // Sliding-window layer, ring not yet full, row count not a multiple
+        // of the staging block.
+        Shape(name: "window-only-partial-stage", numHeads: 64,
+              windowCount: 37, windowStartPos: 0,
+              compressedCount: 0, selectedCount: nil),
+        // HCA layer: full window plus a dense compressed region.
+        Shape(name: "window-plus-dense-compressed", numHeads: 64,
+              windowCount: 128, windowStartPos: 501,
+              compressedCount: 200, selectedCount: nil),
+        // CSA layer past index_topk: the indexer narrows the compressed
+        // region to a scattered subset.
+        Shape(name: "indexer-selected-subset", numHeads: 64,
+              windowCount: 128, windowStartPos: 4123,
+              compressedCount: 300, selectedCount: 97),
+        // Compressed rows only.
+        Shape(name: "compressed-only", numHeads: 64,
+              windowCount: 0, windowStartPos: 0,
+              compressedCount: 64, selectedCount: nil),
+        // Head count that does not fill the last threadgroup: the tail
+        // simdgroup must still reach every barrier and write nothing.
+        Shape(name: "ragged-head-count", numHeads: 60,
+              windowCount: 128, windowStartPos: 900,
+              compressedCount: 300, selectedCount: 137),
+    ]
+
+    private static let headDim = 512
+    private static let ringCapacity = 128
+    private static let maxHeads = 64
+    private static let maxCompressed = 512
+
+    @Test(arguments: shapes)
+    func matchesTheTwoPassReference(shape: Shape) throws {
+        let ctx = try MetalContext()
+        let kernels = try DSV4Kernels(context: ctx,
+                                      config: .deepseekV4Flash_284B_A13B)
+        let referencePSO = try ctx.pipeline("dsv4_attention_decode_reference",
+                                            constants: [],
+                                            maxTotalThreadsPerThreadgroup: 256)
+        let device = ctx.device
+
+        func halfBuffer(_ count: Int) throws -> MTLBuffer {
+            try #require(device.makeBuffer(
+                length: count * MemoryLayout<Float16>.stride,
+                options: .storageModeShared))
+        }
+
+        var rng = SplitMix64(seed: 0xD5_4000_0000_0001)
+        let q = try halfBuffer(Self.maxHeads * Self.headDim)
+        let windowKV = try halfBuffer(Self.ringCapacity * Self.headDim)
+        let compressedKV = try halfBuffer(Self.maxCompressed * Self.headDim)
+        fillUnitHalves(q, count: Self.maxHeads * Self.headDim, rng: &rng)
+        fillUnitHalves(windowKV, count: Self.ringCapacity * Self.headDim,
+                       rng: &rng)
+        fillUnitHalves(compressedKV, count: Self.maxCompressed * Self.headDim,
+                       rng: &rng)
+
+        let sinks = try #require(device.makeBuffer(
+            length: Self.maxHeads * MemoryLayout<Float>.stride,
+            options: .storageModeShared))
+        let sinkPtr = sinks.contents().assumingMemoryBound(to: Float.self)
+        for h in 0..<Self.maxHeads {
+            sinkPtr[h] = rng.uniform(-2.0, 2.0)
+        }
+
+        let selected = try #require(device.makeBuffer(
+            length: max(1, Self.maxCompressed) * MemoryLayout<UInt32>.stride,
+            options: .storageModeShared))
+        let selectedCount: UInt32
+        if let k = shape.selectedCount {
+            // Production hands the kernel a sorted, distinct subset.
+            var picks = Set<UInt32>()
+            while picks.count < k {
+                picks.insert(UInt32(rng.next() % UInt64(shape.compressedCount)))
+            }
+            let sorted = picks.sorted()
+            let ptr = selected.contents().assumingMemoryBound(to: UInt32.self)
+            for (i, e) in sorted.enumerated() { ptr[i] = e }
+            selectedCount = UInt32(k)
+        } else {
+            selectedCount = DSV4Kernels.selectAll
+        }
+
+        let outNew = try halfBuffer(Self.maxHeads * Self.headDim)
+        let outRef = try halfBuffer(Self.maxHeads * Self.headDim)
+        memset(outNew.contents(), 0, outNew.length)
+        memset(outRef.contents(), 0, outRef.length)
+
+        let scale = Float(ArchConfig.deepseekV4Flash_284B_A13B.attentionScale)
+        let cb = try #require(ctx.queue.makeCommandBuffer())
+        kernels.encodeAttention(
+            commandBuffer: cb,
+            q: q, windowKV: windowKV, compressedKV: compressedKV,
+            selected: selected,
+            sinks: sinks, sinksOffset: 0,
+            out: outNew,
+            headDim: Self.headDim, numHeads: shape.numHeads,
+            windowCount: shape.windowCount,
+            windowStartPos: shape.windowStartPos,
+            ringCapacity: Self.ringCapacity,
+            compressedCount: shape.compressedCount,
+            selectedCount: selectedCount,
+            scale: scale)
+        try encodeReference(
+            pso: referencePSO, commandBuffer: cb,
+            q: q, windowKV: windowKV, compressedKV: compressedKV,
+            selected: selected, sinks: sinks, out: outRef,
+            numHeads: shape.numHeads,
+            windowCount: shape.windowCount,
+            windowStartPos: shape.windowStartPos,
+            compressedCount: shape.compressedCount,
+            selectedCount: selectedCount,
+            scale: scale)
+        cb.commit()
+        cb.waitUntilCompleted()
+        #expect(cb.error == nil)
+
+        let newPtr = outNew.contents().assumingMemoryBound(to: Float16.self)
+        let refPtr = outRef.contents().assumingMemoryBound(to: Float16.self)
+        var maxDiff: Float = 0
+        var worst = 0
+        for i in 0..<(shape.numHeads * Self.headDim) {
+            let d = abs(Float(newPtr[i]) - Float(refPtr[i]))
+            if d > maxDiff { maxDiff = d; worst = i }
+        }
+        #expect(maxDiff <= Self.tolerance,
+                "\(shape.name): max |new - reference| = \(maxDiff) at head \(worst / Self.headDim), channel \(worst % Self.headDim)")
+
+        // A convex combination of unit-magnitude rows is never all zero, so a
+        // silently skipped kernel would pass the diff check above.
+        var nonZero = 0
+        for i in 0..<(shape.numHeads * Self.headDim) where newPtr[i] != 0 {
+            nonZero += 1
+        }
+        #expect(nonZero > shape.numHeads * Self.headDim / 2,
+                "\(shape.name): output is mostly zero (\(nonZero) non-zero)")
+
+        // Heads past `numHeads` belong to no simdgroup with a store.
+        for i in (shape.numHeads * Self.headDim)..<(Self.maxHeads * Self.headDim) {
+            #expect(newPtr[i] == 0, "\(shape.name): wrote past numHeads")
+        }
+    }
+
+    /// Hand-encode the retired two-pass kernel: one threadgroup per head, no
+    /// `num_heads` argument.
+    private func encodeReference(pso: MTLComputePipelineState,
+                                 commandBuffer: MTLCommandBuffer,
+                                 q: MTLBuffer, windowKV: MTLBuffer,
+                                 compressedKV: MTLBuffer, selected: MTLBuffer,
+                                 sinks: MTLBuffer, out: MTLBuffer,
+                                 numHeads: Int,
+                                 windowCount: Int, windowStartPos: Int,
+                                 compressedCount: Int, selectedCount: UInt32,
+                                 scale: Float) throws {
+        let enc = try #require(commandBuffer.makeComputeCommandEncoder())
+        enc.setComputePipelineState(pso)
+        enc.setBuffer(q, offset: 0, index: 0)
+        enc.setBuffer(windowKV, offset: 0, index: 1)
+        enc.setBuffer(compressedKV, offset: 0, index: 2)
+        enc.setBuffer(selected, offset: 0, index: 3)
+        enc.setBuffer(sinks, offset: 0, index: 4)
+        enc.setBuffer(out, offset: 0, index: 5)
+        var hd = UInt32(Self.headDim)
+        var wc = UInt32(windowCount)
+        var ws = UInt32(windowStartPos)
+        var rc = UInt32(Self.ringCapacity)
+        var cc = UInt32(compressedCount)
+        var sc = selectedCount
+        var sl = scale
+        enc.setBytes(&hd, length: MemoryLayout<UInt32>.size, index: 6)
+        enc.setBytes(&wc, length: MemoryLayout<UInt32>.size, index: 7)
+        enc.setBytes(&ws, length: MemoryLayout<UInt32>.size, index: 8)
+        enc.setBytes(&rc, length: MemoryLayout<UInt32>.size, index: 9)
+        enc.setBytes(&cc, length: MemoryLayout<UInt32>.size, index: 10)
+        enc.setBytes(&sc, length: MemoryLayout<UInt32>.size, index: 11)
+        enc.setBytes(&sl, length: MemoryLayout<Float>.size, index: 12)
+        enc.dispatchThreadgroups(
+            MTLSize(width: numHeads, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    private func fillUnitHalves(_ buffer: MTLBuffer, count: Int,
+                                rng: inout SplitMix64) {
+        let ptr = buffer.contents().assumingMemoryBound(to: Float16.self)
+        for i in 0..<count { ptr[i] = Float16(rng.uniform(-1.0, 1.0)) }
+    }
+}

--- a/Tests/Mference/Core/Kernels/DSV4/DSV4AttentionPreconditionTests.swift
+++ b/Tests/Mference/Core/Kernels/DSV4/DSV4AttentionPreconditionTests.swift
@@ -4,12 +4,12 @@ import Testing
 
 @testable import Mference
 
-/// Regression coverage for the compressed-entry ceiling: a CSA layer past
-/// 8K tokens has more than 2048 *emitted* entries, but the indexer narrows
-/// attention to its top-512 picks, so encoding must bound what the kernel
-/// actually loads — not the total cache count. The old precondition
-/// terminated the process on `compressedCount > 2048` even with selection
-/// active, which crashed every context option above 8K.
+/// Regression coverage for the compressed-entry ceiling. A precondition on
+/// the total cache count once terminated the process at `compressedCount >
+/// 2048`, crashing every context option above 8K even though the indexer had
+/// already narrowed attention to its top-512 picks. The online-softmax kernel
+/// streams entries instead of materializing logits, so no ceiling remains at
+/// all — encoding must stay trap-free at any entry count.
 @Suite struct DSV4AttentionPreconditionTests {
 
     private func makeKernels(_ ctx: MetalContext) throws -> DSV4Kernels {
@@ -41,6 +41,21 @@ import Testing
             headDim: 512, numHeads: 64,
             windowCount: 128, windowStartPos: 16_256, ringCapacity: 128,
             compressedCount: 4096, selectedCount: 512,
+            scale: 0.044)
+
+        // Well past the retired 2048-entry ceiling with no selection active:
+        // the kernel no longer caps the enumerated region.
+        kernels.encodeAttention(
+            commandBuffer: cb,
+            q: scratch,
+            windowKV: scratch,
+            compressedKV: scratch,
+            selected: scratch,
+            sinks: scratch, sinksOffset: 0,
+            out: scratch,
+            headDim: 512, numHeads: 64,
+            windowCount: 128, windowStartPos: 16_256, ringCapacity: 128,
+            compressedCount: 4096, selectedCount: DSV4Kernels.selectAll,
             scale: 0.044)
 
         // HCA at the 64K context ceiling: 512 dense entries, no selection.

--- a/Tests/Mference/Core/Kernels/DSV4/DSV4OGroupProjectionParityTests.swift
+++ b/Tests/Mference/Core/Kernels/DSV4/DSV4OGroupProjectionParityTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Metal
+import Testing
+
+@testable import Mference
+import MferenceValidationSupport
+
+/// The DeepSeek-V4 grouped output projection used to be `oGroups` separate
+/// INT4 GEMV dispatches per layer, each with its own byte-offset arithmetic in
+/// Swift (8 dispatches x 43 layers x every token). `dsv4_o_group_gemv_int4`
+/// covers all groups in one dispatch by deriving the group from the output row
+/// index, and reuses `dequant_int4_gemv_simd`'s row body verbatim — so the
+/// result must be bit-identical, not merely close.
+@Suite struct DSV4OGroupProjectionParityTests {
+
+    @Test func fusedDispatchMatchesPerGroupGEMVsExactly() throws {
+        let cfg = ArchConfig.deepseekV4Flash_284B_A13B
+        let ca = cfg.compressedAttention
+        let rank = ca.oLoraRank
+        let groups = ca.oGroups
+        let groupIn = cfg.numHeads * cfg.fullHeadDim / groups
+        let rows = rank * groups
+        let groupsPerRow = groupIn / Quantization.groupSize
+
+        let ctx = try MetalContext()
+        let kernels = try DSV4Kernels(context: ctx, config: cfg)
+        let int4 = try DequantInt4GEMV(context: ctx,
+                                       additionalShapes: cfg.decodeInt4GEMVShapes)
+        let device = ctx.device
+        var rng = SplitMix64(seed: 0x0A_5017_2026_0802)
+
+        // Packed INT4 weights: one nibble per input channel, row-major.
+        let weightBytes = rows * groupIn / 2
+        let weights = try #require(device.makeBuffer(length: weightBytes,
+                                                    options: .storageModeShared))
+        let words = weights.contents().assumingMemoryBound(to: UInt64.self)
+        for i in 0..<(weightBytes / 8) { words[i] = rng.next() }
+
+        // BF16 affine scale / bias per 64-channel group.
+        func bf16Buffer(_ count: Int, lo: Float, hi: Float) throws -> MTLBuffer {
+            let buf = try #require(device.makeBuffer(
+                length: count * MemoryLayout<UInt16>.stride,
+                options: .storageModeShared))
+            let ptr = buf.contents().assumingMemoryBound(to: UInt16.self)
+            for i in 0..<count {
+                ptr[i] = UInt16(truncatingIfNeeded:
+                                    rng.uniform(lo, hi).bitPattern >> 16)
+            }
+            return buf
+        }
+        let scales = try bf16Buffer(rows * groupsPerRow, lo: 0.002, hi: 0.02)
+        let biases = try bf16Buffer(rows * groupsPerRow, lo: -0.05, hi: 0.05)
+
+        // Activation: the whole roped attention output, all groups end to end.
+        let x = try #require(device.makeBuffer(
+            length: groups * groupIn * MemoryLayout<Float16>.stride,
+            options: .storageModeShared))
+        let xPtr = x.contents().assumingMemoryBound(to: Float16.self)
+        for i in 0..<(groups * groupIn) { xPtr[i] = Float16(rng.uniform(-1, 1)) }
+
+        func outBuffer() throws -> MTLBuffer {
+            let buf = try #require(device.makeBuffer(
+                length: rows * MemoryLayout<Float16>.stride,
+                options: .storageModeShared))
+            memset(buf.contents(), 0, buf.length)
+            return buf
+        }
+        let yFused = try outBuffer()
+        let yPerGroup = try outBuffer()
+
+        let cb = try #require(ctx.queue.makeCommandBuffer())
+        kernels.encodeOGroupProjection(
+            commandBuffer: cb,
+            weights: weights, weightsOffset: 0,
+            scales: scales, scalesOffset: 0,
+            biases: biases, biasesOffset: 0,
+            x: x, y: yFused,
+            rank: rank, groupIn: groupIn, groups: groups)
+
+        // The retired call site: one GEMV per group, offsets computed Swift-side.
+        let fp16 = MemoryLayout<Float16>.stride
+        let rowBytes = groupIn / 2
+        for g in 0..<groups {
+            let rowBase = g * rank
+            int4.encode(commandBuffer: cb,
+                        weights: weights, weightsOffset: rowBase * rowBytes,
+                        scales: scales, scalesOffset: rowBase * groupsPerRow * 2,
+                        biases: biases, biasesOffset: rowBase * groupsPerRow * 2,
+                        x: x, xOffset: g * groupIn * fp16,
+                        y: yPerGroup, yOffset: g * rank * fp16,
+                        m: UInt32(rank), n: UInt32(groupIn))
+        }
+        cb.commit()
+        cb.waitUntilCompleted()
+        #expect(cb.error == nil)
+
+        let fusedPtr = yFused.contents().assumingMemoryBound(to: Float16.self)
+        let refPtr = yPerGroup.contents().assumingMemoryBound(to: Float16.self)
+        var mismatches = 0
+        var firstMismatch = -1
+        var nonZero = 0
+        for i in 0..<rows {
+            if fusedPtr[i] != refPtr[i] {
+                mismatches += 1
+                if firstMismatch < 0 { firstMismatch = i }
+            }
+            if fusedPtr[i] != 0 { nonZero += 1 }
+        }
+        #expect(mismatches == 0,
+                "\(mismatches)/\(rows) rows differ; first at row \(firstMismatch), group \(firstMismatch / max(rank, 1))")
+        #expect(nonZero > rows / 2, "fused output is mostly zero")
+    }
+}

--- a/Tests/Mference/Core/Kernels/MoE/RouterTopKParityTests.swift
+++ b/Tests/Mference/Core/Kernels/MoE/RouterTopKParityTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Metal
+import Testing
+@testable import Mference
+import MferenceValidationSupport
+
+/// The production router selects run one SIMD wide (`*_par`); the original
+/// single-thread kernels stay in `moe.metal` purely as the parity reference.
+/// These tests dispatch both over the same logits and require identical
+/// indices, identical order, and bit-equal FP16 weights — the parallel kernels
+/// are a scheduling change only, never a numerical one.
+@Suite struct RouterTopKParityTests {
+    private struct Selection: Equatable {
+        let indices: [UInt32]
+        let weightBits: [UInt16]
+    }
+
+    private enum Fixture {
+        /// Expert counts spanning the production shapes (128 Gemma/Qwen, 256
+        /// DeepSeek V4) plus non-multiple-of-32 and short counts that exercise
+        /// the -INFINITY sentinel lanes.
+        static let expertCounts: [UInt32] = [8, 16, 24, 33, 100, 128, 168, 255, 256]
+        static let trials = 12
+    }
+
+    // MARK: - k8 (Gemma 4 / Qwen 3.6)
+
+    @Test("Parallel k8 select matches the serial kernel bit for bit",
+          arguments: Fixture.expertCounts)
+    func k8SelectMatchesSerial(numExperts: UInt32) throws {
+        let context = try MetalContext()
+        let serial = try context.pipeline("router_topk_select_k8")
+        let parallel = try context.pipeline("router_topk_select_k8_par")
+        var rng = SplitMix64(seed: 0x5EED_0001 &+ UInt64(numExperts))
+
+        for trial in 0..<Fixture.trials {
+            let logits = Self.logits(count: Int(numExperts),
+                                     trial: trial,
+                                     rng: &rng)
+            let scale = (0..<Int(numExperts)).map { _ in rng.uniform(0.6, 1.4) }
+            let expected = try Self.runK8(context: context, pipeline: serial,
+                                          logits: logits, expertScale: scale)
+            let actual = try Self.runK8(context: context, pipeline: parallel,
+                                        logits: logits, expertScale: scale)
+            #expect(actual == expected,
+                    "numExperts=\(numExperts) trial=\(trial)")
+        }
+    }
+
+    // MARK: - k6 sqrtsoftplus (DeepSeek V4 learned routing)
+
+    @Test("Parallel sqrtsoftplus k6 select matches the serial kernel bit for bit",
+          arguments: Fixture.expertCounts)
+    func k6SelectMatchesSerial(numExperts: UInt32) throws {
+        let context = try MetalContext()
+        let serial = try context.pipeline("router_topk_select_sqrtsoftplus_k6")
+        let parallel = try context.pipeline(
+            "router_topk_select_sqrtsoftplus_k6_par")
+        var rng = SplitMix64(seed: 0x5EED_0002 &+ UInt64(numExperts))
+
+        for trial in 0..<Fixture.trials {
+            let logits = Self.logits(count: Int(numExperts),
+                                     trial: trial,
+                                     rng: &rng)
+            // Duplicated correction biases add a second source of exact ties in
+            // the selection score.
+            let bias = (0..<Int(numExperts)).map { index -> Float in
+                trial % 3 == 0 ? Float((index / 7) % 4) * 0.25 : rng.uniform(-0.3, 0.3)
+            }
+            let expected = try Self.runK6(context: context, pipeline: serial,
+                                          logits: logits, correctionBias: bias)
+            let actual = try Self.runK6(context: context, pipeline: parallel,
+                                        logits: logits, correctionBias: bias)
+            #expect(actual == expected,
+                    "numExperts=\(numExperts) trial=\(trial)")
+        }
+    }
+
+    // MARK: - k6 hash weighting (DeepSeek V4 frozen routing)
+
+    @Test("Parallel hash weights match the serial kernel bit for bit")
+    func hashWeightsMatchSerial() throws {
+        let context = try MetalContext()
+        let serial = try context.pipeline("router_hash_weights_k6")
+        let parallel = try context.pipeline("router_hash_weights_k6_par")
+        var rng = SplitMix64(seed: 0x5EED_0003)
+        let numExperts = 256
+
+        for trial in 0..<Fixture.trials {
+            let logits = Self.logits(count: numExperts, trial: trial, rng: &rng)
+            // Repeated experts are legal in a frozen tid2eid row.
+            let indices = (0..<6).map { slot -> UInt32 in
+                trial % 4 == 0
+                    ? UInt32((slot % 2) * 17)
+                    : UInt32(rng.next() % UInt64(numExperts))
+            }
+            let expected = try Self.runHash(context: context, pipeline: serial,
+                                            logits: logits, indices: indices)
+            let actual = try Self.runHash(context: context, pipeline: parallel,
+                                          logits: logits, indices: indices)
+            #expect(actual == expected, "trial=\(trial)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// Trials deliberately mix continuous logits with heavily quantized ones so
+    /// exact ties (the only case where tie-breaking is observable) are common.
+    private static func logits(count: Int,
+                               trial: Int,
+                               rng: inout SplitMix64) -> [Float] {
+        switch trial % 4 {
+        case 0:
+            return (0..<count).map { _ in rng.uniform(-4.0, 4.0) }
+        case 1:
+            // Coarse quantization: many exact duplicates.
+            return (0..<count).map { _ in (rng.uniform(-3.0, 3.0) * 4).rounded() / 4 }
+        case 2:
+            // Only three distinct values; the top-k boundary always lands on a
+            // tie run, so index order decides the outcome.
+            let levels: [Float] = [1.5, 0.5, -0.5]
+            return (0..<count).map { _ in levels[Int(rng.next() % 3)] }
+        default:
+            // Every logit identical: selection is pure index order.
+            return [Float](repeating: 0.75, count: count)
+        }
+    }
+
+    // MARK: - Dispatch helpers
+
+    private static func runK8(context: MetalContext,
+                              pipeline: MTLComputePipelineState,
+                              logits: [Float],
+                              expertScale: [Float]) throws -> Selection {
+        let topK = 8
+        guard let logitBuffer = context.device.makeBuffer(
+                  bytes: logits,
+                  length: logits.count * MemoryLayout<Float>.stride,
+                  options: .storageModeShared),
+              let scaleBuffer = context.device.makeBuffer(
+                  bytes: expertScale.map(Quantization.bf16Bits),
+                  length: expertScale.count * MemoryLayout<UInt16>.stride,
+                  options: .storageModeShared),
+              let indexBuffer = context.device.makeBuffer(
+                  length: topK * MemoryLayout<UInt32>.stride,
+                  options: .storageModeShared),
+              let weightBuffer = Fp16Buffer.make(context.device, count: topK),
+              let commandBuffer = context.queue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        var expertCount = UInt32(logits.count)
+        encoder.setComputePipelineState(pipeline)
+        encoder.setBuffer(logitBuffer, offset: 0, index: 0)
+        encoder.setBuffer(scaleBuffer, offset: 0, index: 1)
+        encoder.setBuffer(indexBuffer, offset: 0, index: 2)
+        encoder.setBuffer(weightBuffer, offset: 0, index: 3)
+        encoder.setBytes(&expertCount, length: MemoryLayout<UInt32>.stride, index: 4)
+        encoder.dispatchThreadgroups(
+            MTLSize(width: 1, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        #expect(commandBuffer.error == nil)
+        return Selection(indices: readIndices(indexBuffer, count: topK),
+                         weightBits: readWeightBits(weightBuffer, count: topK))
+    }
+
+    private static func runK6(context: MetalContext,
+                              pipeline: MTLComputePipelineState,
+                              logits: [Float],
+                              correctionBias: [Float]) throws -> Selection {
+        let topK = 6
+        guard let logitBuffer = context.device.makeBuffer(
+                  bytes: logits,
+                  length: logits.count * MemoryLayout<Float>.stride,
+                  options: .storageModeShared),
+              let biasBuffer = context.device.makeBuffer(
+                  bytes: correctionBias,
+                  length: correctionBias.count * MemoryLayout<Float>.stride,
+                  options: .storageModeShared),
+              let indexBuffer = context.device.makeBuffer(
+                  length: topK * MemoryLayout<UInt32>.stride,
+                  options: .storageModeShared),
+              let weightBuffer = Fp16Buffer.make(context.device, count: topK),
+              let commandBuffer = context.queue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        var expertCount = UInt32(logits.count)
+        var routeScale = Float(2.5)
+        encoder.setComputePipelineState(pipeline)
+        encoder.setBuffer(logitBuffer, offset: 0, index: 0)
+        encoder.setBuffer(biasBuffer, offset: 0, index: 1)
+        encoder.setBuffer(indexBuffer, offset: 0, index: 2)
+        encoder.setBuffer(weightBuffer, offset: 0, index: 3)
+        encoder.setBytes(&expertCount, length: MemoryLayout<UInt32>.stride, index: 4)
+        encoder.setBytes(&routeScale, length: MemoryLayout<Float>.stride, index: 5)
+        encoder.dispatchThreadgroups(
+            MTLSize(width: 1, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        #expect(commandBuffer.error == nil)
+        return Selection(indices: readIndices(indexBuffer, count: topK),
+                         weightBits: readWeightBits(weightBuffer, count: topK))
+    }
+
+    private static func runHash(context: MetalContext,
+                                pipeline: MTLComputePipelineState,
+                                logits: [Float],
+                                indices: [UInt32]) throws -> Selection {
+        let topK = 6
+        guard let logitBuffer = context.device.makeBuffer(
+                  bytes: logits,
+                  length: logits.count * MemoryLayout<Float>.stride,
+                  options: .storageModeShared),
+              let indexBuffer = context.device.makeBuffer(
+                  bytes: indices,
+                  length: indices.count * MemoryLayout<UInt32>.stride,
+                  options: .storageModeShared),
+              let weightBuffer = Fp16Buffer.make(context.device, count: topK),
+              let commandBuffer = context.queue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        var routeScale = Float(2.5)
+        encoder.setComputePipelineState(pipeline)
+        encoder.setBuffer(logitBuffer, offset: 0, index: 0)
+        encoder.setBuffer(indexBuffer, offset: 0, index: 1)
+        encoder.setBuffer(weightBuffer, offset: 0, index: 2)
+        encoder.setBytes(&routeScale, length: MemoryLayout<Float>.stride, index: 3)
+        encoder.dispatchThreadgroups(
+            MTLSize(width: 1, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        #expect(commandBuffer.error == nil)
+        return Selection(indices: indices,
+                         weightBits: readWeightBits(weightBuffer, count: topK))
+    }
+
+    private static func readIndices(_ buffer: MTLBuffer, count: Int) -> [UInt32] {
+        let pointer = buffer.contents().bindMemory(to: UInt32.self, capacity: count)
+        return (0..<count).map { pointer[$0] }
+    }
+
+    private static func readWeightBits(_ buffer: MTLBuffer, count: Int) -> [UInt16] {
+        let pointer = buffer.contents().bindMemory(to: UInt16.self, capacity: count)
+        return (0..<count).map { pointer[$0] }
+    }
+}

--- a/Tests/Mference/Core/Runtime/DSV4ChunkedPrefillTests.swift
+++ b/Tests/Mference/Core/Runtime/DSV4ChunkedPrefillTests.swift
@@ -170,6 +170,32 @@ struct DSV4ChunkedPrefillTests {
         Self.expectIdentical(reference, chunked, label: "mixed spans")
     }
 
+    /// A single span that crosses the lightning-selection cutover (the
+    /// `--prefill-chunk auto` shape for long prompts) must batch its eligible
+    /// prefix and replay only the remainder token-by-token, splitting at the
+    /// cutover even mid compressor window — position 51 with the toy's
+    /// `indexTopK 12 × rate 4`.
+    @Test("span crossing the lightning cutover batches its eligible prefix")
+    func cutoverCrossingSpanBatchesPrefix() async throws {
+        let harness = try Self.makeHarness(chunkTokens: 64)
+        defer { try? FileManager.default.removeItem(at: harness.dir) }
+        let tokens = Self.prompt(60)
+        #expect(DSV4ChunkedPrefill.batchedTokenPrefix(config: .deepseekV4Toy(),
+                                                      startPosition: 0,
+                                                      tokenCount: 60,
+                                                      expertCacheSlots: 16) == 51)
+        #expect(!DSV4ChunkedPrefill.supports(config: .deepseekV4Toy(),
+                                             startPosition: 0, tokenCount: 60,
+                                             expertCacheSlots: 16))
+        let continuation: [Int32] = [17, 42]
+        let reference = try await Self.decodeReference(harness, tokens: tokens,
+                                                       continuation: continuation)
+        let chunked = try await Self.chunkedRun(harness, tokens: tokens,
+                                                continuation: continuation,
+                                                chunkTokens: 64)
+        Self.expectIdentical(reference, chunked, label: "cutover split")
+    }
+
     /// Two runs of the same chunked prefill must agree, so the scratch reuse
     /// across chunks and layers carries no state between calls.
     @Test("chunked prefill is reproducible across runs")

--- a/Tests/Mference/Core/Runtime/DSV4ChunkedPrefillTests.swift
+++ b/Tests/Mference/Core/Runtime/DSV4ChunkedPrefillTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Metal
+import Testing
+@testable import Mference
+
+/// Pins the DeepSeek-V4 chunked-prefill contract: `prefillChunked(T tokens)`
+/// must be indistinguishable from `T` sequential `produce(...)` calls, both in
+/// the logits it leaves behind and in the attention state it hands to the
+/// decoder afterwards.
+///
+/// The fixture (`DSV4ToySynthetic`) covers every DSV4 layer flavour in four
+/// layers — window-only, CSA (compressor + lightning-indexer key emission),
+/// HCA — with hash-routed and learned-router MoE layers, INT2 experts, a
+/// 16-slot sliding-window ring that wraps several times over these prompts,
+/// and enough live experts per chunk to span more than one routed tile.
+@Suite(.serialized)
+struct DSV4ChunkedPrefillTests {
+
+    private struct Harness {
+        let dir: URL
+        let ctx: MetalContext
+        let runner: RealForwardRunner
+        let logits: MTLBuffer
+        let vocab: Int
+    }
+
+    private static func makeHarness(maxContext: Int = 96,
+                                    chunkTokens: Int = 32) throws -> Harness {
+        let dir = try DSV4ToySynthetic.write()
+        let ctx = try MetalContext()
+        let model = try Model.load(directoryURL: dir,
+                                   device: ctx.device,
+                                   expecting: .deepseekV4Toy(),
+                                   streamingMode: .pread(slotCount: 16))
+        let runtime = RuntimeConfiguration(expertCacheSlots: 16,
+                                           prefillChunkTokens: chunkTokens,
+                                           forceLogitsHead: true)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: maxContext,
+                                           runtimeConfiguration: runtime)
+        let vocab = model.config.vocabSize
+        guard let buf = ctx.device.makeBuffer(
+            length: vocab * MemoryLayout<Float16>.stride,
+            options: .storageModeShared) else {
+            throw ModelError.residentBufferWrapFailed
+        }
+        return Harness(dir: dir, ctx: ctx, runner: runner, logits: buf, vocab: vocab)
+    }
+
+    /// Deterministic prompt inside the toy vocabulary.
+    private static func prompt(_ count: Int) -> [Int32] {
+        (0..<count).map { Int32(($0 &* 37 &+ 11) % 251) }
+    }
+
+    private static func snapshot(_ harness: Harness) -> [UInt16] {
+        let ptr = harness.logits.contents().bindMemory(to: UInt16.self,
+                                                       capacity: harness.vocab)
+        return (0..<harness.vocab).map { ptr[$0] }
+    }
+
+    /// Runs `tokens` through the decode path one at a time, then `extra` more
+    /// continuation steps, returning the raw logits bits after each of the
+    /// last `1 + extra` positions.
+    private static func decodeReference(_ harness: Harness,
+                                        tokens: [Int32],
+                                        continuation: [Int32]) async throws -> [[UInt16]] {
+        harness.runner.reset()
+        var out: [[UInt16]] = []
+        for (i, token) in tokens.enumerated() {
+            try await harness.runner.produce(token: token, position: i,
+                                             into: harness.logits)
+        }
+        out.append(snapshot(harness))
+        for (i, token) in continuation.enumerated() {
+            try await harness.runner.produce(token: token,
+                                             position: tokens.count + i,
+                                             into: harness.logits)
+            out.append(snapshot(harness))
+        }
+        return out
+    }
+
+    private static func chunkedRun(_ harness: Harness,
+                                   tokens: [Int32],
+                                   continuation: [Int32],
+                                   chunkTokens: Int) async throws -> [[UInt16]] {
+        harness.runner.reset()
+        var out: [[UInt16]] = []
+        let result = try await harness.runner.prefillChunked(
+            tokens: tokens[...],
+            startPosition: 0,
+            outputMode: .logits,
+            config: .production(chunkTokens: chunkTokens),
+            into: harness.logits,
+            onProgress: { _ in })
+        #expect(result.newPosition == tokens.count)
+        #expect(harness.runner.continuationPosition == tokens.count)
+        out.append(snapshot(harness))
+        for (i, token) in continuation.enumerated() {
+            try await harness.runner.produce(token: token,
+                                             position: tokens.count + i,
+                                             into: harness.logits)
+            out.append(snapshot(harness))
+        }
+        return out
+    }
+
+    private static func expectIdentical(_ want: [[UInt16]], _ got: [[UInt16]],
+                                        label: String) {
+        #expect(want.count == got.count, "\(label): step count")
+        for (step, (w, g)) in zip(want, got).enumerated() {
+            let mismatches = zip(w, g).filter { $0 != $1 }.count
+            #expect(mismatches == 0,
+                    "\(label): step \(step) has \(mismatches) mismatched logits")
+            if mismatches > 0, let first = zip(w, g).enumerated()
+                .first(where: { $0.element.0 != $0.element.1 }) {
+                let want = String(first.element.0, radix: 16)
+                let got = String(first.element.1, radix: 16)
+                Issue.record("\(label): first mismatch at vocab \(first.offset): want 0x\(want) got 0x\(got)")
+            }
+        }
+    }
+
+    /// The core contract. Every case is a *batched* chunk: the CSA lightning
+    /// selection cutover for the toy config is absolute position 48
+    /// (`indexTopK 12 * csaCompressRate 4`).
+    ///
+    /// - 24 tokens / chunk 32: one full chunk.
+    /// - 45 tokens / chunk 64: one ragged chunk.
+    /// - 45 tokens / chunk 32: a full chunk plus a 13-token ragged tail, so
+    ///   the compressor's pending window, the prior-Ca carry, and the window
+    ///   ring all have to survive a chunk boundary mid-window.
+    @Test("chunked prefill equals sequential decode",
+          arguments: [(24, 32), (45, 64), (45, 32), (32, 32)])
+    func chunkedPrefillMatchesSequentialDecode(promptLength: Int,
+                                              chunkTokens: Int) async throws {
+        let harness = try Self.makeHarness(chunkTokens: chunkTokens)
+        defer { try? FileManager.default.removeItem(at: harness.dir) }
+        let tokens = Self.prompt(promptLength)
+        let continuation: [Int32] = [5, 91, 200]
+        let reference = try await Self.decodeReference(harness, tokens: tokens,
+                                                       continuation: continuation)
+        let chunked = try await Self.chunkedRun(harness, tokens: tokens,
+                                                continuation: continuation,
+                                                chunkTokens: chunkTokens)
+        Self.expectIdentical(reference, chunked,
+                             label: "prompt \(promptLength) chunk \(chunkTokens)")
+    }
+
+    /// A prompt long enough that the second span crosses the lightning-indexer
+    /// cutover, so one call mixes a batched chunk and a token-by-token
+    /// fallback chunk. The result must still match pure decode.
+    @Test("mixed batched and fallback spans equal sequential decode")
+    func mixedSpansMatchSequentialDecode() async throws {
+        let harness = try Self.makeHarness(chunkTokens: 32)
+        defer { try? FileManager.default.removeItem(at: harness.dir) }
+        let tokens = Self.prompt(60)
+        #expect(DSV4ChunkedPrefill.supports(config: .deepseekV4Toy(),
+                                            startPosition: 0, tokenCount: 32,
+                                            expertCacheSlots: 16))
+        #expect(!DSV4ChunkedPrefill.supports(config: .deepseekV4Toy(),
+                                             startPosition: 32, tokenCount: 28,
+                                             expertCacheSlots: 16))
+        let continuation: [Int32] = [17, 42]
+        let reference = try await Self.decodeReference(harness, tokens: tokens,
+                                                       continuation: continuation)
+        let chunked = try await Self.chunkedRun(harness, tokens: tokens,
+                                                continuation: continuation,
+                                                chunkTokens: 32)
+        Self.expectIdentical(reference, chunked, label: "mixed spans")
+    }
+
+    /// Two runs of the same chunked prefill must agree, so the scratch reuse
+    /// across chunks and layers carries no state between calls.
+    @Test("chunked prefill is reproducible across runs")
+    func chunkedPrefillIsReproducible() async throws {
+        let harness = try Self.makeHarness(chunkTokens: 32)
+        defer { try? FileManager.default.removeItem(at: harness.dir) }
+        let tokens = Self.prompt(40)
+        let first = try await Self.chunkedRun(harness, tokens: tokens,
+                                              continuation: [3], chunkTokens: 32)
+        let second = try await Self.chunkedRun(harness, tokens: tokens,
+                                               continuation: [3], chunkTokens: 32)
+        Self.expectIdentical(first, second, label: "repeat")
+    }
+}

--- a/Tests/Mference/Core/Runtime/DSV4ToySynthetic.swift
+++ b/Tests/Mference/Core/Runtime/DSV4ToySynthetic.swift
@@ -1,0 +1,555 @@
+import Foundation
+@testable import Mference
+@testable import MferenceRepackCore
+
+/// Synthetic DeepSeek-V4 Flash toy fixture: a tiny runnable `.gturbo/`
+/// directory with the DSV4 tensor-name contract (bare `model.` trunk prefix,
+/// low-rank `attn.wq_a`/`wq_b`, shared-KV `attn.wkv`, grouped `attn.wo_a`/
+/// `wo_b`, per-layer `attn_hc`/`ffn_hc` mixes, a CSA compressor + lightning
+/// indexer, an HCA compressor, hash-routed leading layers, and INT2 routed
+/// experts). Mirrors `QwenToySynthetic.write()`.
+///
+/// The layer mask is `[0, 0, 3, 4]`, so one fixture covers every DSV4 layer
+/// flavour: two window-only layers, a CSA layer (compressor + indexer key
+/// emission), and an HCA layer. `numHashRoutedLayers = 3` puts layers 0-2 on
+/// the frozen `tid2eid` table and leaves layer 3 on the learned router.
+enum DSV4ToySynthetic {
+
+    /// Deterministic 64-bit PRNG so the fixture bytes are reproducible.
+    private struct Rng {
+        var state: UInt64
+        mutating func next() -> UInt64 {
+            state &+= 0x9E37_79B9_7F4A_7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z >> 31)
+        }
+        mutating func unit() -> Float { Float(next() >> 40) / Float(1 << 24) }
+        mutating func symmetric(_ scale: Float) -> Float { (unit() * 2 - 1) * scale }
+    }
+
+    private enum Fill {
+        /// Packed quantized weights + BF16 scales/biases.
+        case quantized
+        /// BF16 payload, values drawn around `center` +/- `spread`.
+        case bf16(center: Float, spread: Float)
+        /// FP32 payload, values drawn around `center` +/- `spread`.
+        case fp32(center: Float, spread: Float)
+        /// UInt32 payload in `0..<bound`.
+        case u32(bound: UInt32)
+    }
+
+    private struct ResidentSpec {
+        let name: String
+        let dtype: UInt8
+        let shape: [UInt32]
+        let weightBytes: UInt64
+        let scaleBytes: UInt64
+        let biasBytes: UInt64
+        let fill: Fill
+    }
+
+    // swiftlint:disable:next function_body_length
+    static func write() throws -> URL {
+        let toy = ArchConfig.deepseekV4Toy()
+        let ca = toy.compressedAttention
+        let hc = toy.hyperConnections
+        let d = toy.hiddenSize
+        let u16 = MemoryLayout<UInt16>.stride
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gturbo-dsv4-toy-\(UUID().uuidString)")
+        let exp = dir.appendingPathComponent("packed_experts")
+        try FileManager.default.createDirectory(at: exp, withIntermediateDirectories: true)
+
+        func int4Spec(_ name: String, rows: Int, cols: Int) -> ResidentSpec {
+            let groups = cols / Quantization.groupSize
+            let aux = UInt64(rows * groups * u16)
+            return ResidentSpec(name: name, dtype: 0,
+                                shape: [UInt32(rows), UInt32(cols), 0, 0],
+                                weightBytes: UInt64(rows * cols / 2),
+                                scaleBytes: aux, biasBytes: aux, fill: .quantized)
+        }
+        func bf16Spec(_ name: String, shape: [UInt32], count: Int,
+                      center: Float, spread: Float) -> ResidentSpec {
+            ResidentSpec(name: name, dtype: 1, shape: shape,
+                         weightBytes: UInt64(count * u16),
+                         scaleBytes: 0, biasBytes: 0,
+                         fill: .bf16(center: center, spread: spread))
+        }
+        func fp32Spec(_ name: String, shape: [UInt32], count: Int,
+                      center: Float, spread: Float) -> ResidentSpec {
+            ResidentSpec(name: name, dtype: 3, shape: shape,
+                         weightBytes: UInt64(count * MemoryLayout<Float>.stride),
+                         scaleBytes: 0, biasBytes: 0,
+                         fill: .fp32(center: center, spread: spread))
+        }
+        func u32Spec(_ name: String, shape: [UInt32], count: Int,
+                     bound: UInt32) -> ResidentSpec {
+            ResidentSpec(name: name, dtype: 0, shape: shape,
+                         weightBytes: UInt64(count * MemoryLayout<UInt32>.stride),
+                         scaleBytes: 0, biasBytes: 0, fill: .u32(bound: bound))
+        }
+
+        // 1. Resident specs.
+        let hcRows = (2 + hc.mult) * hc.mult
+        let hcCols = hc.mult * d
+        var specs: [ResidentSpec] = [
+            int4Spec("model.embed_tokens.weight", rows: toy.vocabSize, cols: d),
+            int4Spec("lm_head.weight", rows: toy.vocabSize, cols: d),
+            bf16Spec("model.norm.weight", shape: [UInt32(d), 0, 0, 0], count: d,
+                     center: 1.0, spread: 0.02),
+            fp32Spec("model.hc_head.fn",
+                     shape: [UInt32(hcRows), UInt32(hcCols), 0, 0],
+                     count: hcRows * hcCols, center: 0, spread: 0.01),
+            fp32Spec("model.hc_head.base", shape: [UInt32(hcRows), 0, 0, 0],
+                     count: hcRows, center: 0, spread: 0.02),
+            fp32Spec("model.hc_head.scale", shape: [3, 0, 0, 0], count: 3,
+                     center: 1.0, spread: 0.0),
+        ]
+
+        let qDim = toy.numHeads * toy.fullHeadDim
+        for L in 0..<toy.numLayers {
+            let p = "model.layers.\(L)"
+            specs.append(bf16Spec("\(p).attn_norm.weight",
+                                  shape: [UInt32(d), 0, 0, 0], count: d,
+                                  center: 1.0, spread: 0.02))
+            specs.append(bf16Spec("\(p).ffn_norm.weight",
+                                  shape: [UInt32(d), 0, 0, 0], count: d,
+                                  center: 1.0, spread: 0.02))
+            specs.append(int4Spec("\(p).attn.wq_a.weight", rows: ca.qLoraRank, cols: d))
+            specs.append(bf16Spec("\(p).attn.q_norm.weight",
+                                  shape: [UInt32(ca.qLoraRank), 0, 0, 0],
+                                  count: ca.qLoraRank, center: 1.0, spread: 0.02))
+            specs.append(int4Spec("\(p).attn.wq_b.weight", rows: qDim, cols: ca.qLoraRank))
+            specs.append(int4Spec("\(p).attn.wkv.weight", rows: toy.fullHeadDim, cols: d))
+            specs.append(bf16Spec("\(p).attn.kv_norm.weight",
+                                  shape: [UInt32(toy.fullHeadDim), 0, 0, 0],
+                                  count: toy.fullHeadDim, center: 1.0, spread: 0.02))
+            specs.append(fp32Spec("\(p).attn.attn_sink",
+                                  shape: [UInt32(toy.numHeads), 0, 0, 0],
+                                  count: toy.numHeads, center: 0, spread: 0.1))
+            specs.append(int4Spec("\(p).attn.wo_a.weight",
+                                  rows: ca.oGroups * ca.oLoraRank,
+                                  cols: qDim / ca.oGroups))
+            specs.append(int4Spec("\(p).attn.wo_b.weight",
+                                  rows: d, cols: ca.oGroups * ca.oLoraRank))
+            for site in ["attn_hc", "ffn_hc"] {
+                specs.append(fp32Spec("\(p).\(site).fn",
+                                      shape: [UInt32(hcRows), UInt32(hcCols), 0, 0],
+                                      count: hcRows * hcCols, center: 0, spread: 0.01))
+                specs.append(fp32Spec("\(p).\(site).base",
+                                      shape: [UInt32(hcRows), 0, 0, 0],
+                                      count: hcRows, center: 0, spread: 0.02))
+                specs.append(fp32Spec("\(p).\(site).scale", shape: [3, 0, 0, 0],
+                                      count: 3, center: 1.0, spread: 0.0))
+            }
+            // The DSV4 router gate is unquantized BF16.
+            specs.append(bf16Spec("\(p).ffn.gate.weight",
+                                  shape: [UInt32(toy.numExperts), UInt32(d), 0, 0],
+                                  count: toy.numExperts * d, center: 0, spread: 0.03))
+            if toy.layerIsHashRouted(L) {
+                specs.append(u32Spec("\(p).ffn.gate.tid2eid",
+                                     shape: [UInt32(toy.vocabSize),
+                                             UInt32(toy.topKExperts), 0, 0],
+                                     count: toy.vocabSize * toy.topKExperts,
+                                     bound: UInt32(toy.numExperts)))
+            } else {
+                specs.append(fp32Spec("\(p).ffn.gate.e_score_correction_bias",
+                                      shape: [UInt32(toy.numExperts), 0, 0, 0],
+                                      count: toy.numExperts, center: 0, spread: 0.02))
+            }
+            specs.append(int4Spec("\(p).ffn.shared_experts.gate_proj.weight",
+                                  rows: toy.intermediateSize, cols: d))
+            specs.append(int4Spec("\(p).ffn.shared_experts.up_proj.weight",
+                                  rows: toy.intermediateSize, cols: d))
+            specs.append(int4Spec("\(p).ffn.shared_experts.down_proj.weight",
+                                  rows: d, cols: toy.intermediateSize))
+
+            let isCSA = toy.layerIsCSA(L)
+            let isHCA = toy.layerIsHCA(L)
+            if isCSA || isHCA {
+                let rate = isCSA ? ca.csaCompressRate : ca.hcaCompressRate
+                let rowWidth = isCSA ? 2 * toy.fullHeadDim : toy.fullHeadDim
+                specs.append(int4Spec("\(p).attn.compressor.wkv.weight",
+                                      rows: rowWidth, cols: d))
+                specs.append(int4Spec("\(p).attn.compressor.wgate.weight",
+                                      rows: rowWidth, cols: d))
+                specs.append(bf16Spec("\(p).attn.compressor.norm.weight",
+                                      shape: [UInt32(toy.fullHeadDim), 0, 0, 0],
+                                      count: toy.fullHeadDim, center: 1.0, spread: 0.02))
+                specs.append(bf16Spec("\(p).attn.compressor.ape",
+                                      shape: [UInt32(rate), UInt32(rowWidth), 0, 0],
+                                      count: rate * rowWidth, center: 0, spread: 0.1))
+            }
+            if isCSA {
+                let idxWidth = 2 * ca.indexHeadDim
+                specs.append(int4Spec("\(p).attn.indexer.compressor.wkv.weight",
+                                      rows: idxWidth, cols: d))
+                specs.append(int4Spec("\(p).attn.indexer.compressor.wgate.weight",
+                                      rows: idxWidth, cols: d))
+                specs.append(bf16Spec("\(p).attn.indexer.compressor.norm.weight",
+                                      shape: [UInt32(ca.indexHeadDim), 0, 0, 0],
+                                      count: ca.indexHeadDim, center: 1.0, spread: 0.02))
+                specs.append(bf16Spec("\(p).attn.indexer.compressor.ape",
+                                      shape: [UInt32(ca.csaCompressRate),
+                                              UInt32(idxWidth), 0, 0],
+                                      count: ca.csaCompressRate * idxWidth,
+                                      center: 0, spread: 0.1))
+                specs.append(int4Spec("\(p).attn.indexer.wq_b.weight",
+                                      rows: ca.indexNHeads * ca.indexHeadDim,
+                                      cols: ca.qLoraRank))
+                specs.append(int4Spec("\(p).attn.indexer.weights_proj.weight",
+                                      rows: ca.indexNHeads, cols: d))
+            }
+        }
+
+        // 2. Serialize the resident index + payload.
+        let names = specs.map(\.name)
+        let stringTable = names.joined().data(using: .utf8)!
+        let headerBytes = GTurboBinary.indexHeaderBytes
+        let entryBytes = GTurboBinary.indexEntryBytes
+        let entriesBase = headerBytes
+        let stringTableBase = entriesBase + names.count * entryBytes
+        var nameAbsOffsets: [UInt32] = []
+        var cursor = 0
+        for n in names {
+            nameAbsOffsets.append(UInt32(stringTableBase + cursor))
+            cursor += n.utf8.count
+        }
+        // The payload base and every sub-tensor offset must be 16-byte
+        // aligned: the resident region starts right after a string table whose
+        // length depends on the tensor names, and DSV4 binds FP32 tensors
+        // (attn_sink, the hyper-connection mixes) straight out of this file.
+        // A 2-byte-aligned offset is legal for the BF16/INT4 tensors but
+        // silently corrupts a `device const float*` binding.
+        func align16(_ value: UInt64) -> UInt64 { (value + 15) & ~15 }
+        let indexBytes = align16(UInt64(stringTableBase + stringTable.count))
+
+        var entries: [ResidentEntry] = []
+        entries.reserveCapacity(specs.count)
+        var payloadCursor = indexBytes
+        for spec in specs {
+            let weightOffset = align16(payloadCursor)
+            let scaleOffset = spec.scaleBytes > 0 ? align16(weightOffset + spec.weightBytes) : 0
+            let biasOffset = spec.biasBytes > 0 ? align16(scaleOffset + spec.scaleBytes) : 0
+            entries.append(ResidentEntry(
+                name: spec.name, dtype: spec.dtype, logicalShape4: spec.shape,
+                fileOffset: weightOffset, sizeBytes: spec.weightBytes,
+                scaleOffset: scaleOffset, scaleSize: spec.scaleBytes,
+                biasOffset: biasOffset, biasSize: spec.biasBytes,
+                quantSpec: nil,
+                sourceWeight: ModelLoaderTests.dummySource(spec.name),
+                sourceScales: nil, sourceBiases: nil))
+            payloadCursor = biasOffset > 0
+                ? biasOffset + spec.biasBytes
+                : (scaleOffset > 0 ? scaleOffset + spec.scaleBytes
+                                   : weightOffset + spec.weightBytes)
+        }
+        let residentSize = payloadCursor - indexBytes
+        let totalBytes = Int(indexBytes + residentSize)
+
+        var fileBuf = [UInt8](repeating: 0, count: totalBytes)
+        fileBuf.withUnsafeMutableBytes { raw in
+            let base = raw.baseAddress!
+            GTurboBinary.writeIndexHeader(into: base,
+                                          indexSize: indexBytes,
+                                          residentSize: residentSize,
+                                          entryCount: UInt64(entries.count))
+            for (i, e) in entries.enumerated() {
+                GTurboBinary.writeIndexEntry(
+                    into: base.advanced(by: entriesBase + i * entryBytes),
+                    entry: e, nameOffset: nameAbsOffsets[i])
+            }
+            _ = stringTable.withUnsafeBytes { sb in
+                memcpy(base.advanced(by: stringTableBase), sb.baseAddress!,
+                       stringTable.count)
+            }
+            var rng = Rng(state: 0x5DEE_CE66_D00D_1234)
+            for (i, spec) in specs.enumerated() {
+                let entry = entries[i]
+                let dst = base.advanced(by: Int(entry.fileOffset))
+                switch spec.fill {
+                case .quantized:
+                    let bytes = dst.assumingMemoryBound(to: UInt8.self)
+                    for j in 0..<Int(entry.sizeBytes) {
+                        bytes[j] = UInt8(truncatingIfNeeded: rng.next())
+                    }
+                    let scales = base.advanced(by: Int(entry.scaleOffset))
+                        .assumingMemoryBound(to: UInt16.self)
+                    let biases = base.advanced(by: Int(entry.biasOffset))
+                        .assumingMemoryBound(to: UInt16.self)
+                    // Zero-centred, small-magnitude affine dequant: nibble
+                    // codes 0...15 map to roughly +/- 8 * scale, so activations
+                    // stay well inside FP16 range through every layer.
+                    for j in 0..<(Int(entry.scaleSize) / u16) {
+                        let scale = 0.003 + rng.unit() * 0.003
+                        scales[j] = Quantization.bf16Bits(scale)
+                        biases[j] = Quantization.bf16Bits(-7.5 * scale)
+                    }
+                case .bf16(let center, let spread):
+                    let out = dst.assumingMemoryBound(to: UInt16.self)
+                    for j in 0..<(Int(entry.sizeBytes) / u16) {
+                        out[j] = Quantization.bf16Bits(center + rng.symmetric(spread))
+                    }
+                case .fp32(let center, let spread):
+                    let out = dst.assumingMemoryBound(to: Float.self)
+                    for j in 0..<(Int(entry.sizeBytes) / 4) {
+                        out[j] = center + rng.symmetric(spread)
+                    }
+                case .u32(let bound):
+                    let out = dst.assumingMemoryBound(to: UInt32.self)
+                    for j in 0..<(Int(entry.sizeBytes) / 4) {
+                        out[j] = UInt32(rng.next() % UInt64(bound))
+                    }
+                }
+            }
+        }
+        let weightsURL = dir.appendingPathComponent("model_weights.bin")
+        try Data(fileBuf).write(to: weightsURL)
+        let weightsSha = try Sha256Verifier.hashFile(at: weightsURL)
+
+        // 3. Packed experts: INT2 affine gate/up/down, page-aligned stride.
+        func appendU16(_ values: [UInt16], to bytes: inout [UInt8]) {
+            for value in values {
+                bytes.append(UInt8(truncatingIfNeeded: value))
+                bytes.append(UInt8(truncatingIfNeeded: value >> 8))
+            }
+        }
+        /// One INT2 affine row: four 2-bit codes per byte, low bits first,
+        /// with a BF16 scale/bias per group of `Quantization.groupSize`.
+        func int2Row(cols: Int, rng: inout Rng)
+            -> (packed: [UInt8], scales: [UInt16], biases: [UInt16]) {
+            var packed = [UInt8](repeating: 0, count: cols / 4)
+            for i in 0..<cols {
+                let q = UInt8(rng.next() % 4)
+                packed[i / 4] |= q << UInt8(2 * (i % 4))
+            }
+            var scales: [UInt16] = []
+            var biases: [UInt16] = []
+            for _ in 0..<(cols / Quantization.groupSize) {
+                let scale = 0.006 + rng.unit() * 0.006
+                scales.append(Quantization.bf16Bits(scale))
+                biases.append(Quantization.bf16Bits(-1.5 * scale))
+            }
+            return (packed, scales, biases)
+        }
+
+        func toyExpertBlob(layer: Int, expert: Int)
+            -> (bytes: [UInt8], tensors: [String: [String: Any]]) {
+            var rng = Rng(state: UInt64(layer &* 1_000 &+ expert &+ 7) &* 0x2545_F491_4F6C_DD1D)
+            var bytes: [UInt8] = []
+            var tensors: [String: [String: Any]] = [:]
+            func addProjection(prefix: String, rows: Int, cols: Int) {
+                let quantized = (0..<rows).map { _ in int2Row(cols: cols, rng: &rng) }
+                let packedOffset = bytes.count
+                for row in quantized { bytes.append(contentsOf: row.packed) }
+                tensors[prefix] = [
+                    "offset": packedOffset, "size": bytes.count - packedOffset,
+                    "dtype": "U32", "shape": [rows, cols], "bits": 2,
+                ]
+                let scalesOffset = bytes.count
+                for row in quantized { appendU16(row.scales, to: &bytes) }
+                tensors["\(prefix)_scales"] = [
+                    "offset": scalesOffset, "size": bytes.count - scalesOffset,
+                    "dtype": "BF16", "shape": [rows, cols / Quantization.groupSize],
+                ]
+                let biasesOffset = bytes.count
+                for row in quantized { appendU16(row.biases, to: &bytes) }
+                tensors["\(prefix)_biases"] = [
+                    "offset": biasesOffset, "size": bytes.count - biasesOffset,
+                    "dtype": "BF16", "shape": [rows, cols / Quantization.groupSize],
+                ]
+            }
+            addProjection(prefix: "gate", rows: toy.moeIntermediateSize, cols: d)
+            addProjection(prefix: "up", rows: toy.moeIntermediateSize, cols: d)
+            addProjection(prefix: "down", rows: d, cols: toy.moeIntermediateSize)
+            return (bytes, tensors)
+        }
+
+        let expertStride = UInt64(getpagesize())
+        let layerBytes = Int(expertStride) * toy.numExperts
+        var layoutLayers: [[String: Any]] = []
+        for L in 0..<toy.numLayers {
+            var payload = Data(count: layerBytes)
+            var experts: [[String: Any]] = []
+            for E in 0..<toy.numExperts {
+                let blob = toyExpertBlob(layer: L, expert: E)
+                precondition(blob.bytes.count <= Int(expertStride),
+                             "toy expert blob (\(blob.bytes.count) B) exceeds stride \(expertStride)")
+                let baseB = E * Int(expertStride)
+                for (i, byte) in blob.bytes.enumerated() { payload[baseB + i] = byte }
+                experts.append([
+                    "expert": E,
+                    "offset": UInt64(E) * expertStride,
+                    "size": expertStride,
+                    "tensors": blob.tensors,
+                ])
+            }
+            let basename = String(format: "layer_%02d.bin", L)
+            try payload.write(to: exp.appendingPathComponent(basename))
+            layoutLayers.append(["layer": L, "file": basename, "experts": experts])
+        }
+        var layerShaByName: [String: String] = [:]
+        for L in 0..<toy.numLayers {
+            let basename = String(format: "layer_%02d.bin", L)
+            layerShaByName["packed_experts/\(basename)"] =
+                try Sha256Verifier.hashFile(at: exp.appendingPathComponent(basename))
+        }
+
+        // 4. layout.json
+        let layoutData = try JSONSerialization.data(
+            withJSONObject: [
+                "expertStride": expertStride,
+                "numLayers": toy.numLayers,
+                "expertsPerLayer": toy.numExperts,
+                "layers": layoutLayers,
+            ] as [String: Any], options: [.sortedKeys])
+        let layoutURL = exp.appendingPathComponent("layout.json")
+        try layoutData.write(to: layoutURL)
+        let layoutSha = try Sha256Verifier.hashFile(at: layoutURL)
+
+        // 5. manifest.json
+        var files: [String: [String: Any]] = [
+            "model_weights.bin": ["size": totalBytes, "sha256": weightsSha],
+            "packed_experts/layout.json": ["size": layoutData.count, "sha256": layoutSha],
+        ]
+        for (rel, sha) in layerShaByName {
+            files[rel] = ["size": layerBytes, "sha256": sha]
+        }
+        func quantSlot(_ bits: Int) -> [String: Any] {
+            ["weightBits": bits, "scheme": "affine", "scaleType": "bf16",
+             "biasType": "bf16", "groupSize": Quantization.groupSize]
+        }
+        let archDict: [String: Any] = [
+            "hiddenSize": toy.hiddenSize, "ffnIntermediate": toy.intermediateSize,
+            "moeIntermediateSize": toy.moeIntermediateSize,
+            "numHeads": toy.numHeads, "numKVHeads": toy.numKVHeads,
+            "numFullKVHeads": toy.numFullKVHeads,
+            "headDim": toy.headDim, "fullHeadDim": toy.fullHeadDim,
+            "vocabSize": toy.vocabSize, "slidingWindow": toy.slidingWindow,
+            "finalLogitSoftcap": toy.finalLogitSoftcap,
+            "ropeTheta": toy.ropeTheta, "fullRopeTheta": toy.fullRopeTheta,
+            "partialRotaryFactor": toy.partialRotaryFactor,
+            "numLayers": toy.numLayers, "numExperts": toy.numExperts,
+            "topKExperts": toy.topKExperts,
+            "tieWordEmbeddings": toy.tieWordEmbeddings,
+            "attentionKEqV": toy.attentionKEqV,
+            "hiddenActivation": toy.hiddenActivation,
+            "fullAttentionLayerMask": toy.fullAttentionLayerMask.map { Int($0) },
+            "family": toy.family.rawValue,
+            "attnOutputGate": toy.attnOutputGate,
+            "attentionScale": toy.attentionScale,
+            "embeddingScaledBySqrtHidden": toy.embeddingScaledBySqrtHidden,
+            "routerScaled": toy.routerScaled,
+            "ffnSandwichNorms": toy.ffnSandwichNorms,
+            "sharedExpertGated": toy.sharedExpertGated,
+            "ropeNeoxSubdim": toy.ropeNeoxSubdim,
+            "caQLoraRank": ca.qLoraRank, "caOLoraRank": ca.oLoraRank,
+            "caOGroups": ca.oGroups, "caRopeHeadDim": ca.ropeHeadDim,
+            "caIndexNHeads": ca.indexNHeads, "caIndexHeadDim": ca.indexHeadDim,
+            "caIndexTopK": ca.indexTopK,
+            "caCSACompressRate": ca.csaCompressRate,
+            "caHCACompressRate": ca.hcaCompressRate,
+            "caCompressRopeTheta": ca.compressRopeTheta,
+            "caRopeScalingFactor": ca.ropeScalingFactor,
+            "caRopeScalingOriginalMax": ca.ropeScalingOriginalMax,
+            "caRopeScalingBetaFast": ca.ropeScalingBetaFast,
+            "caRopeScalingBetaSlow": ca.ropeScalingBetaSlow,
+            "hcMult": hc.mult, "hcSinkhornIters": hc.sinkhornIters, "hcEps": hc.eps,
+            "numHashRoutedLayers": toy.numHashRoutedLayers,
+            "routerScoringFunc": toy.routerScoringFunc,
+            "routedScalingFactor": toy.routedScalingFactor,
+            "swigluLimit": toy.swigluLimit,
+            "linearNumKHeads": 0, "linearNumVHeads": 0,
+            "linearKeyHeadDim": 0, "linearValueHeadDim": 0,
+            "linearConvKernelSize": 0,
+        ]
+        let manifestRoot: [String: Any] = [
+            "magic": "GTURBO",
+            "versionMajor": 1,
+            "versionMinor": 0,
+            "flags": ["streamingPresent": true, "turboQuantKV": false,
+                      "aneSharedExpert": false],
+            "modelID": "dsv4-toy",
+            "arch": archDict,
+            "quant": [
+                "embedding": quantSlot(4), "attention": quantSlot(4),
+                "router": quantSlot(8), "sharedExpert": quantSlot(4),
+                "routedExpert": quantSlot(2),
+            ],
+            "files": files,
+            "expertsPerLayer": toy.numExperts,
+            "numLayers": toy.numLayers,
+            "expertStride": expertStride,
+        ]
+        let manifestData = try JSONSerialization.data(
+            withJSONObject: manifestRoot,
+            options: [.sortedKeys, .withoutEscapingSlashes])
+        try manifestData.write(to: dir.appendingPathComponent("manifest.json"))
+        return dir
+    }
+}
+
+extension ArchConfig {
+    /// Tiny DeepSeek-V4 Flash baseline. Toy sizes everywhere they are free,
+    /// but every hard kernel constraint is respected:
+    ///
+    ///  * `fullHeadDim == 512` — `dsv4_attention_decode` is written for the
+    ///    absorbed-MLA KV width and `DSV4Kernels` preconditions on it.
+    ///  * `numHeads` a multiple of `DSV4Kernels.attentionHeadsPerThreadgroup`.
+    ///  * `hyperConnections.mult <= 4` — `dsv4_hc_weights` sizes its mix
+    ///    scratch for that.
+    ///  * `numHeads * fullHeadDim / oGroups` a multiple of the quant group.
+    ///  * `topKExperts == MoEDeepseekV4.topK` — the routed kernels are k6.
+    ///  * `numExperts > 8` so a chunk's live experts span more than one
+    ///    routed tile.
+    ///  * `indexTopK == 12` with `csaCompressRate == 4` puts the chunked
+    ///    prefill's lightning-selection cutover at absolute position 48, so a
+    ///    single fixture exercises both the batched path and the
+    ///    token-by-token fallback.
+    static func deepseekV4Toy() -> ArchConfig {
+        ArchConfig(
+            hiddenSize: 256,
+            intermediateSize: 64,
+            moeIntermediateSize: 64,
+            numHeads: 8,
+            numKVHeads: 1,
+            numFullKVHeads: 1,
+            headDim: 512,
+            fullHeadDim: 512,
+            vocabSize: 256,
+            slidingWindow: 16,
+            finalLogitSoftcap: 0.0,
+            ropeTheta: 10_000.0,
+            fullRopeTheta: 10_000.0,
+            partialRotaryFactor: 0.125,
+            numLayers: 4,
+            numExperts: 16,
+            topKExperts: 6,
+            tieWordEmbeddings: false,
+            attentionKEqV: true,
+            fullAttentionLayerMask: [0, 0, 3, 4],
+            hiddenActivation: "silu",
+            family: .deepseekV4Flash,
+            attnOutputGate: false,
+            attentionScale: 0.044194173824159216,
+            embeddingScaledBySqrtHidden: false,
+            routerScaled: false,
+            ffnSandwichNorms: false,
+            sharedExpertGated: false,
+            ropeNeoxSubdim: false,
+            compressedAttention: CompressedAttentionConfig(
+                qLoraRank: 128, oLoraRank: 64, oGroups: 2,
+                ropeHeadDim: 64,
+                indexNHeads: 2, indexHeadDim: 64, indexTopK: 12,
+                csaCompressRate: 4, hcaCompressRate: 8,
+                compressRopeTheta: 160_000.0),
+            hyperConnections: HyperConnectionConfig(mult: 2, sinkhornIters: 4,
+                                                    eps: 1e-6),
+            numHashRoutedLayers: 3,
+            routerScoringFunc: "sqrtsoftplus",
+            routedScalingFactor: 1.5,
+            swigluLimit: 10.0)
+    }
+}

--- a/Tests/Mference/Core/Runtime/DecodeOverlapTests.swift
+++ b/Tests/Mference/Core/Runtime/DecodeOverlapTests.swift
@@ -1,0 +1,441 @@
+import Testing
+import Foundation
+import Metal
+@testable import Mference
+
+/// Decode-loop overlap restructure: the layer's attention buffer now signals a
+/// shared event right after the router top-k and keeps the shared-expert FFN
+/// encoded behind that signal, so the routed-expert pread overlaps GPU work.
+/// These tests pin the two properties that restructure must preserve — the
+/// numerics are untouched, and the phase counters describe the decode window
+/// rather than the prompt.
+@Suite struct DecodeOverlapTests {
+
+    private func makeRunner() throws -> (URL, MetalContext, RealForwardRunner) {
+        let dir = try QwenToySynthetic.write()
+        let ctx = try MetalContext()
+        let model = try Model.load(directoryURL: dir,
+                                   device: ctx.device,
+                                   expecting: .qwen36Toy())
+        let runner = try RealForwardRunner(model: model,
+                                           context: ctx,
+                                           maxContext: 64)
+        return (dir, ctx, runner)
+    }
+
+    private func makeLogits(_ ctx: MetalContext, vocab: Int) throws -> MTLBuffer {
+        guard let buf = ctx.device.makeBuffer(
+            length: vocab * MemoryLayout<Float16>.stride,
+            options: .storageModeShared) else {
+            throw ModelError.residentBufferWrapFailed
+        }
+        return buf
+    }
+
+    private func decodeGreedy(_ runner: RealForwardRunner,
+                              _ logits: MTLBuffer,
+                              steps: Int) async throws -> [UInt32] {
+        var out: [UInt32] = []
+        var token: Int32 = 1
+        for position in 0..<steps {
+            try await runner.produce(token: token, position: position, into: logits)
+            out.append(runner.lastGreedyToken)
+            token = Int32(runner.lastGreedyToken)
+        }
+        return out
+    }
+
+    /// Determinism across the sync restructure. Waiting on the mid-buffer
+    /// router signal and waiting on the whole buffer differ only in *when* the
+    /// CPU wakes: the same kernels are encoded in the same order onto the same
+    /// serial queue, so both must emit identical tokens.
+    @Test func routerSignalWait_matchesFullCommandBufferWait() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx, vocab: 1024)
+
+        runner.routerEventWaitEnabled = true
+        let early = try await decodeGreedy(runner, logits, steps: 4)
+
+        runner.reset()
+        runner.routerEventWaitEnabled = false
+        let full = try await decodeGreedy(runner, logits, steps: 4)
+
+        #expect(early == full)
+        #expect(early.allSatisfy { $0 < 1024 })
+    }
+
+    /// The restructure must not disturb the prefill/decode equivalence the
+    /// runner already guarantees: prefilling a prompt then decoding gives the
+    /// same argmax as decoding those tokens one at a time.
+    @Test func mergedSharedExpert_keepsPrefillDecodeEquivalence() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx, vocab: 1024)
+
+        try await runner.produce(token: 11, position: 0, into: logits)
+        try await runner.produce(token: 7, position: 1, into: logits)
+        let reference = runner.lastGreedyToken
+
+        runner.reset()
+        let tokens: [Int32] = [11]
+        _ = try await runner.prefillChunked(tokens: tokens[...],
+                                            startPosition: 0,
+                                            outputMode: .greedyIfAvailable,
+                                            config: .production(chunkTokens: 32),
+                                            into: logits,
+                                            onProgress: { _ in })
+        try await runner.produce(token: 7, position: 1, into: logits)
+        #expect(runner.lastGreedyToken == reference)
+    }
+
+    /// Phase counters describe the decode window. Prefill accumulates into the
+    /// same counters (DeepSeek-V4 prefill is literally a decode loop), so
+    /// `prefillChunked` must hand back a zeroed window; decode then fills it.
+    @Test func phaseCounters_resetAtPrefillDecodeBoundary() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx, vocab: 1024)
+
+        let tokens: [Int32] = [1, 2, 3, 4]
+        _ = try await runner.prefillChunked(tokens: tokens[...],
+                                            startPosition: 0,
+                                            outputMode: .greedyIfAvailable,
+                                            config: .production(chunkTokens: 32),
+                                            into: logits,
+                                            onProgress: { _ in })
+        #expect(runner.totalCb1Nanos == 0)
+        #expect(runner.totalIoNanos == 0)
+        #expect(runner.totalCb2Nanos == 0)
+        #expect(runner.totalIoOverlappedNanos == 0)
+        #expect(runner.totalIoExposedNanos == 0)
+
+        try await runner.produce(token: 5, position: 4, into: logits)
+        #expect(runner.totalCb1Nanos > 0)
+    }
+
+    /// Explicit reset is idempotent and clears every phase counter.
+    @Test func beginDecodePhaseWindow_zeroesCounters() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx, vocab: 1024)
+
+        try await runner.produce(token: 1, position: 0, into: logits)
+        #expect(runner.totalCb1Nanos > 0)
+        runner.beginDecodePhaseWindow()
+        #expect(runner.totalCb1Nanos == 0)
+        #expect(runner.totalIoNanos == 0)
+        #expect(runner.totalCb2Nanos == 0)
+        #expect(runner.totalHeadNanos == 0)
+        #expect(runner.totalHeadFusedNanos == 0)
+        #expect(runner.totalIoOverlappedNanos == 0)
+        #expect(runner.totalIoExposedNanos == 0)
+        runner.beginDecodePhaseWindow()
+        #expect(runner.totalCb1Nanos == 0)
+    }
+
+    /// Speculative prefetch changes *when* expert bytes are read, never *which*
+    /// bytes reach a kernel: a prediction only pre-populates the slot cache the
+    /// real plan would have filled anyway. All three modes must decode
+    /// identically.
+    @Test func speculativePrefetchModes_produceIdenticalTokens() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx, vocab: 1024)
+
+        runner.speculativePrefetchMode = .off
+        let off = try await decodeGreedy(runner, logits, steps: 5)
+
+        runner.reset()
+        runner.speculativePrefetchMode = .prefetch
+        let prefetch = try await decodeGreedy(runner, logits, steps: 5)
+
+        runner.reset()
+        runner.speculativePrefetchMode = .advise
+        let advise = try await decodeGreedy(runner, logits, steps: 5)
+
+        #expect(off == prefetch)
+        #expect(off == advise)
+        #expect(off.allSatisfy { $0 < 1024 })
+    }
+
+    /// The Qwen toy routes 8-of-8 experts into a 16-slot cache, so after the
+    /// first token nothing can ever miss and a correct predictor issues
+    /// nothing. Pinned explicitly: "no reads issued" here is the right answer,
+    /// not a silently broken predictor.
+    @Test func speculativePrefetch_issuesNothingWhenEveryExpertIsResident() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx, vocab: 1024)
+
+        runner.speculativePrefetchMode = .prefetch
+        _ = try await decodeGreedy(runner, logits, steps: 6)
+
+        #expect(runner.totalSpecPrefetchIssued == 0)
+        #expect(runner.totalSpecPrefetchBytes == 0)
+        // Confirmation is scored against everything the predictor named, not
+        // against the (here empty) subset that needed reading.
+        #expect(runner.totalSpecPrefetchConfirmed <= runner.totalSpecPrefetchPredicted)
+    }
+
+    @Test func speculativePrefetchMode_parsesEnvironmentSpellings() {
+        typealias Mode = RealForwardRunner.SpeculativePrefetchMode
+        #expect(Mode.parse(nil) == .off)
+        #expect(Mode.parse("0") == .off)
+        #expect(Mode.parse("off") == .off)
+        #expect(Mode.parse("1") == .prefetch)
+        #expect(Mode.parse("on") == .prefetch)
+        #expect(Mode.parse("PREFETCH") == .prefetch)
+        #expect(Mode.parse("advise") == .advise)
+        #expect(Mode.parse("Advise") == .advise)
+        #expect(Mode.parse("nonsense") == .off)
+    }
+
+    /// The overlap probe is what makes "io exposed" trustworthy: it must report
+    /// nil (still running) until every tracked buffer completes, then the
+    /// completion time of the last one.
+    @Test func overlapProbe_reportsOnlyWhenAllBuffersFinish() throws {
+        let ctx = try MetalContext()
+        let probe = RealForwardRunner.GPUOverlapProbe()
+        #expect(probe.finishedNanos == 0)
+
+        let cb = ctx.queue.makeCommandBuffer()!
+        probe.track(cb)
+        #expect(probe.finishedNanos == nil)
+        let before = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+        cb.commit()
+        cb.waitUntilCompleted()
+        // The completion handler runs on a Metal thread; give it a moment.
+        let deadline = Date().addingTimeInterval(5)
+        while probe.finishedNanos == nil, Date() < deadline {
+            usleep(1_000)
+        }
+        guard let finished = probe.finishedNanos else {
+            Issue.record("overlap probe never observed the completion handler")
+            return
+        }
+        #expect(finished >= before)
+    }
+}
+
+/// Speculative prefetch on a fixture that can actually miss: the DeepSeek-V4
+/// toy routes 6 of 16 experts per layer, so an 8-slot cache guarantees real
+/// evictions and gives the previous-token predictor something to predict.
+/// This is also the primary target path (`produceTokenDSV4`).
+@Suite(.serialized)
+struct SpeculativePrefetchDSV4Tests {
+
+    private struct Harness {
+        let dir: URL
+        let runner: RealForwardRunner
+        let logits: MTLBuffer
+    }
+
+    /// Eight slots for sixteen experts: every token evicts.
+    private func makeHarness(slots: Int = 8) throws -> Harness {
+        let dir = try DSV4ToySynthetic.write()
+        let ctx = try MetalContext()
+        let model = try Model.load(directoryURL: dir,
+                                   device: ctx.device,
+                                   expecting: .deepseekV4Toy(),
+                                   streamingMode: .pread(slotCount: slots))
+        let runtime = RuntimeConfiguration(expertCacheSlots: slots,
+                                           prefillChunkTokens: 32,
+                                           forceLogitsHead: true)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64,
+                                           runtimeConfiguration: runtime)
+        guard let logits = ctx.device.makeBuffer(
+            length: model.config.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared) else {
+            throw ModelError.residentBufferWrapFailed
+        }
+        return Harness(dir: dir, runner: runner, logits: logits)
+    }
+
+    private func decode(_ h: Harness, steps: Int) async throws -> [Float] {
+        var out: [Float] = []
+        for position in 0..<steps {
+            try await h.runner.produce(token: Int32(position % 7 + 1),
+                                       position: position,
+                                       into: h.logits)
+            let ptr = h.logits.contents().assumingMemoryBound(to: Float16.self)
+            out.append(Float(ptr[0]))
+            out.append(Float(ptr[1]))
+        }
+        return out
+    }
+
+    /// The default "previous token's routing" predictor provably cannot issue a
+    /// read: only layer L's own plans touch layer L's slots, so last token's
+    /// experts are still resident when we would predict them. Even with 16
+    /// experts, top-6 routing and only 8 slots — a cache that evicts on every
+    /// token — the predicted set is always the resident set.
+    @Test func previousTokenPredictorNeverFindsANonResidentExpert() async throws {
+        let h = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: h.dir) }
+        h.runner.speculativePrefetchMode = .prefetch
+
+        _ = try await decode(h, steps: 6)
+
+        #expect(h.runner.totalSpecPrefetchIssued == 0)
+        #expect(h.runner.totalSpecPrefetchBytes == 0)
+    }
+
+    /// Everything downstream of the predictor — reserve, background pread,
+    /// join, confirmation scoring, byte accounting — works end to end. Driven
+    /// through the predictor seam so the test does not depend on a fixture
+    /// whose routing happens to churn the cache.
+    @Test func injectedPredictorDrivesReserveReadJoinAndConfirm() async throws {
+        let h = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: h.dir) }
+        h.runner.speculativePrefetchMode = .prefetch
+        // Predict the whole expert file: guarantees non-resident experts every
+        // layer, so the machinery is exercised on every single layer step.
+        h.runner.speculativeExpertPredictor = { _ in Array(0..<16) }
+
+        _ = try await decode(h, steps: 4)
+
+        #expect(h.runner.totalSpecPrefetchIssued > 0)
+        #expect(h.runner.totalSpecPrefetchBytes > 0)
+        #expect(h.runner.totalSpecPrefetchConfirmed > 0)
+        #expect(h.runner.totalSpecPrefetchConfirmed <= h.runner.totalSpecPrefetchPredicted)
+    }
+
+    /// Advise mode warms the page cache without touching slots: reads are
+    /// "issued" but no expert bytes are copied into the cache, so residency is
+    /// driven entirely by the real plans.
+    @Test func adviseModeIssuesWithoutClaimingSlots() async throws {
+        let h = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: h.dir) }
+        h.runner.speculativePrefetchMode = .advise
+        h.runner.speculativeExpertPredictor = { _ in Array(0..<16) }
+
+        _ = try await decode(h, steps: 4)
+
+        #expect(h.runner.totalSpecPrefetchIssued > 0)
+    }
+
+    /// PILOT engages on the fixture that can miss: the lookahead GEMV names a
+    /// next-layer expert set, some of it is non-resident and gets read, and the
+    /// real plan confirms some of it. Recall is bounded, not asserted at a
+    /// level — it is an empirical property of the model, which is exactly what
+    /// the counters exist to measure.
+    @Test func pilotModeIssuesReadsAndMeasuresRecall() async throws {
+        let h = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: h.dir) }
+        h.runner.speculativePrefetchMode = .pilot
+
+        _ = try await decode(h, steps: 6)
+
+        #expect(h.runner.totalSpecPrefetchPredicted > 0)
+        #expect(h.runner.totalSpecPrefetchIssued > 0)
+        #expect(h.runner.totalSpecPrefetchBytes > 0)
+        #expect(h.runner.totalSpecPrefetchConfirmed > 0)
+        #expect(h.runner.totalSpecPrefetchConfirmed <= h.runner.totalSpecPrefetchPredicted)
+    }
+
+    /// The whole point of the exercise: unlike the temporal predictor, PILOT
+    /// names experts the cache does *not* already hold.
+    @Test func pilotPredictsNonResidentExpertsUnlikeTheTemporalPredictor() async throws {
+        let pilot = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: pilot.dir) }
+        pilot.runner.speculativePrefetchMode = .pilot
+        _ = try await decode(pilot, steps: 6)
+
+        let temporal = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: temporal.dir) }
+        temporal.runner.speculativePrefetchMode = .prefetch
+        _ = try await decode(temporal, steps: 6)
+
+        #expect(temporal.runner.totalSpecPrefetchIssued == 0)
+        #expect(pilot.runner.totalSpecPrefetchIssued > 0)
+    }
+
+    /// Determinism: the lookahead GEMV writes only private buffers and the
+    /// prefetch only pre-populates slots, so seeded output must be byte
+    /// identical to speculation being off.
+    @Test func pilotModeLogitsAreIdenticalToOff() async throws {
+        let off = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: off.dir) }
+        off.runner.speculativePrefetchMode = .off
+        let baseline = try await decode(off, steps: 6)
+
+        let pilot = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: pilot.dir) }
+        pilot.runner.speculativePrefetchMode = .pilot
+        #expect(try await decode(pilot, steps: 6) == baseline)
+    }
+
+    /// Hash-routed layers bypass the GEMV: their expert set is an exact
+    /// function of the token id, so predictions for them are perfect. The toy
+    /// has hash-routed layers, so decoding the same token repeatedly must
+    /// confirm every hash-layer prediction.
+    @Test func hashRoutedNextLayerPredictionIsExact() async throws {
+        let h = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: h.dir) }
+        h.runner.speculativePrefetchMode = .pilot
+        #expect(ArchConfig.deepseekV4Toy().numHashRoutedLayers > 0)
+
+        for position in 0..<5 {
+            try await h.runner.produce(token: 3, position: position, into: h.logits)
+        }
+        // Predictions exist and at least the hash-layer ones are confirmed.
+        #expect(h.runner.totalSpecPrefetchPredicted > 0)
+        #expect(h.runner.totalSpecPrefetchConfirmed > 0)
+    }
+
+    /// Determinism under an aggressively wrong predictor: speculation evicting
+    /// and refilling slots on every layer must not change a single logit.
+    @Test func aggressiveMispredictionDoesNotChangeLogits() async throws {
+        let off = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: off.dir) }
+        off.runner.speculativePrefetchMode = .off
+        let baseline = try await decode(off, steps: 5)
+
+        let noisy = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: noisy.dir) }
+        noisy.runner.speculativePrefetchMode = .prefetch
+        // Rotating garbage: maximum eviction pressure, minimum recall.
+        nonisolated(unsafe) var tick = 0
+        noisy.runner.speculativeExpertPredictor = { layer in
+            tick += 1
+            return [(layer * 7 + tick) % 16, (layer * 3 + tick * 5) % 16]
+        }
+        #expect(try await decode(noisy, steps: 5) == baseline)
+    }
+
+    /// The determinism contract on the path that can actually mispredict:
+    /// speculation reorders I/O, never values.
+    @Test func allModesProduceIdenticalLogits() async throws {
+        let off = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: off.dir) }
+        off.runner.speculativePrefetchMode = .off
+        let baseline = try await decode(off, steps: 6)
+
+        let prefetch = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: prefetch.dir) }
+        prefetch.runner.speculativePrefetchMode = .prefetch
+        #expect(try await decode(prefetch, steps: 6) == baseline)
+
+        let advise = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: advise.dir) }
+        advise.runner.speculativePrefetchMode = .advise
+        #expect(try await decode(advise, steps: 6) == baseline)
+    }
+
+    /// Speculation must survive a mid-stream reset (the pending read is joined,
+    /// the predictor is cleared) and keep producing the same logits as a fresh
+    /// runner would.
+    @Test func resetDuringSpeculationIsSafe() async throws {
+        let h = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: h.dir) }
+        h.runner.speculativePrefetchMode = .prefetch
+
+        let first = try await decode(h, steps: 4)
+        h.runner.reset()
+        #expect(h.runner.continuationPosition == 0)
+        let second = try await decode(h, steps: 4)
+        #expect(first == second)
+    }
+}


### PR DESCRIPTION
## Summary

Performance pass on the DeepSeek V4 Flash path, porting proven techniques from [antirez/ds4](https://github.com/antirez/ds4) and [JustVugg/colibri](https://github.com/JustVugg/colibri). Every change is parity-tested against the existing path; several candidate optimizations were implemented, measured, and deliberately reverted with the rationale recorded.

### Measured (Apple M5, 24 GB, `dsv4.gturbo`, seed 42, 16 slots, identical protocol before/after)

| Metric | Before | After |
|---|---|---|
| Prefill, 629-token prompt | 183.8 s (3.4 tok/s) | **107.0 s (5.9 tok/s), 1.7x** |
| Prefill, 3051-token prompt | ~892 s (extrapolated) | **473.2 s, 1.9x** (first 2051 tok batched, remainder falls back) |
| Decode | 3.60–3.74 tok/s | 3.73–3.81 tok/s (disk-bound; see below) |
| DSV4 context ceiling | ~8.3K hard kernel cap (threadgroup array trap) | no kernel cap (Swift `maxContext` only) |
| Tests | 829 | **857, all green** |

> Long-prompt number updated after review: the original `beae4cd` measured 734.8 s because a span crossing the lightning cutover was rejected wholesale and the whole prompt silently fell back to token-by-token (caught by Codex review). `7e3b789` splits crossing spans so the eligible prefix stays batched — remeasured 473.2 s with identical output text.

Decode output is byte-identical to the pre-change engine in every configuration tested; chunked prefill is bit-exact against the sequential path (full-logits equality, not argmax).

## Changes

**DSV4 chunked prefill** (`RealForwardRunner+DSV4Prefill.swift`, new) — prompts previously ran token-by-token through the decode path. Now layer-major batched chunks: one command buffer per layer per chunk, routed-expert reads grouped per expert and amortized across the chunk (~1.3 TB → ~86 GB read for an 800-token prompt), depth-1 tile pipelining reusing the `PrefillRoutedTileScheduler` discipline. Positions past the lightning-selection cutover (`(indexTopK + 1) × csaRate − 1` = 2051 for the production model) fall back to the sequential path; a span crossing the cutover batches its eligible prefix and replays only the remainder. A mid-chunk failure marks the runner dirty (same `markDirty`/`markCommitted` discipline as `executePrefillChunk`), rejecting further use until `reset()`. `MFERENCE_DSV4_PREFILL=off` escape hatch.

**DSV4 attention decode kernel** — restructured on ds4's heads8 pattern: 8 query heads per threadgroup, each shared K=V row staged once to threadgroup memory and consumed by all 8 heads for both QK and V; online softmax removes the 2176-entry logits array and the context cap it imposed. Parity with the retained reference kernel within 1 fp16 ulp. Grouped o_proj collapsed 8 dispatches → 1 (bit-identical); per-row compressor blit encoders replaced by direct GEMV writes.

**Router top-k on GPU, parallelized** — the sqrtsoftplus k6, hash k6, and k8 selects ran on a single GPU thread; now parallel simdgroup selection (colibri's `r_top8_par` pattern), bit-identical including tie order, proven against the retained serial kernels.

**Decode loop overlap** — an `MTLSharedEvent` signaled immediately after the router top-k write wakes the CPU to plan slots and start expert preads while the same command buffer continues executing the shared-expert FFN (passive wait, no spin — colibri's M-series power-budget finding). `MFERENCE_ROUTER_EVENT=0` reverts to full-buffer waits. `MFERENCE_PHASES` counters now reset at the prefill/decode boundary and split expert I/O into overlapped vs exposed.

**PILOT speculative prefetch** (default **OFF**) — layer L+1's router applied to layer L's post-attention state, encoded in the same command buffer (zero extra syncs), feeding a slot-safe background pread pool with join/eviction-protection/confirmation accounting. Measured 67.5% recall on the real model and −70% exposed decode I/O — but a net wall-clock loss on the 24 GB test machine (speculative read volume saturates the SSD), so it ships disabled. `MFERENCE_SPEC_PREFETCH=pilot` for machines with disk/page-cache headroom.

### Measured-and-reverted (rationale in code comments/tests)
- GEMV activation threadgroup staging: int4 GEMV already at DRAM roofline (143–156 GB/s), int2 gain ~1.5% — below the repo's bar.
- Prefill readahead (`F_RDADVISE` lookahead): the existing 8-way concurrent pread already saturates the disk.
- Temporal-locality prefetch: structurally cannot fire — per-layer slot caches already retain last-token experts (pinned by a test).

## Why decode barely moved

The truthful phase counters show decode on this machine is disk-bound: ~16 s of every 34 s decode window is exposed expert pread, and PILOT proved that hiding it just moves the same bytes elsewhere on a saturated SSD. The kernel/sync work matters on machines where experts fit in page cache (32 GB+), where the GPU path becomes binding. Remaining levers for small-RAM machines: fewer bytes on disk (rANS-style lossless expert compression, ~24%) and more cache slots.

## Test plan
- [x] Full suite: 857 tests / 139 suites green (`Scripts/test.sh`)
- [x] Parity suites: router top-k (bit-identical incl. ties), attention (1 fp16 ulp), o_proj (bit-identical), chunked prefill (full-logits bit-exact across chunk sizes, ragged tails, mixed batched/fallback spans, a cutover-crossing span split mid compressor window, plus a negative control that corrupts the reduce and must fail)
- [x] Determinism: seeded decode output byte-identical across event on/off, spec-prefetch modes, and prefill chunked/sequential
- [x] Real-model benchmarks before/after on identical protocol (numbers above)
- [ ] Community-benchmark protocol run on a larger-RAM machine (M5 Pro/Max) to quantify the kernel-path gains where decode is not disk-bound
