### PR TITLE
feat: Inkling-Small 276B-A12B support (4-bit MLX, SSD-streamed experts)

### DIFF
--- a/Sources/Mference/Infrastructure/Metal/MetalContext.swift
+++ b/Sources/Mference/Infrastructure/Metal/MetalContext.swift
@@ -78,6 +78,7 @@ public final class MetalContext: @unchecked Sendable {
         "prefill",
         "gdn",
         "dsv4",
+        "inkling",
     ]
 
     /// Bundle locations for runtime shader modules.
@@ -88,6 +89,7 @@ public final class MetalContext: @unchecked Sendable {
         "dsv4": "Metal/DSV4",
         "fused": "Metal/Fusions",
         "gdn": "Metal/GDN",
+        "inkling": "Metal/Inkling",
         "logit": "Metal/Sampling",
         "moe": "Metal/MoE",
         "prefill": "Metal/Prefill",

--- a/Sources/Mference/Infrastructure/ModelIO/ManifestReader.swift
+++ b/Sources/Mference/Infrastructure/ModelIO/ManifestReader.swift
@@ -67,6 +67,26 @@ public struct ManifestArch: Decodable, Equatable, Sendable {
     public let routerScoringFunc: String?
     public let routedScalingFactor: Double?
     public let swigluLimit: Double?
+
+    // Inkling relative-position / short-conv / router extensions. Optional for
+    // the same reason: absent values validate against the defaults the other
+    // three families hold (one shared expert, unit logit scale, rest zeroed).
+    public let relDRel: Int?
+    public let relExtent: Int?
+    public let relProjDim: Int?
+    public let relLogScalingFloor: Int?
+    public let relLogScalingAlpha: Double?
+    public let sconvKernelSize: Int?
+    public let numSharedExperts: Int?
+    public let numDenseLayers: Int?
+    public let denseIntermediateSize: Int?
+    public let sharedExpertSink: Bool?
+    public let embedNormEnabled: Bool?
+    public let logitsWidthMultiplier: Double?
+    public let routerGateBias: Bool?
+    public let routerNormAfterTopK: Bool?
+    public let routerGlobalScale: Bool?
+    public let unpaddedVocabSize: Int?
 }
 
 public struct ManifestQuantSlot: Decodable, Equatable, Sendable {
@@ -182,7 +202,11 @@ public enum ManifestReader {
         for f in requiredFiles {
             if m.files[f] == nil { throw ModelError.missingFile(name: f) }
         }
-        for L in 0..<m.numLayers {
+        // Leading dense-FFN layers carry no routed experts, so the writer
+        // emits no blob for them (Inkling's layers 0-1). `validateArch` has
+        // already confirmed the manifest agrees with the baseline on the
+        // count, so it is safe to skip exactly that many.
+        for L in expected.numDenseLayers..<m.numLayers {
             let padded = String(format: "packed_experts/layer_%02d.bin", L)
             let plain  = "packed_experts/layer_\(L).bin"
             if m.files[padded] == nil && m.files[plain] == nil {
@@ -339,6 +363,38 @@ public enum ManifestReader {
                   a.routedScalingFactor ?? 1.0, e.routedScalingFactor)
         try check("swigluLimit",
                   a.swigluLimit ?? 0.0, e.swigluLimit)
+        try check("relDRel",
+                  a.relDRel ?? 0, e.relativePosition.dRel)
+        try check("relExtent",
+                  a.relExtent ?? 0, e.relativePosition.extent)
+        try check("relProjDim",
+                  a.relProjDim ?? 0, e.relativePosition.projDim)
+        try check("relLogScalingFloor",
+                  a.relLogScalingFloor ?? 0, e.relativePosition.logScalingFloor)
+        try check("relLogScalingAlpha",
+                  a.relLogScalingAlpha ?? 0.0, e.relativePosition.logScalingAlpha)
+        try check("sconvKernelSize",
+                  a.sconvKernelSize ?? 0, e.sconvKernelSize)
+        try check("numSharedExperts",
+                  a.numSharedExperts ?? 1, e.numSharedExperts)
+        try check("numDenseLayers",
+                  a.numDenseLayers ?? 0, e.numDenseLayers)
+        try check("denseIntermediateSize",
+                  a.denseIntermediateSize ?? 0, e.denseIntermediateSize)
+        try check("sharedExpertSink",
+                  a.sharedExpertSink ?? false, e.sharedExpertSink)
+        try check("embedNormEnabled",
+                  a.embedNormEnabled ?? false, e.embedNormEnabled)
+        try check("logitsWidthMultiplier",
+                  a.logitsWidthMultiplier ?? 1.0, e.logitsWidthMultiplier)
+        try check("routerGateBias",
+                  a.routerGateBias ?? false, e.routerGateBias)
+        try check("routerNormAfterTopK",
+                  a.routerNormAfterTopK ?? false, e.routerNormAfterTopK)
+        try check("routerGlobalScale",
+                  a.routerGlobalScale ?? false, e.routerGlobalScale)
+        try check("unpaddedVocabSize",
+                  a.unpaddedVocabSize ?? 0, e.unpaddedVocabSize)
     }
 
     /// Decode just enough of `manifest.json` to identify the model family,

--- a/Sources/Mference/Infrastructure/ModelIO/ModelTypes.swift
+++ b/Sources/Mference/Infrastructure/ModelIO/ModelTypes.swift
@@ -9,6 +9,7 @@ public enum ModelFamily: String, Sendable, Equatable {
     case gemma4 = "gemma4"
     case qwen36 = "qwen36"
     case deepseekV4Flash = "deepseekV4Flash"
+    case inklingSmall = "inklingSmall"
 }
 
 /// Gated-DeltaNet (linear attention) dimensions. Zeroed for architectures
@@ -128,6 +129,40 @@ public struct HyperConnectionConfig: Sendable, Equatable {
     public static let none = HyperConnectionConfig(mult: 0, sinkhornIters: 0, eps: 0)
 }
 
+/// Learned relative-attention position encoding, used by architectures that
+/// carry no RoPE at all. Inkling projects the residual to `projDim`
+/// (`attn.wr_du`, width `numHeads * dRel`) and reshapes it to a per-head
+/// `dRel` relative-state vector, which mixes a bank of bias-vs-distance
+/// profiles (`attn.rel_logits_proj.proj`, `[dRel, extent]`) into one bias per
+/// backward distance. The bias is zero outside `0 ..< extent`.
+///
+/// `extent` here is the **full-attention** width. Sliding layers use
+/// `ArchConfig.slidingWindow` instead, so the two layer kinds ship differently
+/// shaped `proj` tensors (Inkling: `[16, 512]` local, `[16, 1024]` global).
+/// The `logScaling*` correction likewise applies only to full-attention
+/// layers. Zeroed for RoPE architectures.
+public struct RelativePositionConfig: Sendable, Equatable {
+    public let dRel: Int
+    /// Bias width on full-attention layers; sliding layers use the window.
+    public let extent: Int
+    /// Output width of `attn.wr_du`, i.e. `numHeads * dRel`.
+    public let projDim: Int
+    public let logScalingFloor: Int
+    public let logScalingAlpha: Double
+
+    public init(dRel: Int, extent: Int, projDim: Int,
+                logScalingFloor: Int, logScalingAlpha: Double) {
+        self.dRel = dRel
+        self.extent = extent
+        self.projDim = projDim
+        self.logScalingFloor = logScalingFloor
+        self.logScalingAlpha = logScalingAlpha
+    }
+
+    public static let none = RelativePositionConfig(
+        dRel: 0, extent: 0, projDim: 0, logScalingFloor: 0, logScalingAlpha: 0)
+}
+
 /// Compile-time architecture baseline. `manifest.json -> arch` must match this
 /// field-by-field at load time; mismatches throw `ModelError.archMismatch`.
 ///
@@ -202,6 +237,36 @@ public struct ArchConfig: Sendable, Equatable {
     public let routedScalingFactor: Double
     /// Clamp for expert gate (max) and up (±) pre-activations. 0 = no clamp.
     public let swigluLimit: Double
+    /// Learned relative-attention bias; `.none` for RoPE architectures.
+    public let relativePosition: RelativePositionConfig
+    /// Depthwise short-convolution width applied to the block inputs and to
+    /// the K/V streams. 0 disables the short-conv path entirely.
+    public let sconvKernelSize: Int
+    /// Shared experts active on every token (Gemma/Qwen/DeepSeek ship 1,
+    /// Inkling 2).
+    public let numSharedExperts: Int
+    /// Leading layers that use a plain dense FFN instead of the MoE block.
+    public let numDenseLayers: Int
+    /// FFN width of those dense layers; 0 when `numDenseLayers` is 0.
+    public let denseIntermediateSize: Int
+    /// Whether the shared experts occupy their own router logits as sinks, so
+    /// the gate emits `numExperts + numSharedExperts` scores.
+    public let sharedExpertSink: Bool
+    /// RMS norm applied to the token embeddings before the first layer.
+    public let embedNormEnabled: Bool
+    /// muP output scaling divided into the logits. 1.0 disables.
+    public let logitsWidthMultiplier: Double
+    /// Real vocabulary size when the embedding matrix is padded for alignment.
+    /// Logits beyond this are padding and must be dropped before sampling, or
+    /// the model can emit ids the tokenizer cannot decode. 0 means "no
+    /// padding": `vocabSize` is the real vocabulary.
+    public let unpaddedVocabSize: Int
+    /// Learned additive bias on the router logits, used for selection only.
+    public let routerGateBias: Bool
+    /// Renormalize the top-k router weights after selection rather than before.
+    public let routerNormAfterTopK: Bool
+    /// Per-layer learned scalar multiplying the router weights.
+    public let routerGlobalScale: Bool
 
     public init(
         hiddenSize: Int,
@@ -239,7 +304,19 @@ public struct ArchConfig: Sendable, Equatable {
         numHashRoutedLayers: Int = 0,
         routerScoringFunc: String = "softmax",
         routedScalingFactor: Double = 1.0,
-        swigluLimit: Double = 0.0
+        swigluLimit: Double = 0.0,
+        relativePosition: RelativePositionConfig = .none,
+        sconvKernelSize: Int = 0,
+        numSharedExperts: Int = 1,
+        numDenseLayers: Int = 0,
+        denseIntermediateSize: Int = 0,
+        sharedExpertSink: Bool = false,
+        embedNormEnabled: Bool = false,
+        logitsWidthMultiplier: Double = 1.0,
+        routerGateBias: Bool = false,
+        routerNormAfterTopK: Bool = false,
+        routerGlobalScale: Bool = false,
+        unpaddedVocabSize: Int = 0
     ) {
         self.hiddenSize = hiddenSize
         self.intermediateSize = intermediateSize
@@ -277,6 +354,18 @@ public struct ArchConfig: Sendable, Equatable {
         self.routerScoringFunc = routerScoringFunc
         self.routedScalingFactor = routedScalingFactor
         self.swigluLimit = swigluLimit
+        self.relativePosition = relativePosition
+        self.sconvKernelSize = sconvKernelSize
+        self.numSharedExperts = numSharedExperts
+        self.numDenseLayers = numDenseLayers
+        self.denseIntermediateSize = denseIntermediateSize
+        self.sharedExpertSink = sharedExpertSink
+        self.embedNormEnabled = embedNormEnabled
+        self.logitsWidthMultiplier = logitsWidthMultiplier
+        self.routerGateBias = routerGateBias
+        self.routerNormAfterTopK = routerNormAfterTopK
+        self.routerGlobalScale = routerGlobalScale
+        self.unpaddedVocabSize = unpaddedVocabSize
     }
 
     /// Canonical Gemma 4 26B-A4B baseline, checked against the installed
@@ -436,11 +525,88 @@ public struct ArchConfig: Sendable, Equatable {
         return mask
     }
 
+    /// Canonical Inkling-Small 276B-A12B baseline, checked against the
+    /// installed model manifest. Source checkpoint
+    /// `pipenetwork/Inkling-Small-MLX-4bit` revision `9d6e4720` (MLX affine
+    /// 4-bit, group 64, uniform across embeddings/attention/experts; the
+    /// router gate stays BF16). See `docs/INKLING_SMALL.md`.
+    ///
+    /// The distinguishing features versus the other three families: no RoPE at
+    /// all (a learned relative-attention bias carries position, so
+    /// `ropeTheta`/`partialRotaryFactor` are zero), depthwise short
+    /// convolutions on the block inputs and the K/V streams, two shared
+    /// experts that sink their own router logits, and two leading dense-FFN
+    /// layers at 8× the expert width.
+    ///
+    /// `intermediateSize` is the shared-expert FFN width, which equals the
+    /// routed width here (2048); `denseIntermediateSize` (16 384) applies only
+    /// to layers 0–1.
+    public static let inklingSmall_276B_A12B = ArchConfig(
+        hiddenSize: 4096,
+        intermediateSize: 2048,
+        moeIntermediateSize: 2048,
+        numHeads: 32,
+        numKVHeads: 8,
+        numFullKVHeads: 8,
+        headDim: 128,
+        fullHeadDim: 128,
+        vocabSize: 201_024,
+        slidingWindow: 512,
+        finalLogitSoftcap: 0.0,
+        ropeTheta: 0.0,
+        fullRopeTheta: 0.0,
+        partialRotaryFactor: 0.0,
+        numLayers: 42,
+        numExperts: 256,
+        topKExperts: 6,
+        tieWordEmbeddings: false,
+        attentionKEqV: false,
+        fullAttentionLayerMask: Self.inklingSmallLayerMask(),
+        hiddenActivation: "silu",
+        family: .inklingSmall,
+        attnOutputGate: false,
+        // Inkling RMS-normalizes q and k per head, so attention scales by
+        // `1 / head_dim`, NOT `1 / sqrt(head_dim)` — see
+        // `inkling_mlx/attention.py`. Kept as the same expression the
+        // converter evaluates, since `validateArch` compares exactly.
+        attentionScale: 1.0 / Double(128),
+        embeddingScaledBySqrtHidden: false,
+        routerScaled: false,
+        ffnSandwichNorms: false,
+        sharedExpertGated: false,
+        ropeNeoxSubdim: false,
+        routerScoringFunc: "sigmoid",
+        routedScalingFactor: 8.0,              // route_scale
+        swigluLimit: 0.0,
+        relativePosition: RelativePositionConfig(
+            dRel: 16, extent: 1024, projDim: 512,
+            logScalingFloor: 128_000, logScalingAlpha: 0.1),
+        sconvKernelSize: 4,
+        numSharedExperts: 2,
+        numDenseLayers: 2,
+        denseIntermediateSize: 16_384,
+        sharedExpertSink: true,
+        embedNormEnabled: true,
+        logitsWidthMultiplier: 16.0,
+        routerGateBias: true,
+        routerNormAfterTopK: true,
+        routerGlobalScale: true,
+        unpaddedVocabSize: 200_058
+    )
+
+    private static func inklingSmallLayerMask() -> [UInt8] {
+        // `local_layer_ids` covers every layer except 5, 11, 17, 23, 29, 35
+        // and 41 — i.e. one global layer at the end of each group of six.
+        // 0 = sliding-window (512), 1 = full attention.
+        (0..<42).map { $0 % 6 == 5 ? 1 : 0 }
+    }
+
     /// Registry keyed by `manifest.arch.family` for auto-detection at load.
     public static let knownArchitectures: [ModelFamily: ArchConfig] = [
         .gemma4: .gemma4_26B_A4B,
         .qwen36: .qwen36_35B_A3B,
         .deepseekV4Flash: .deepseekV4Flash_284B_A13B,
+        .inklingSmall: .inklingSmall_276B_A12B,
     ]
 
     /// Resident INT4 GEMV shapes this architecture issues during decode, for

--- a/Sources/Mference/Infrastructure/ModelIO/PackedExpertsLayout.swift
+++ b/Sources/Mference/Infrastructure/ModelIO/PackedExpertsLayout.swift
@@ -89,6 +89,12 @@ enum PackedExpertsLayoutReader {
             else {
                 throw ModelError.indexCorrupt(detail: "layout.json: malformed layer entry")
             }
+            // Leading dense-FFN layers carry no routed experts; the writer
+            // emits an empty entry and no blob file (Inkling's layers 0-1).
+            if expertsArr.isEmpty {
+                layers.append(LayerLayout(layer: layerIdx, file: file, experts: []))
+                continue
+            }
             var experts = [ExpertEntry?](repeating: nil, count: expertsPerLayer)
             for expertObj in expertsArr {
                 guard

--- a/Sources/Mference/Kernels/Inkling/InklingKernels.swift
+++ b/Sources/Mference/Kernels/Inkling/InklingKernels.swift
@@ -20,6 +20,8 @@ final class InklingKernels {
     private let gammaCombinePSO: MTLComputePipelineState
     private let scalePSO: MTLComputePipelineState
     private let headEpiloguePSO: MTLComputePipelineState
+    private let scaleAccumPSO: MTLComputePipelineState
+    private let f32ToF16PSO: MTLComputePipelineState
     private let f16ToF32PSO: MTLComputePipelineState
     private let sconvF32OutPSO: MTLComputePipelineState
     private let residualAddF32DPSO: MTLComputePipelineState
@@ -42,6 +44,8 @@ final class InklingKernels {
         self.scalePSO = try context.pipeline("inkling_scale_f16")
         self.headEpiloguePSO = try context.pipeline("inkling_head_epilogue")
         self.f16ToF32PSO = try context.pipeline("inkling_f16_to_f32")
+        self.scaleAccumPSO = try context.pipeline("inkling_scale_accum_f32")
+        self.f32ToF16PSO = try context.pipeline("inkling_f32_to_f16")
         self.sconvF32OutPSO = try context.pipeline("inkling_sconv_step_f32out")
         self.residualAddF32DPSO = try context.pipeline("inkling_residual_add_f32d")
         self.residualAddF32PSO = try context.pipeline("inkling_residual_add_f32")
@@ -158,12 +162,13 @@ final class InklingKernels {
     /// then selection + weighting. `onesScale` is a bf16 all-ones [d] buffer.
     func encodeRouter(commandBuffer cb: MTLCommandBuffer,
                       weights: MTLBuffer, weightsOffset: Int,
-                      hidden: MTLBuffer,
+                      hidden: MTLBuffer, hiddenOffset: Int = 0,
                       onesScale: MTLBuffer,
                       gateBias: MTLBuffer, gateBiasOffset: Int,
                       globalScale: MTLBuffer, globalScaleOffset: Int,
-                      outIndices: MTLBuffer,
-                      outWeights: MTLBuffer,
+                      outIndices: MTLBuffer, outIndicesOffset: Int = 0,
+                      outWeights: MTLBuffer, outWeightsOffset: Int = 0,
+                      gammasOut: MTLBuffer? = nil, gammasOffset: Int = 0,
                       numRouted: UInt32, numShared: UInt32,
                       topK: UInt32, routeScale: Float,
                       d: UInt32) {
@@ -172,7 +177,7 @@ final class InklingKernels {
         if let enc = cb.makeComputeCommandEncoder() {
             enc.setComputePipelineState(routerGemvPSO)
             enc.setBuffer(weights, offset: weightsOffset, index: 0)
-            enc.setBuffer(hidden, offset: 0, index: 1)
+            enc.setBuffer(hidden, offset: hiddenOffset, index: 1)
             enc.setBuffer(onesScale, offset: 0, index: 2)
             enc.setBuffer(routerLogits, offset: 0, index: 3)
             enc.setBytes(&total, length: 4, index: 4)
@@ -186,7 +191,11 @@ final class InklingKernels {
                                gateBias: gateBias, gateBiasOffset: gateBiasOffset,
                                globalScale: globalScale,
                                globalScaleOffset: globalScaleOffset,
-                               outIndices: outIndices, outWeights: outWeights,
+                               outIndices: outIndices,
+                               outIndicesOffset: outIndicesOffset,
+                               outWeights: outWeights,
+                               outWeightsOffset: outWeightsOffset,
+                               gammasOut: gammasOut, gammasOffset: gammasOffset,
                                numRouted: numRouted, numShared: numShared,
                                topK: topK, routeScale: routeScale)
     }
@@ -196,8 +205,9 @@ final class InklingKernels {
     func encodeRouterSelectOnly(commandBuffer cb: MTLCommandBuffer,
                                 gateBias: MTLBuffer, gateBiasOffset: Int,
                                 globalScale: MTLBuffer, globalScaleOffset: Int,
-                                outIndices: MTLBuffer,
-                                outWeights: MTLBuffer,
+                                outIndices: MTLBuffer, outIndicesOffset: Int = 0,
+                                outWeights: MTLBuffer, outWeightsOffset: Int = 0,
+                                gammasOut: MTLBuffer? = nil, gammasOffset: Int = 0,
                                 numRouted: UInt32, numShared: UInt32,
                                 topK: UInt32, routeScale: Float) {
         guard let enc = cb.makeComputeCommandEncoder() else { return }
@@ -206,9 +216,9 @@ final class InklingKernels {
         enc.setBuffer(routerLogits, offset: 0, index: 0)
         enc.setBuffer(gateBias, offset: gateBiasOffset, index: 1)
         enc.setBuffer(globalScale, offset: globalScaleOffset, index: 2)
-        enc.setBuffer(outIndices, offset: 0, index: 3)
-        enc.setBuffer(outWeights, offset: 0, index: 4)
-        enc.setBuffer(sharedGammas, offset: 0, index: 5)
+        enc.setBuffer(outIndices, offset: outIndicesOffset, index: 3)
+        enc.setBuffer(outWeights, offset: outWeightsOffset, index: 4)
+        enc.setBuffer(gammasOut ?? sharedGammas, offset: gammasOffset, index: 5)
         enc.setBytes(&nr, length: 4, index: 6)
         enc.setBytes(&ns, length: 4, index: 7)
         enc.setBytes(&tk, length: 4, index: 8)
@@ -231,6 +241,39 @@ final class InklingKernels {
         enc.setBuffer(sharedGammas, offset: 0, index: 2)
         enc.setBuffer(y, offset: 0, index: 3)
         enc.setBytes(&n, length: 4, index: 4)
+        enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// acc(f32, at offset) += w * x(f16).
+    func encodeScaleAccum(commandBuffer cb: MTLCommandBuffer,
+                          acc: MTLBuffer, accOffset: Int,
+                          x: MTLBuffer,
+                          weight: Float, count: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var w = weight
+        var n = count
+        enc.setComputePipelineState(scaleAccumPSO)
+        enc.setBuffer(acc, offset: accOffset, index: 0)
+        enc.setBuffer(x, offset: 0, index: 1)
+        enc.setBytes(&w, length: 4, index: 2)
+        enc.setBytes(&n, length: 4, index: 3)
+        enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// dst(f16) = src(f32 at offset), narrowing.
+    func encodeF32ToF16(commandBuffer cb: MTLCommandBuffer,
+                        src: MTLBuffer, srcOffset: Int,
+                        dst: MTLBuffer, count: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var n = count
+        enc.setComputePipelineState(f32ToF16PSO)
+        enc.setBuffer(src, offset: srcOffset, index: 0)
+        enc.setBuffer(dst, offset: 0, index: 1)
+        enc.setBytes(&n, length: 4, index: 2)
         enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
                             threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
         enc.endEncoding()
@@ -261,13 +304,14 @@ final class InklingKernels {
 
     /// hidden(f32) += scale * delta(f32).
     func encodeResidualAddF32Delta(commandBuffer cb: MTLCommandBuffer,
-                                   hidden: MTLBuffer, delta: MTLBuffer,
+                                   hidden: MTLBuffer, hiddenOffset: Int = 0,
+                                   delta: MTLBuffer,
                                    count: UInt32, scale: Float = 1.0) {
         guard let enc = cb.makeComputeCommandEncoder() else { return }
         var n = count
         var sc = scale
         enc.setComputePipelineState(residualAddF32DPSO)
-        enc.setBuffer(hidden, offset: 0, index: 0)
+        enc.setBuffer(hidden, offset: hiddenOffset, index: 0)
         enc.setBuffer(delta, offset: 0, index: 1)
         enc.setBytes(&n, length: 4, index: 2)
         enc.setBytes(&sc, length: 4, index: 3)
@@ -278,12 +322,13 @@ final class InklingKernels {
 
     /// hidden(f32) = f16 src widened; the embed seeds the FP32 stream once.
     func encodeF16ToF32(commandBuffer cb: MTLCommandBuffer,
-                        src: MTLBuffer, dst: MTLBuffer, count: UInt32) {
+                        src: MTLBuffer, dst: MTLBuffer, dstOffset: Int = 0,
+                        count: UInt32) {
         guard let enc = cb.makeComputeCommandEncoder() else { return }
         var n = count
         enc.setComputePipelineState(f16ToF32PSO)
         enc.setBuffer(src, offset: 0, index: 0)
-        enc.setBuffer(dst, offset: 0, index: 1)
+        enc.setBuffer(dst, offset: dstOffset, index: 1)
         enc.setBytes(&n, length: 4, index: 2)
         enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
                             threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
@@ -306,14 +351,14 @@ final class InklingKernels {
 
     /// out(f16) = rmsnorm(x_f32) * weight(bf16).
     func encodeRMSF32(commandBuffer cb: MTLCommandBuffer,
-                      x: MTLBuffer,
+                      x: MTLBuffer, xOffset: Int = 0,
                       weight: MTLBuffer, weightOffset: Int,
                       out: MTLBuffer,
                       d: UInt32, eps: Float) {
         guard let enc = cb.makeComputeCommandEncoder() else { return }
         var dd = d, e = eps
         enc.setComputePipelineState(rmsF32PSO)
-        enc.setBuffer(x, offset: 0, index: 0)
+        enc.setBuffer(x, offset: xOffset, index: 0)
         enc.setBuffer(weight, offset: weightOffset, index: 1)
         enc.setBuffer(out, offset: 0, index: 2)
         enc.setBytes(&dd, length: 4, index: 3)

--- a/Sources/Mference/Kernels/Inkling/InklingKernels.swift
+++ b/Sources/Mference/Kernels/Inkling/InklingKernels.swift
@@ -1,0 +1,363 @@
+import Foundation
+import Metal
+
+/// Inkling-Small family kernels: depthwise short convolutions, per-head Q/K
+/// RMS norm (no V norm), single-token attention with the learned
+/// relative-position bias, the sigmoid router with shared-expert sinks, and
+/// two small elementwise helpers.
+///
+/// The router GEMV reuses `router_gemv_bf16_r4` (the DSV4/Qwen unquantized
+/// BF16 router precedent) over 258 rows — 256 routed logits plus the 2
+/// shared-expert sink logits — into a dedicated fp32 logits buffer;
+/// `inkling_router_select` then applies the family's selection and weighting
+/// semantics (see docs/INKLING_SMALL.md "Forward-pass contract").
+final class InklingKernels {
+    private let sconvPSO: MTLComputePipelineState
+    private let qkNormPSO: MTLComputePipelineState
+    private let attentionPSO: MTLComputePipelineState
+    private let routerGemvPSO: MTLComputePipelineState
+    private let routerSelectPSO: MTLComputePipelineState
+    private let gammaCombinePSO: MTLComputePipelineState
+    private let scalePSO: MTLComputePipelineState
+    private let headEpiloguePSO: MTLComputePipelineState
+    private let f16ToF32PSO: MTLComputePipelineState
+    private let sconvF32OutPSO: MTLComputePipelineState
+    private let residualAddF32DPSO: MTLComputePipelineState
+    private let residualAddF32PSO: MTLComputePipelineState
+    private let rmsF32PSO: MTLComputePipelineState
+    /// fp32 logits for the 256 routed + 2 shared sink scores.
+    let routerLogits: MTLBuffer
+    /// fp32 gammas for the 2 shared experts, written by the select kernel.
+    let sharedGammas: MTLBuffer
+
+    init(context: MetalContext,
+         numRouted: Int,
+         numShared: Int) throws {
+        self.sconvPSO = try context.pipeline("inkling_sconv_step")
+        self.qkNormPSO = try context.pipeline("inkling_qk_norm")
+        self.attentionPSO = try context.pipeline("inkling_attention_decode")
+        self.routerGemvPSO = try context.pipeline("router_gemv_bf16_r4")
+        self.routerSelectPSO = try context.pipeline("inkling_router_select")
+        self.gammaCombinePSO = try context.pipeline("inkling_gamma_combine")
+        self.scalePSO = try context.pipeline("inkling_scale_f16")
+        self.headEpiloguePSO = try context.pipeline("inkling_head_epilogue")
+        self.f16ToF32PSO = try context.pipeline("inkling_f16_to_f32")
+        self.sconvF32OutPSO = try context.pipeline("inkling_sconv_step_f32out")
+        self.residualAddF32DPSO = try context.pipeline("inkling_residual_add_f32d")
+        self.residualAddF32PSO = try context.pipeline("inkling_residual_add_f32")
+        self.rmsF32PSO = try context.pipeline("inkling_rms_f32in")
+        guard let logits = context.device.makeBuffer(
+            length: (numRouted + numShared) * MemoryLayout<Float>.size,
+            options: .storageModeShared) else {
+            throw MetalError.libraryCompileFailed("inkling router logits buffer allocation failed")
+        }
+        logits.label = "inkling.routerLogits"
+        self.routerLogits = logits
+        guard let gammas = context.device.makeBuffer(
+            length: max(numShared, 1) * MemoryLayout<Float>.size,
+            options: .storageModeShared) else {
+            throw MetalError.libraryCompileFailed("inkling shared gammas buffer allocation failed")
+        }
+        gammas.label = "inkling.sharedGammas"
+        self.sharedGammas = gammas
+    }
+
+    /// One decode step of the depthwise causal conv: `out = conv(x) + x`,
+    /// fp32 state (last K-1 inputs per channel) updated in place.
+    func encodeSconvStep(commandBuffer cb: MTLCommandBuffer,
+                         x: MTLBuffer, xOffset: Int = 0,
+                         state: MTLBuffer,
+                         weight: MTLBuffer, weightOffset: Int,
+                         out: MTLBuffer, outOffset: Int = 0,
+                         channels: UInt32,
+                         kernelSize: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var c = channels
+        var k = kernelSize
+        enc.setComputePipelineState(sconvPSO)
+        enc.setBuffer(x, offset: xOffset, index: 0)
+        enc.setBuffer(state, offset: 0, index: 1)
+        enc.setBuffer(weight, offset: weightOffset, index: 2)
+        enc.setBuffer(out, offset: outOffset, index: 3)
+        enc.setBytes(&c, length: 4, index: 4)
+        enc.setBytes(&k, length: 4, index: 5)
+        enc.dispatchThreads(MTLSize(width: Int(channels), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// Per-head weighted RMS norm on Q [nq, hd] and K [nkv, hd] in place.
+    func encodeQKNorm(commandBuffer cb: MTLCommandBuffer,
+                      q: MTLBuffer,
+                      k: MTLBuffer, kOffset: Int,
+                      qWeight: MTLBuffer, qWeightOffset: Int,
+                      kWeight: MTLBuffer, kWeightOffset: Int,
+                      headDim: UInt32, numQHeads: UInt32, numKVHeads: UInt32,
+                      eps: Float) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var hd = headDim, nq = numQHeads, nkv = numKVHeads, e = eps
+        enc.setComputePipelineState(qkNormPSO)
+        enc.setBuffer(q, offset: 0, index: 0)
+        enc.setBuffer(k, offset: kOffset, index: 1)
+        enc.setBuffer(qWeight, offset: qWeightOffset, index: 2)
+        enc.setBuffer(kWeight, offset: kWeightOffset, index: 3)
+        enc.setBytes(&hd, length: 4, index: 4)
+        enc.setBytes(&nq, length: 4, index: 5)
+        enc.setBytes(&nkv, length: 4, index: 6)
+        enc.setBytes(&e, length: 4, index: 7)
+        enc.dispatchThreadgroups(
+            MTLSize(width: Int(numQHeads + numKVHeads), height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// Single-token GQA attention with the inline relative-position bias.
+    /// `relExtent` is the bias width for THIS layer (window for sliding
+    /// layers, `rel_extent` for global ones); `tau` is the log-scaling factor
+    /// (1.0 below the floor and on sliding layers); `ringCapacity` is 0 for
+    /// non-ring caches.
+    func encodeAttentionDecode(commandBuffer cb: MTLCommandBuffer,
+                               q: MTLBuffer,
+                               k: MTLBuffer,
+                               v: MTLBuffer,
+                               rel: MTLBuffer,
+                               proj: MTLBuffer, projOffset: Int,
+                               out: MTLBuffer,
+                               headDim: UInt32, numQHeads: UInt32, numKVHeads: UInt32,
+                               seqLen: UInt32, kvStart: UInt32,
+                               relExtent: UInt32, dRel: UInt32,
+                               ringCapacity: UInt32,
+                               scale: Float, tau: Float) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var hd = headDim, nq = numQHeads, nkv = numKVHeads
+        var sl = seqLen, ks = kvStart, re = relExtent, dr = dRel, rc = ringCapacity
+        var sc = scale, tu = tau
+        enc.setComputePipelineState(attentionPSO)
+        enc.setBuffer(q, offset: 0, index: 0)
+        enc.setBuffer(k, offset: 0, index: 1)
+        enc.setBuffer(v, offset: 0, index: 2)
+        enc.setBuffer(rel, offset: 0, index: 3)
+        enc.setBuffer(proj, offset: projOffset, index: 4)
+        enc.setBuffer(out, offset: 0, index: 5)
+        enc.setBytes(&hd, length: 4, index: 6)
+        enc.setBytes(&nq, length: 4, index: 7)
+        enc.setBytes(&nkv, length: 4, index: 8)
+        enc.setBytes(&sl, length: 4, index: 9)
+        enc.setBytes(&ks, length: 4, index: 10)
+        enc.setBytes(&re, length: 4, index: 11)
+        enc.setBytes(&dr, length: 4, index: 12)
+        enc.setBytes(&rc, length: 4, index: 13)
+        enc.setBytes(&sc, length: 4, index: 14)
+        enc.setBytes(&tu, length: 4, index: 15)
+        enc.dispatchThreadgroups(MTLSize(width: Int(numQHeads), height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// BF16 router GEMV over `numRouted + numShared` rows into `routerLogits`,
+    /// then selection + weighting. `onesScale` is a bf16 all-ones [d] buffer.
+    func encodeRouter(commandBuffer cb: MTLCommandBuffer,
+                      weights: MTLBuffer, weightsOffset: Int,
+                      hidden: MTLBuffer,
+                      onesScale: MTLBuffer,
+                      gateBias: MTLBuffer, gateBiasOffset: Int,
+                      globalScale: MTLBuffer, globalScaleOffset: Int,
+                      outIndices: MTLBuffer,
+                      outWeights: MTLBuffer,
+                      numRouted: UInt32, numShared: UInt32,
+                      topK: UInt32, routeScale: Float,
+                      d: UInt32) {
+        var total = numRouted + numShared
+        var dim = d
+        if let enc = cb.makeComputeCommandEncoder() {
+            enc.setComputePipelineState(routerGemvPSO)
+            enc.setBuffer(weights, offset: weightsOffset, index: 0)
+            enc.setBuffer(hidden, offset: 0, index: 1)
+            enc.setBuffer(onesScale, offset: 0, index: 2)
+            enc.setBuffer(routerLogits, offset: 0, index: 3)
+            enc.setBytes(&total, length: 4, index: 4)
+            enc.setBytes(&dim, length: 4, index: 5)
+            enc.dispatchThreadgroups(
+                MTLSize(width: (Int(total) + 3) / 4, height: 1, depth: 1),
+                threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+            enc.endEncoding()
+        }
+        encodeRouterSelectOnly(commandBuffer: cb,
+                               gateBias: gateBias, gateBiasOffset: gateBiasOffset,
+                               globalScale: globalScale,
+                               globalScaleOffset: globalScaleOffset,
+                               outIndices: outIndices, outWeights: outWeights,
+                               numRouted: numRouted, numShared: numShared,
+                               topK: topK, routeScale: routeScale)
+    }
+
+    /// Selection + weighting over an already-populated `routerLogits`.
+    /// Split out so tests can feed synthetic logits directly.
+    func encodeRouterSelectOnly(commandBuffer cb: MTLCommandBuffer,
+                                gateBias: MTLBuffer, gateBiasOffset: Int,
+                                globalScale: MTLBuffer, globalScaleOffset: Int,
+                                outIndices: MTLBuffer,
+                                outWeights: MTLBuffer,
+                                numRouted: UInt32, numShared: UInt32,
+                                topK: UInt32, routeScale: Float) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var nr = numRouted, ns = numShared, tk = topK, rs = routeScale
+        enc.setComputePipelineState(routerSelectPSO)
+        enc.setBuffer(routerLogits, offset: 0, index: 0)
+        enc.setBuffer(gateBias, offset: gateBiasOffset, index: 1)
+        enc.setBuffer(globalScale, offset: globalScaleOffset, index: 2)
+        enc.setBuffer(outIndices, offset: 0, index: 3)
+        enc.setBuffer(outWeights, offset: 0, index: 4)
+        enc.setBuffer(sharedGammas, offset: 0, index: 5)
+        enc.setBytes(&nr, length: 4, index: 6)
+        enc.setBytes(&ns, length: 4, index: 7)
+        enc.setBytes(&tk, length: 4, index: 8)
+        enc.setBytes(&rs, length: 4, index: 9)
+        enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// y = gammas[0]*a + gammas[1]*b.
+    func encodeGammaCombine(commandBuffer cb: MTLCommandBuffer,
+                            a: MTLBuffer, b: MTLBuffer,
+                            y: MTLBuffer,
+                            count: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var n = count
+        enc.setComputePipelineState(gammaCombinePSO)
+        enc.setBuffer(a, offset: 0, index: 0)
+        enc.setBuffer(b, offset: 0, index: 1)
+        enc.setBuffer(sharedGammas, offset: 0, index: 2)
+        enc.setBuffer(y, offset: 0, index: 3)
+        enc.setBytes(&n, length: 4, index: 4)
+        enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// Sconv step with FP32 output (attn/mlp sublayer-output sites).
+    func encodeSconvStepF32Out(commandBuffer cb: MTLCommandBuffer,
+                               x: MTLBuffer,
+                               state: MTLBuffer,
+                               weight: MTLBuffer, weightOffset: Int,
+                               out: MTLBuffer,
+                               channels: UInt32,
+                               kernelSize: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var c = channels
+        var k = kernelSize
+        enc.setComputePipelineState(sconvF32OutPSO)
+        enc.setBuffer(x, offset: 0, index: 0)
+        enc.setBuffer(state, offset: 0, index: 1)
+        enc.setBuffer(weight, offset: weightOffset, index: 2)
+        enc.setBuffer(out, offset: 0, index: 3)
+        enc.setBytes(&c, length: 4, index: 4)
+        enc.setBytes(&k, length: 4, index: 5)
+        enc.dispatchThreads(MTLSize(width: Int(channels), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// hidden(f32) += scale * delta(f32).
+    func encodeResidualAddF32Delta(commandBuffer cb: MTLCommandBuffer,
+                                   hidden: MTLBuffer, delta: MTLBuffer,
+                                   count: UInt32, scale: Float = 1.0) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var n = count
+        var sc = scale
+        enc.setComputePipelineState(residualAddF32DPSO)
+        enc.setBuffer(hidden, offset: 0, index: 0)
+        enc.setBuffer(delta, offset: 0, index: 1)
+        enc.setBytes(&n, length: 4, index: 2)
+        enc.setBytes(&sc, length: 4, index: 3)
+        enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// hidden(f32) = f16 src widened; the embed seeds the FP32 stream once.
+    func encodeF16ToF32(commandBuffer cb: MTLCommandBuffer,
+                        src: MTLBuffer, dst: MTLBuffer, count: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var n = count
+        enc.setComputePipelineState(f16ToF32PSO)
+        enc.setBuffer(src, offset: 0, index: 0)
+        enc.setBuffer(dst, offset: 0, index: 1)
+        enc.setBytes(&n, length: 4, index: 2)
+        enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// hidden(f32) += delta(f16).
+    func encodeResidualAddF32(commandBuffer cb: MTLCommandBuffer,
+                              hidden: MTLBuffer, delta: MTLBuffer, count: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var n = count
+        enc.setComputePipelineState(residualAddF32PSO)
+        enc.setBuffer(hidden, offset: 0, index: 0)
+        enc.setBuffer(delta, offset: 0, index: 1)
+        enc.setBytes(&n, length: 4, index: 2)
+        enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// out(f16) = rmsnorm(x_f32) * weight(bf16).
+    func encodeRMSF32(commandBuffer cb: MTLCommandBuffer,
+                      x: MTLBuffer,
+                      weight: MTLBuffer, weightOffset: Int,
+                      out: MTLBuffer,
+                      d: UInt32, eps: Float) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var dd = d, e = eps
+        enc.setComputePipelineState(rmsF32PSO)
+        enc.setBuffer(x, offset: 0, index: 0)
+        enc.setBuffer(weight, offset: weightOffset, index: 1)
+        enc.setBuffer(out, offset: 0, index: 2)
+        enc.setBytes(&dd, length: 4, index: 3)
+        enc.setBytes(&e, length: 4, index: 4)
+        enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// Logits epilogue: scale the real vocabulary by `c` and pin the padding
+    /// tail to -inf so it can never be sampled.
+    func encodeHeadEpilogue(commandBuffer cb: MTLCommandBuffer,
+                            logits: MTLBuffer,
+                            scale c: Float,
+                            validVocab: UInt32,
+                            totalVocab: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var scale = c
+        var valid = validVocab
+        var total = totalVocab
+        enc.setComputePipelineState(headEpiloguePSO)
+        enc.setBuffer(logits, offset: 0, index: 0)
+        enc.setBytes(&scale, length: 4, index: 1)
+        enc.setBytes(&valid, length: 4, index: 2)
+        enc.setBytes(&total, length: 4, index: 3)
+        enc.dispatchThreads(MTLSize(width: Int(totalVocab), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// In-place x *= c over `count` half elements.
+    func encodeScale(commandBuffer cb: MTLCommandBuffer,
+                     x: MTLBuffer,
+                     by c: Float,
+                     count: UInt32) {
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var scale = c
+        var n = count
+        enc.setComputePipelineState(scalePSO)
+        enc.setBuffer(x, offset: 0, index: 0)
+        enc.setBytes(&scale, length: 4, index: 1)
+        enc.setBytes(&n, length: 4, index: 2)
+        enc.dispatchThreads(MTLSize(width: Int(count), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+}

--- a/Sources/Mference/Metal/Inkling/inkling.metal
+++ b/Sources/Mference/Metal/Inkling/inkling.metal
@@ -1,0 +1,439 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// ============================================================================
+// Inkling-Small family kernels.
+//
+// Semantics transcribed from the reference `inkling_mlx` package shipped in
+// the checkpoint repo (see docs/INKLING_SMALL.md "Forward-pass contract"):
+//
+//  - inkling_sconv_step: depthwise causal 1-D conv, kernel K, groups == C,
+//    no bias, no activation, PLUS the module-internal residual add. State is
+//    the last K-1 inputs, fp32, updated in place. Reference computes in fp32
+//    regardless of model dtype.
+//  - inkling_qk_norm: per-head RMS norm (weighted) on Q and K. V is NOT
+//    normalized in this family, which is why the Gemma fused epilogue (which
+//    RMS-norms V) is not reused.
+//  - inkling_attention_decode: single-token GQA attention with the learned
+//    relative-position bias computed inline, optional sliding window over a
+//    ring-buffered cache, and the long-context log-scaling factor `tau`
+//    multiplying both q·k and the bias (causal mask unaffected).
+//  - inkling_router_select: sigmoid router. Correction bias affects SELECTION
+//    only; weights are softmax(logsigmoid(raw logits)) over the 6 selected
+//    experts AND the 2 shared-expert sink logits, scaled by
+//    route_scale * global_scale. Whole router runs in fp32 — bf16 rounding
+//    flips near-tied top-k picks (reference warning).
+//  - inkling_gamma_combine: y = g0*a + g1*b for the two shared experts.
+//  - inkling_scale_f16: in-place scalar multiply (muP logit scaling).
+// ============================================================================
+
+constant constexpr uint kInklingAttnThreads = 128;
+constant constexpr uint kInklingAttnMaxSimdGroups = 4;
+constant constexpr uint kInklingMaxHeadDim = 128;
+constant constexpr uint kInklingMaxDRel = 16;
+
+// ----------------------------------------------------------------------------
+// Depthwise short convolution, one decode step.
+//   x_in   : [C] half — this step's input column.
+//   state  : [C, K-1] float — previous K-1 inputs per channel (oldest first).
+//   w      : [C, K] bfloat — per-channel taps (checkpoint layout [C, K, 1]).
+//   out    : [C] half — conv(x) + x, written at out_offset.
+// out[c] = x[c] + sum_{j<K-1} w[c,j]*state[c,j] + w[c,K-1]*x[c]; then the
+// state row shifts left and x enters at the end.
+// ----------------------------------------------------------------------------
+kernel void inkling_sconv_step(
+    device const half*   x_in    [[buffer(0)]],
+    device       float*  state   [[buffer(1)]],
+    device const bfloat* w       [[buffer(2)]],
+    device       half*   out     [[buffer(3)]],
+    constant     uint&   C       [[buffer(4)]],
+    constant     uint&   K       [[buffer(5)]],
+    uint c [[thread_position_in_grid]]
+) {
+    if (c >= C) return;
+    const uint km1 = K - 1u;
+    const float xv = float(x_in[c]);
+    device float* row = state + c * km1;
+    device const bfloat* taps = w + c * K;
+    float acc = xv * float(taps[km1]);
+    for (uint j = 0; j < km1; ++j) {
+        acc = fma(row[j], float(taps[j]), acc);
+    }
+    out[c] = half(acc + xv);
+    // Shift the state row and append this input.
+    for (uint j = 0; j + 1u < km1; ++j) { row[j] = row[j + 1u]; }
+    row[km1 - 1u] = xv;
+}
+
+// ----------------------------------------------------------------------------
+// Per-head weighted RMS norm over Q [NQ, HD] and K [NKV, HD], fp32 math.
+// Threadgroup per head; heads [0, NQ) are Q, [NQ, NQ+NKV) are K.
+// ----------------------------------------------------------------------------
+[[kernel, max_total_threads_per_threadgroup(kInklingAttnThreads)]]
+void inkling_qk_norm(
+    device       half*   q        [[buffer(0)]],
+    device       half*   k        [[buffer(1)]],
+    device const bfloat* q_weight [[buffer(2)]],   // [HD]
+    device const bfloat* k_weight [[buffer(3)]],   // [HD]
+    constant     uint&   head_dim [[buffer(4)]],
+    constant     uint&   nq       [[buffer(5)]],
+    constant     uint&   nkv      [[buffer(6)]],
+    constant     float&  eps      [[buffer(7)]],
+    uint tg   [[threadgroup_position_in_grid]],
+    uint lid  [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id  [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroups    [[simdgroups_per_threadgroup]]
+) {
+    threadgroup float scratch[kInklingAttnMaxSimdGroups];
+    threadgroup float bcast;
+    const uint HD = head_dim;
+    const bool is_q = tg < nq;
+    if (!is_q && tg >= nq + nkv) return;
+    device half* row = is_q ? (q + tg * HD) : (k + (tg - nq) * HD);
+    device const bfloat* w = is_q ? q_weight : k_weight;
+
+    float acc = 0.0f;
+    for (uint i = lid; i < HD; i += lsize) {
+        const float v = float(row[i]);
+        acc = fma(v, v, acc);
+    }
+    float s = simd_sum(acc);
+    if (simd_lane_id == 0) { scratch[simd_group_id] = s; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simd_group_id == 0) {
+        float t = (simd_lane_id < simdgroups) ? scratch[simd_lane_id] : 0.0f;
+        t = simd_sum(t);
+        if (simd_lane_id == 0) { bcast = t; }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const float inv = rsqrt(bcast / float(HD) + eps);
+    for (uint i = lid; i < HD; i += lsize) {
+        row[i] = half(float(row[i]) * inv * float(w[i]));
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Single-token GQA attention with inline relative-position bias.
+//
+//   Q    : [NQ, HD] half (post per-head RMS norm)
+//   K/V  : [slots, NKV, HD] half — ring-buffered when ring_cap > 0.
+//   rel  : [NQ, D_REL] half — this token's relative states (wr_du output).
+//   proj : [D_REL, rel_extent] bfloat — bias-vs-distance profile bank.
+//
+// For kv position p: dist = q_pos - p (>= 0 by construction of [kv_start,
+// seq_len)); bias = dot(rel[h], proj[:, dist]) if dist < rel_extent else 0.
+// logit = tau * (scale * q·k + bias). tau folds the global-layer log-scaling
+// of both q and the bias; the caller passes 1.0 for sliding layers and for
+// positions below the floor.
+// ----------------------------------------------------------------------------
+[[kernel, max_total_threads_per_threadgroup(kInklingAttnThreads)]]
+void inkling_attention_decode(
+    device const half*   Q          [[buffer(0)]],
+    device const half*   K          [[buffer(1)]],
+    device const half*   V          [[buffer(2)]],
+    device const half*   rel        [[buffer(3)]],
+    device const bfloat* proj       [[buffer(4)]],
+    device       half*   out        [[buffer(5)]],  // [NQ, HD]
+    constant     uint&   head_dim   [[buffer(6)]],
+    constant     uint&   nq         [[buffer(7)]],
+    constant     uint&   nkv        [[buffer(8)]],
+    constant     uint&   seq_len    [[buffer(9)]],
+    constant     uint&   kv_start   [[buffer(10)]],
+    constant     uint&   rel_extent [[buffer(11)]],
+    constant     uint&   d_rel      [[buffer(12)]],
+    constant     uint&   ring_cap   [[buffer(13)]],
+    constant     float&  scale      [[buffer(14)]],
+    constant     float&  tau        [[buffer(15)]],
+    uint tg   [[threadgroup_position_in_grid]],
+    uint lid  [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id  [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroups    [[simdgroups_per_threadgroup]]
+) {
+    threadgroup float q_smem[kInklingMaxHeadDim];
+    threadgroup float rel_smem[kInklingMaxDRel];
+    threadgroup float scratch[kInklingAttnMaxSimdGroups];
+    threadgroup float bcast;
+
+    const uint HD = head_dim;
+    const uint q_head = tg;
+    if (q_head >= nq) return;
+    const uint kv_head = q_head / (nq / nkv);
+    const uint q_pos = seq_len - 1u;
+
+    device const half* Q_row = Q + q_head * HD;
+    for (uint i = lid; i < HD; i += lsize) { q_smem[i] = float(Q_row[i]); }
+    device const half* rel_row = rel + q_head * d_rel;
+    if (lid < d_rel) { rel_smem[lid] = float(rel_row[lid]); }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float o_local = 0.0f;  // one output element per thread (HD <= lsize)
+    const uint my_i = lid; // element index this thread owns
+    float m_run = -INFINITY;
+    float d_run = 0.0f;
+
+    for (uint p = kv_start; p < seq_len; ++p) {
+        const uint phys = (ring_cap != 0u) ? (p % ring_cap) : p;
+        device const half* K_row = K + (phys * nkv + kv_head) * HD;
+        device const half* V_row = V + (phys * nkv + kv_head) * HD;
+
+        float partial = 0.0f;
+        for (uint i = lid; i < HD; i += lsize) {
+            partial = fma(q_smem[i], float(K_row[i]), partial);
+        }
+        float s = simd_sum(partial);
+        if (simd_lane_id == 0) { scratch[simd_group_id] = s; }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (simd_group_id == 0) {
+            float t = (simd_lane_id < simdgroups) ? scratch[simd_lane_id] : 0.0f;
+            t = simd_sum(t);
+            if (simd_lane_id == 0) { bcast = t; }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        float qk = bcast;
+
+        const uint dist = q_pos - p;
+        float bias = 0.0f;
+        if (dist < rel_extent) {
+            for (uint i = 0; i < d_rel; ++i) {
+                bias = fma(rel_smem[i], float(proj[i * rel_extent + dist]), bias);
+            }
+        }
+        const float logit = tau * fma(qk, scale, bias);
+
+        const float m_new = max(m_run, logit);
+        const float alpha = fast::exp(m_run - m_new);
+        const float p_exp = fast::exp(logit - m_new);
+        d_run = d_run * alpha + p_exp;
+        if (my_i < HD) {
+            o_local = o_local * alpha + p_exp * float(V_row[my_i]);
+        }
+        m_run = m_new;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    device half* out_row = out + q_head * HD;
+    if (my_i < HD) {
+        out_row[my_i] = half((d_run > 0.0f) ? (o_local / d_run) : 0.0f);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Sigmoid router selection over 258 logits (256 routed + 2 shared sinks).
+// Single threadgroup; the scan is 256 elements so one thread does selection.
+//
+//   logits       : [n_routed + n_shared] float, from router_gemv_bf16_r4.
+//   bias         : [n_routed] float — e_score_correction_bias; selection only.
+//   global_scale : [1] float — per-layer learned scalar.
+//   out_indices  : [top_k] uint
+//   out_weights  : [top_k] half — routed expert weights (phase-2 layout).
+//   out_gammas   : [n_shared] float — shared-expert weights.
+// ----------------------------------------------------------------------------
+kernel void inkling_router_select(
+    device const float* logits       [[buffer(0)]],
+    device const float* bias         [[buffer(1)]],
+    device const float* global_scale [[buffer(2)]],
+    device       uint*  out_indices  [[buffer(3)]],
+    device       half*  out_weights  [[buffer(4)]],
+    device       float* out_gammas   [[buffer(5)]],
+    constant     uint&  n_routed     [[buffer(6)]],
+    constant     uint&  n_shared     [[buffer(7)]],
+    constant     uint&  top_k        [[buffer(8)]],
+    constant     float& route_scale  [[buffer(9)]],
+    uint tid [[thread_position_in_threadgroup]]
+) {
+    if (tid != 0) return;
+    // Selection score: sigmoid(logit) + bias. Insertion into a small
+    // descending top-k array, matching argpartition's set semantics (intra-set
+    // order is irrelevant downstream).
+    uint  top_idx[8];
+    float top_score[8];
+    const uint KK = min(top_k, 8u);
+    for (uint i = 0; i < KK; ++i) { top_idx[i] = 0u; top_score[i] = -INFINITY; }
+    for (uint e = 0; e < n_routed; ++e) {
+        const float s = 1.0f / (1.0f + fast::exp(-logits[e])) + bias[e];
+        if (s <= top_score[KK - 1u]) continue;
+        uint pos = KK;
+        while (pos > 0u && top_score[pos - 1u] < s) { --pos; }
+        for (uint j = KK - 1u; j > pos; --j) {
+            top_score[j] = top_score[j - 1u];
+            top_idx[j]   = top_idx[j - 1u];
+        }
+        top_score[pos] = s;
+        top_idx[pos]   = e;
+    }
+
+    // Weights: softmax over logsigmoid of the RAW logits of the selected
+    // experts plus the shared sinks, then route_scale * global_scale.
+    // logsigmoid(x) = -log(1 + e^{-x}) = -log1p(exp(-x)); use the stable form
+    // min(x, 0) - log1p(exp(-|x|)).
+    float lp[10];
+    const uint total = KK + n_shared;
+    for (uint i = 0; i < total; ++i) {
+        const float x = (i < KK) ? logits[top_idx[i]] : logits[n_routed + (i - KK)];
+        lp[i] = min(x, 0.0f) - log(1.0f + fast::exp(-fabs(x)));
+    }
+    float mx = -INFINITY;
+    for (uint i = 0; i < total; ++i) { mx = max(mx, lp[i]); }
+    float denom = 0.0f;
+    for (uint i = 0; i < total; ++i) { denom += fast::exp(lp[i] - mx); }
+    const float s_all = route_scale * global_scale[0] / denom;
+    for (uint i = 0; i < KK; ++i) {
+        out_indices[i] = top_idx[i];
+        out_weights[i] = half(fast::exp(lp[i] - mx) * s_all);
+    }
+    for (uint s = 0; s < n_shared; ++s) {
+        out_gammas[s] = fast::exp(lp[KK + s] - mx) * s_all;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// y = gammas[0]*a + gammas[1]*b  (shared-expert combine, fp32 accumulate).
+// ----------------------------------------------------------------------------
+kernel void inkling_gamma_combine(
+    device const half*  a      [[buffer(0)]],
+    device const half*  b      [[buffer(1)]],
+    device const float* gammas [[buffer(2)]],
+    device       half*  y      [[buffer(3)]],
+    constant     uint&  count  [[buffer(4)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    y[i] = half(gammas[0] * float(a[i]) + gammas[1] * float(b[i]));
+}
+
+// ----------------------------------------------------------------------------
+// FP32 residual-stream helpers. Inkling's residual grows past 55 000 by layer
+// 22 (BF16-trained, muP-style outlier channels) and overflows an FP16 stream
+// at layer 23; the hidden state therefore lives in FP32 for this family.
+// Every consumer is an RMS norm, so only these three ops touch the stream.
+// ----------------------------------------------------------------------------
+kernel void inkling_f16_to_f32(
+    device const half*  src   [[buffer(0)]],
+    device       float* dst   [[buffer(1)]],
+    constant     uint&  count [[buffer(2)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    dst[i] = float(src[i]);
+}
+
+// Same taps/state semantics as inkling_sconv_step, but FP32 output: the
+// sublayer-output convolutions (attn/mlp sites) feed deltas that exceed the
+// FP16 range deep in the stack (~3.5x per-channel gain on outlier channels).
+kernel void inkling_sconv_step_f32out(
+    device const half*   x_in    [[buffer(0)]],
+    device       float*  state   [[buffer(1)]],
+    device const bfloat* w       [[buffer(2)]],
+    device       float*  out     [[buffer(3)]],
+    constant     uint&   C       [[buffer(4)]],
+    constant     uint&   K       [[buffer(5)]],
+    uint c [[thread_position_in_grid]]
+) {
+    if (c >= C) return;
+    const uint km1 = K - 1u;
+    const float xv = float(x_in[c]);
+    device float* row = state + c * km1;
+    device const bfloat* taps = w + c * K;
+    float acc = xv * float(taps[km1]);
+    for (uint j = 0; j < km1; ++j) {
+        acc = fma(row[j], float(taps[j]), acc);
+    }
+    out[c] = acc + xv;
+    for (uint j = 0; j + 1u < km1; ++j) { row[j] = row[j + 1u]; }
+    row[km1 - 1u] = xv;
+}
+
+// `scale` un-folds the FFN output pre-scale (see the runner: router weights
+// and shared gammas are divided by kInklingFFNPrescale so the FP16 MoE
+// intermediates stay inside half range on BF16-magnitude channels; the
+// sconv-with-residual is linear, so scaling back here is exact).
+kernel void inkling_residual_add_f32d(
+    device       float* hidden [[buffer(0)]],
+    device const float* delta  [[buffer(1)]],
+    constant     uint&  count  [[buffer(2)]],
+    constant     float& scale  [[buffer(3)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    hidden[i] = fma(delta[i], scale, hidden[i]);
+}
+
+kernel void inkling_residual_add_f32(
+    device       float* hidden [[buffer(0)]],
+    device const half*  delta  [[buffer(1)]],
+    constant     uint&  count  [[buffer(2)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    hidden[i] += float(delta[i]);
+}
+
+// RMS norm over an FP32 input row with BF16 gains, FP16 output (feeds the
+// INT4/INT8 GEMVs). One threadgroup, fp32 accumulation.
+[[kernel, max_total_threads_per_threadgroup(256)]]
+void inkling_rms_f32in(
+    device const float*  x      [[buffer(0)]],
+    device const bfloat* weight [[buffer(1)]],
+    device       half*   out    [[buffer(2)]],
+    constant     uint&   d      [[buffer(3)]],
+    constant     float&  eps    [[buffer(4)]],
+    uint lid   [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id  [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroups    [[simdgroups_per_threadgroup]]
+) {
+    threadgroup float scratch[8];
+    threadgroup float bcast;
+    float acc = 0.0f;
+    for (uint i = lid; i < d; i += lsize) {
+        const float v = x[i];
+        acc = fma(v, v, acc);
+    }
+    float ssum = simd_sum(acc);
+    if (simd_lane_id == 0) { scratch[simd_group_id] = ssum; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simd_group_id == 0) {
+        float t = (simd_lane_id < simdgroups) ? scratch[simd_lane_id] : 0.0f;
+        t = simd_sum(t);
+        if (simd_lane_id == 0) { bcast = t; }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const float inv = rsqrt(bcast / float(d) + eps);
+    for (uint i = lid; i < d; i += lsize) {
+        out[i] = half(x[i] * inv * float(weight[i]));
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Logits epilogue: i < valid → x[i] *= c (muP 1/16); i >= valid → -INF so the
+// padding rows of the 201 024-wide unembed can never be sampled (the real
+// vocabulary is 200 058).
+// ----------------------------------------------------------------------------
+kernel void inkling_head_epilogue(
+    device       half*  x     [[buffer(0)]],
+    constant     float& c     [[buffer(1)]],
+    constant     uint&  valid [[buffer(2)]],
+    constant     uint&  total [[buffer(3)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= total) return;
+    x[i] = (i < valid) ? half(float(x[i]) * c) : half(-INFINITY);
+}
+
+// ----------------------------------------------------------------------------
+// In-place x *= c over half elements (muP logit scaling, dense global_scale).
+// ----------------------------------------------------------------------------
+kernel void inkling_scale_f16(
+    device       half*  x     [[buffer(0)]],
+    constant     float& c     [[buffer(1)]],
+    constant     uint&  count [[buffer(2)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    x[i] = half(float(x[i]) * c);
+}

--- a/Sources/Mference/Metal/Inkling/inkling.metal
+++ b/Sources/Mference/Metal/Inkling/inkling.metal
@@ -426,6 +426,34 @@ kernel void inkling_head_epilogue(
 }
 
 // ----------------------------------------------------------------------------
+// acc(f32) += w * x(f16) — expert-major prefill accumulation: each streamed
+// expert's GLU output is folded into the per-token FFN accumulator with its
+// routing weight.
+// ----------------------------------------------------------------------------
+kernel void inkling_scale_accum_f32(
+    device       float* acc   [[buffer(0)]],
+    device const half*  x     [[buffer(1)]],
+    constant     float& w     [[buffer(2)]],
+    constant     uint&  count [[buffer(3)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    acc[i] = fma(float(x[i]), w, acc[i]);
+}
+
+// f32 -> f16 narrowing copy (per-token staging of chunk vectors into the
+// fixed GEMV scratch).
+kernel void inkling_f32_to_f16(
+    device const float* src   [[buffer(0)]],
+    device       half*  dst   [[buffer(1)]],
+    constant     uint&  count [[buffer(2)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    dst[i] = half(src[i]);
+}
+
+// ----------------------------------------------------------------------------
 // In-place x *= c over half elements (muP logit scaling, dense global_scale).
 // ----------------------------------------------------------------------------
 kernel void inkling_scale_f16(

--- a/Sources/Mference/Runtime/Inference/Model+Inkling.swift
+++ b/Sources/Mference/Runtime/Inference/Model+Inkling.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Metal
+
+/// Inkling-Small resident-tensor accessors. The family's attention carries no
+/// RoPE (`wr_du` + `rel_logits_proj` encode position), K/V pass through
+/// depthwise short convolutions, layers 0-1 are dense FFN, and the two shared
+/// experts ship stacked in one `[2, ...]` tensor per projection.
+extension Model {
+
+    // MARK: - Attention projections
+
+    public func inklingWqDu(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.wq_du.weight")
+    }
+    public func inklingWkDv(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.wk_dv.weight")
+    }
+    public func inklingWvDv(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.wv_dv.weight")
+    }
+    public func inklingWoUd(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.wo_ud.weight")
+    }
+    /// Relative-state projection, width `numHeads * dRel`.
+    public func inklingWrDu(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.wr_du.weight")
+    }
+    /// Bias-vs-distance profile bank `[dRel, extent]` — BF16, unquantized.
+    /// Extent is `slidingWindow` on local layers and `rel_extent` on global.
+    public func inklingRelProj(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.rel_logits_proj.proj")
+    }
+    public func inklingQNorm(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.q_norm.weight")
+    }
+    public func inklingKNorm(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.k_norm.weight")
+    }
+
+    // MARK: - Short convolutions (BF16 taps, checkpoint layout [C, K, 1])
+
+    public func inklingKSconv(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.k_sconv.weight")
+    }
+    public func inklingVSconv(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn.v_sconv.weight")
+    }
+    public func inklingAttnSconv(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).attn_sconv.weight")
+    }
+    public func inklingMlpSconv(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).mlp_sconv.weight")
+    }
+
+    // MARK: - Router sidecars
+
+    /// `e_score_correction_bias` — FP32 [numExperts]; selection only.
+    public func inklingGateBias(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).mlp.gate.bias")
+    }
+    /// Learned per-layer router output scalar — FP32 [1].
+    public func inklingGateGlobalScale(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).mlp.gate.global_scale")
+    }
+
+    // MARK: - Dense FFN (layers 0..<numDenseLayers)
+
+    public func inklingDenseGate(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).mlp.gate_proj.weight")
+    }
+    public func inklingDenseUp(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).mlp.up_proj.weight")
+    }
+    public func inklingDenseDown(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).mlp.down_proj.weight")
+    }
+    /// Learned output gain of the dense MLP — FP32 [1].
+    public func inklingDenseGlobalScale(layer L: Int) throws -> TensorView {
+        try resident(name: "model.llm.layers.\(L).mlp.global_scale")
+    }
+
+    // MARK: - Stacked shared experts
+
+    /// Sub-view of one shared expert from the stacked `[numShared, ...]`
+    /// tensor: weights, scales, and biases are each contiguous per expert, so
+    /// the slice at index `expert` is a fixed stride into all three regions.
+    public func inklingSharedExpert(_ proj: String, layer L: Int,
+                                    expert e: Int, of numShared: Int) throws -> TensorView {
+        let stacked = try resident(
+            name: "model.llm.layers.\(L).mlp.shared_experts.\(proj).weight")
+        let n = UInt64(numShared)
+        precondition(stacked.length % n == 0 && stacked.scaleLength % n == 0
+                        && stacked.biasLength % n == 0,
+                     "stacked shared-expert tensor not divisible by \(numShared)")
+        let w = stacked.length / n
+        let s = stacked.scaleLength / n
+        let b = stacked.biasLength / n
+        let idx = UInt64(e)
+        return TensorView(buffer: stacked.buffer,
+                          offset: stacked.offset + idx * w, length: w,
+                          scaleOffset: stacked.scaleOffset + idx * s, scaleLength: s,
+                          biasOffset: stacked.biasOffset + idx * b, biasLength: b,
+                          shape: (stacked.shape.1, stacked.shape.2, 1, 1),
+                          dtype: stacked.dtype)
+    }
+
+    /// Reads a resident scalar CPU-side, decoding by the view's dtype. The
+    /// checkpoint mixes precisions here: `mlp.gate.global_scale` and
+    /// `mlp.gate.bias` are FP32, but the dense layers' `mlp.global_scale` is
+    /// BF16 — reading that as raw FP32 yields garbage (2 BF16 bytes + 2
+    /// neighbor bytes), which corrupted layers 0-1 and, through them, every
+    /// downstream activation.
+    public func inklingScalar(_ view: TensorView) -> Float {
+        let base = view.buffer.contents().advanced(by: Int(view.offset))
+        switch view.dtype {
+        case 1:  // BF16
+            return Quantization.bf16ToFloat(base.assumingMemoryBound(to: UInt16.self)[0])
+        case 2:  // FP16
+            return Float(base.assumingMemoryBound(to: Float16.self)[0])
+        case 3:  // FP32
+            return base.assumingMemoryBound(to: Float.self)[0]
+        default:
+            preconditionFailure("inklingScalar: unsupported dtype \(view.dtype)")
+        }
+    }
+}

--- a/Sources/Mference/Runtime/Inference/Model.swift
+++ b/Sources/Mference/Runtime/Inference/Model.swift
@@ -91,22 +91,41 @@ public struct Model {
 
     /// Tensor-name prefix for the language-model trunk. Gemma and Qwen ship
     /// inside a multimodal container (`language_model.model.`); DeepSeek V4
-    /// is text-only and uses the bare `model.` prefix.
+    /// is text-only and uses the bare `model.` prefix. Inkling is multimodal
+    /// but names its towers as siblings (`model.llm.`, `model.visual.`,
+    /// `model.audio.`).
     var trunkPrefix: String {
         switch config.family {
         case .gemma4, .qwen36: return "language_model.model."
         case .deepseekV4Flash: return "model."
+        case .inklingSmall: return "model.llm."
         }
     }
     private var lmHeadName: String {
         switch config.family {
         case .gemma4, .qwen36: return "language_model.lm_head.weight"
         case .deepseekV4Flash: return "lm_head.weight"
+        case .inklingSmall: return "model.llm.unembed.weight"
+        }
+    }
+    /// Inkling names the token embedding `embed`, not `embed_tokens`.
+    private var embeddingName: String {
+        switch config.family {
+        case .gemma4, .qwen36, .deepseekV4Flash:
+            return "\(trunkPrefix)embed_tokens.weight"
+        case .inklingSmall:
+            return "\(trunkPrefix)embed.weight"
         }
     }
 
     public var embedding: TensorView {
-        try! resident(name: "\(trunkPrefix)embed_tokens.weight")
+        try! resident(name: embeddingName)
+    }
+
+    /// RMS norm applied to the token embeddings before the first layer.
+    /// Inkling-only (`use_embed_norm`); absent elsewhere.
+    public var embedNorm: TensorView {
+        try! resident(name: "\(trunkPrefix)embed_norm.weight")
     }
 
     /// Gemma 4 ties lm_head to the embedding; Qwen 3.6 carries a separate
@@ -139,6 +158,8 @@ public struct Model {
             return try resident(name: "language_model.model.layers.\(L).mlp.gate.weight")
         case .deepseekV4Flash:
             return try resident(name: "model.layers.\(L).ffn.gate.weight")
+        case .inklingSmall:
+            return try resident(name: "model.llm.layers.\(L).mlp.gate.weight")
         }
     }
     /// Shared-expert FFN. Gemma emits `.mlp.{gate,up,down}_proj.weight`
@@ -161,6 +182,8 @@ public struct Model {
             return "language_model.model.layers.\(L).mlp.shared_expert.\(proj).weight"
         case .deepseekV4Flash:
             return "model.layers.\(L).ffn.shared_experts.\(proj).weight"
+        case .inklingSmall:
+            return "model.llm.layers.\(L).mlp.shared_experts.\(proj).weight"
         }
     }
     /// Qwen-only scalar gate on the shared-expert branch: a `[1, hidden]`
@@ -172,7 +195,7 @@ public struct Model {
         switch config.family {
         case .gemma4, .qwen36:
             return try resident(name: "\(trunkPrefix)layers.\(L).input_layernorm.weight")
-        case .deepseekV4Flash:
+        case .deepseekV4Flash, .inklingSmall:
             return try resident(name: "\(trunkPrefix)layers.\(L).attn_norm.weight")
         }
     }
@@ -182,6 +205,8 @@ public struct Model {
             return try resident(name: "\(trunkPrefix)layers.\(L).post_attention_layernorm.weight")
         case .deepseekV4Flash:
             return try resident(name: "\(trunkPrefix)layers.\(L).ffn_norm.weight")
+        case .inklingSmall:
+            return try resident(name: "\(trunkPrefix)layers.\(L).mlp_norm.weight")
         }
     }
     public var finalNorm: TensorView {
@@ -490,6 +515,8 @@ public struct Model {
         if streamersBox.streamers[L] != nil {
             return
         }
+        // Leading dense-FFN layers have no routed experts and no blob file.
+        if packedExpertsLayout.layers[L].experts.isEmpty { return }
         let basename = packedExpertsLayout.layers[L].file
         let url = directoryURL
             .appendingPathComponent("packed_experts")
@@ -721,6 +748,8 @@ extension Model {
             guard layer.layer >= 0 && layer.layer < manifest.numLayers else {
                 throw ModelError.trustedReceiptInvalid(detail: "layout layer out of range")
             }
+            // Dense-FFN layers ship no expert blob; nothing to size-check.
+            if layer.experts.isEmpty { continue }
             let relativePath = "packed_experts/\(layer.file)"
             guard let manifestEntry = manifest.files[relativePath] else {
                 throw ModelError.trustedReceiptInvalid(detail: "manifest missing \(relativePath)")

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -266,6 +266,16 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     /// norm, so the stream converts to FP16 only at norm outputs.
     let inklingHiddenF32: MTLBuffer?         // [D] FP32
     let inklingDeltaF32: MTLBuffer?          // [D] FP32 sublayer delta
+    // Layer-major prefill chunk state (see prefillInklingChunk): per-token
+    // FP32 hidden rows, per-token router outputs, and the expert-major FFN
+    // accumulator. Sized to maxPrefillChunkTokens.
+    let inklingHiddenChunk: MTLBuffer?       // [chunk, D] FP32
+    let inklingRoutedXChunk: MTLBuffer?      // [chunk, D] FP16
+    let inklingIdxChunk: MTLBuffer?          // [chunk, 8] u32
+    let inklingWChunk: MTLBuffer?            // [chunk, 8] FP16
+    let inklingGammaChunk: MTLBuffer?        // [chunk, 2] FP32
+    let inklingAccChunk: MTLBuffer?          // [chunk, D] FP32
+    let inklingChunkCapacity: Int
     let inklingSharedY0: MTLBuffer?          // [D] FP16
     let inklingSharedY1: MTLBuffer?          // [D] FP16
     let inklingSharedProjections: [[LayerSharedExpertProjections]]
@@ -422,9 +432,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         self.rms       = try RMSNorm(context: context)
         self.int4      = try DequantInt4GEMV(
             context: context,
-            // Inkling bring-up: the (4096, 4096) constant-folded variant is
-            // under investigation for NaN output; run generic until cleared.
-            additionalShapes: cfg.family == .inklingSmall ? [] : cfg.decodeInt4GEMVShapes)
+            additionalShapes: cfg.decodeInt4GEMVShapes)
         self.attention = try Attention(context: context)
         self.shared    = try SharedExpertRuntime(context: context,
                                                   weightBits: model.sharedExpertWeightBits,
@@ -649,6 +657,14 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingRelScratch = try buf(dRelWidth)
             self.inklingHiddenF32 = try buf(D, MemoryLayout<Float>.size)
             self.inklingDeltaF32 = try buf(D, MemoryLayout<Float>.size)
+            let chunkCap = 128
+            self.inklingChunkCapacity = chunkCap
+            self.inklingHiddenChunk = try buf(chunkCap * D, MemoryLayout<Float>.size)
+            self.inklingRoutedXChunk = try buf(chunkCap * D)
+            self.inklingIdxChunk = try buf(chunkCap * 8, MemoryLayout<UInt32>.size)
+            self.inklingWChunk = try buf(chunkCap * 8)
+            self.inklingGammaChunk = try buf(chunkCap * 2, MemoryLayout<Float>.size)
+            self.inklingAccChunk = try buf(chunkCap * D, MemoryLayout<Float>.size)
             self.inklingSharedY0 = try buf(D)
             self.inklingSharedY1 = try buf(D)
             var convStates: [InklingLayerConvState] = []
@@ -707,6 +723,13 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingRelScratch = nil
             self.inklingHiddenF32 = nil
             self.inklingDeltaF32 = nil
+            self.inklingHiddenChunk = nil
+            self.inklingRoutedXChunk = nil
+            self.inklingIdxChunk = nil
+            self.inklingWChunk = nil
+            self.inklingGammaChunk = nil
+            self.inklingAccChunk = nil
+            self.inklingChunkCapacity = 0
             self.inklingSharedY0 = nil
             self.inklingSharedY1 = nil
             self.inklingSharedProjections = []
@@ -1154,21 +1177,48 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         }
 
         if cfg.family == .inklingSmall {
-            // Inkling prefill v1 replays the decode path token by token — the
-            // same correctness-reference structure DSV4 prefill v1 used. The
-            // short-conv states make out-of-order replay meaningless anyway:
-            // every token's conv output depends on the previous three.
+            // Layer-major chunked prefill with expert-major streaming (each
+            // unique routed expert read once per chunk-layer). The sequential
+            // decode replay remains as the correctness reference behind
+            // MFERENCE_INKLING_PREFILL=seq.
+            let sequential = ProcessInfo.processInfo
+                .environment["MFERENCE_INKLING_PREFILL"] == "seq"
             var pos = startPosition
-            var index = 0
-            for t in tokens {
-                let isLast = index == tokens.count - 1
-                try await produceTokenInkling(token: t, position: pos,
-                                              into: logits,
-                                              emitHead: isLast,
-                                              outputMode: outputMode)
-                pos += 1
-                index += 1
-                if index % 16 == 0 { onProgress(index) }
+            if sequential {
+                var index = 0
+                for t in tokens {
+                    let isLast = index == tokens.count - 1
+                    try await produceTokenInkling(token: t, position: pos,
+                                                  into: logits,
+                                                  emitHead: isLast,
+                                                  outputMode: outputMode)
+                    pos += 1
+                    index += 1
+                    if index % 16 == 0 { onProgress(index) }
+                }
+            } else {
+                // Simple contiguous spans capped by the chunk buffers (the
+                // KV ring also assumes writes at most maxPrefillChunkTokens
+                // ahead of the cursor).
+                let step = max(1, min(config.chunkTokens, inklingChunkCapacity))
+                var offset = 0
+                while offset < tokens.count {
+                    let count = min(step, tokens.count - offset)
+                    let lower = tokens.index(tokens.startIndex, offsetBy: offset)
+                    let upper = tokens.index(lower, offsetBy: count)
+                    prefillChunkState.markDirty(startPosition: pos,
+                                                tokenCount: count)
+                    try await prefillInklingChunk(
+                        tokens: tokens[lower..<upper],
+                        startPosition: pos,
+                        emitHead: offset + count == tokens.count,
+                        outputMode: outputMode,
+                        into: logits)
+                    prefillChunkState.markCommitted()
+                    pos += count
+                    offset += count
+                    onProgress(offset)
+                }
             }
             onProgress(tokens.count)
             if outputMode == .greedyIfAvailable, useFusedGreedyHead {
@@ -3026,27 +3076,27 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             // Q/K/V projections into scratch; K and V then pass through their
             // short convolutions on the way into the KV slot (the cache stores
             // the convolved, K-normed values, exactly like the reference's
-            // post-norm cache). Three plain GEMVs rather than the fused QKV
-            // kernel: this family's (4096, 1024, 4096) shape lands on the
-            // fused kernel's generic fallback, which produced NaN Q on
-            // hardware (K/V sections fine) — debugged 2026-08-03, see
-            // docs/INKLING_SMALL.md. Refuse the fusion until that kernel's
-            // generic path is fixed and parity-tested at this shape.
-            int4.encode(commandBuffer: cb,
-                        weights: q.buffer, weightsOffset: Int(q.offset),
-                        scales:  q.buffer, scalesOffset:  Int(q.scaleOffset),
-                        biases:  q.buffer, biasesOffset:  Int(q.biasOffset),
-                        x: normed, y: qScratch, m: qDim, n: D)
-            int4.encode(commandBuffer: cb,
-                        weights: k.buffer, weightsOffset: Int(k.offset),
-                        scales:  k.buffer, scalesOffset:  Int(k.scaleOffset),
-                        biases:  k.buffer, biasesOffset:  Int(k.biasOffset),
-                        x: normed, y: kStage, m: kvDim, n: D)
-            int4.encode(commandBuffer: cb,
-                        weights: v.buffer, weightsOffset: Int(v.offset),
-                        scales:  v.buffer, scalesOffset:  Int(v.scaleOffset),
-                        biases:  v.buffer, biasesOffset:  Int(v.biasOffset),
-                        x: normed, y: vStage, m: kvDim, n: D)
+            // post-norm cache). The fused kernel was briefly suspected during
+            // the corrupt-shard incident and later exonerated (the NaNs were
+            // bad wq_du bytes); its generic path is A/B-verified against the
+            // three plain GEMVs at this family's (4096, 1024, 4096) shape.
+            fusedQKVGEMV.encode(commandBuffer: cb,
+                                qWeights: q.buffer, qWeightsOffset: Int(q.offset),
+                                qScales: q.buffer, qScalesOffset: Int(q.scaleOffset),
+                                qBiases: q.buffer, qBiasesOffset: Int(q.biasOffset),
+                                kWeights: k.buffer, kWeightsOffset: Int(k.offset),
+                                kScales: k.buffer, kScalesOffset: Int(k.scaleOffset),
+                                kBiases: k.buffer, kBiasesOffset: Int(k.biasOffset),
+                                vWeights: v.buffer, vWeightsOffset: Int(v.offset),
+                                vScales: v.buffer, vScalesOffset: Int(v.scaleOffset),
+                                vBiases: v.buffer, vBiasesOffset: Int(v.biasOffset),
+                                x: normed,
+                                qOut: qScratch,
+                                kOut: kStage, kOutOffset: 0,
+                                vOut: vStage, vOutOffset: 0,
+                                qRows: qDim,
+                                kvRows: kvDim,
+                                n: D)
             dbgCut([("post-qkv qScratch", qScratch, Int(qDim)),
                     ("post-qkv kStage", kStage, Int(kvDim)),
                     ("post-qkv vStage", vStage, Int(kvDim))])
@@ -3403,6 +3453,399 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         }
 
         kv.advance()
+    }
+
+    /// Layer-major batched prefill for Inkling. The chunk's tokens advance
+    /// through one layer at a time; within a MoE layer the routed experts are
+    /// processed EXPERT-major — each unique expert in the chunk's routing is
+    /// streamed once and applied to every token routed to it — so cold-cache
+    /// expert I/O amortizes over the chunk instead of being paid per token
+    /// (~3.4 GB/token when sequential). Attention/sconv/norm reuse the decode
+    /// kernels per token inside one command buffer per layer, which preserves
+    /// conv-state and KV write ordering by construction.
+    private func prefillInklingChunk(tokens: ArraySlice<Int32>,
+                                     startPosition: Int,
+                                     emitHead: Bool,
+                                     outputMode: PrefillOutputMode,
+                                     into logits: MTLBuffer) async throws {
+        guard let inkling, let relScratch = inklingRelScratch,
+              let hiddenChunk = inklingHiddenChunk,
+              let routedXChunk = inklingRoutedXChunk,
+              let idxChunk = inklingIdxChunk,
+              let wChunk = inklingWChunk,
+              let gammaChunk = inklingGammaChunk,
+              let accChunk = inklingAccChunk,
+              let kv else {
+            preconditionFailure("Inkling prefill state missing")
+        }
+        let N = tokens.count
+        precondition(N <= inklingChunkCapacity,
+                     "chunk \(N) exceeds capacity \(inklingChunkCapacity)")
+        let D = UInt32(cfg.hiddenSize)
+        let Dh = cfg.hiddenSize
+        let eps: Float = 1e-6
+        let qDim = UInt32(cfg.numHeads * cfg.headDim)
+        let kvDim = UInt32(cfg.numKVHeads * cfg.headDim)
+        let sconvK = UInt32(cfg.sconvKernelSize)
+        let rel = cfg.relativePosition
+        let toks = Array(tokens)
+
+        func hOff(_ i: Int) -> Int { i * Dh * 4 }
+        func xOff(_ i: Int) -> Int { i * Dh * 2 }
+
+        // Seed the chunk's FP32 hidden rows: embed + embed_norm per token.
+        let emb = model.embedding
+        let embedNorm = model.embedNorm
+        runSync { cb in
+            for (i, t) in toks.enumerated() {
+                embedInt4.encode(commandBuffer: cb,
+                                 table:  emb.buffer, tableOffset:  Int(emb.offset),
+                                 scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
+                                 biases: emb.buffer, biasesOffset: Int(emb.biasOffset),
+                                 out: hidden,
+                                 tokenId: UInt32(bitPattern: t),
+                                 d: D, outScale: 1.0)
+                rms.encodeBF16W(commandBuffer: cb, x: hidden,
+                                weight: embedNorm.buffer,
+                                weightOffset: Int(embedNorm.offset),
+                                out: hidden, d: D, eps: eps)
+                inkling.encodeF16ToF32(commandBuffer: cb, src: hidden,
+                                       dst: hiddenChunk, dstOffset: hOff(i),
+                                       count: D)
+            }
+        }
+
+        for L in 0..<cfg.numLayers {
+            let isFull = cfg.fullAttentionLayerMask[L] == 1
+            let isDense = L < cfg.numDenseLayers
+            let conv = inklingConvStates[L]
+            let inNorm = try model.inputNorm(layer: L)
+            let mlpNorm = try model.postAttnNorm(layer: L)
+            let q = try model.inklingWqDu(layer: L)
+            let k = try model.inklingWkDv(layer: L)
+            let v = try model.inklingWvDv(layer: L)
+            let o = try model.inklingWoUd(layer: L)
+            let wr = try model.inklingWrDu(layer: L)
+            let relProj = try model.inklingRelProj(layer: L)
+            let qNorm = try model.inklingQNorm(layer: L)
+            let kNorm = try model.inklingKNorm(layer: L)
+            let kSconvW = try model.inklingKSconv(layer: L)
+            let vSconvW = try model.inklingVSconv(layer: L)
+            let attnSconvW = try model.inklingAttnSconv(layer: L)
+            let mlpSconvW = try model.inklingMlpSconv(layer: L)
+
+            let cbA = ctx.queue.makeCommandBuffer()!
+            if !isDense, let blit = cbA.makeBlitCommandEncoder() {
+                blit.fill(buffer: accChunk, range: 0..<(N * Dh * 4), value: 0)
+                blit.endEncoding()
+            }
+            for i in 0..<N {
+                let position = startPosition + i
+                let seqLen = UInt32(position + 1)
+                let kSlot = kv.kSlot(layer: L, position: position)
+                let vSlot = kv.vSlot(layer: L, position: position)
+                inkling.encodeRMSF32(commandBuffer: cbA,
+                                     x: hiddenChunk, xOffset: hOff(i),
+                                     weight: inNorm.buffer,
+                                     weightOffset: Int(inNorm.offset),
+                                     out: normed, d: D, eps: eps)
+                int4.encode(commandBuffer: cbA,
+                            weights: q.buffer, weightsOffset: Int(q.offset),
+                            scales:  q.buffer, scalesOffset:  Int(q.scaleOffset),
+                            biases:  q.buffer, biasesOffset:  Int(q.biasOffset),
+                            x: normed, y: qScratch, m: qDim, n: D)
+                int4.encode(commandBuffer: cbA,
+                            weights: k.buffer, weightsOffset: Int(k.offset),
+                            scales:  k.buffer, scalesOffset:  Int(k.scaleOffset),
+                            biases:  k.buffer, biasesOffset:  Int(k.biasOffset),
+                            x: normed, y: kStage, m: kvDim, n: D)
+                int4.encode(commandBuffer: cbA,
+                            weights: v.buffer, weightsOffset: Int(v.offset),
+                            scales:  v.buffer, scalesOffset:  Int(v.scaleOffset),
+                            biases:  v.buffer, biasesOffset:  Int(v.biasOffset),
+                            x: normed, y: vStage, m: kvDim, n: D)
+                int4.encode(commandBuffer: cbA,
+                            weights: wr.buffer, weightsOffset: Int(wr.offset),
+                            scales:  wr.buffer, scalesOffset:  Int(wr.scaleOffset),
+                            biases:  wr.buffer, biasesOffset:  Int(wr.biasOffset),
+                            x: normed, y: relScratch,
+                            m: UInt32(rel.projDim), n: D)
+                inkling.encodeSconvStep(commandBuffer: cbA,
+                                        x: kStage, state: conv.k,
+                                        weight: kSconvW.buffer,
+                                        weightOffset: Int(kSconvW.offset),
+                                        out: kSlot.buffer, outOffset: kSlot.offset,
+                                        channels: kvDim, kernelSize: sconvK)
+                inkling.encodeSconvStep(commandBuffer: cbA,
+                                        x: vStage, state: conv.v,
+                                        weight: vSconvW.buffer,
+                                        weightOffset: Int(vSconvW.offset),
+                                        out: vSlot.buffer, outOffset: vSlot.offset,
+                                        channels: kvDim, kernelSize: sconvK)
+                inkling.encodeQKNorm(commandBuffer: cbA,
+                                     q: qScratch,
+                                     k: kSlot.buffer, kOffset: kSlot.offset,
+                                     qWeight: qNorm.buffer, qWeightOffset: Int(qNorm.offset),
+                                     kWeight: kNorm.buffer, kWeightOffset: Int(kNorm.offset),
+                                     headDim: UInt32(cfg.headDim),
+                                     numQHeads: UInt32(cfg.numHeads),
+                                     numKVHeads: UInt32(cfg.numKVHeads),
+                                     eps: eps)
+                let window = UInt32(cfg.slidingWindow)
+                let kvStart: UInt32 = isFull ? 0 : (seqLen > window ? seqLen - window : 0)
+                let ringCapacity = kv.ringCapacity(layer: L)
+                let activeRing: UInt32 = (!isFull && ringCapacity > 0 && Int(seqLen) > ringCapacity)
+                    ? UInt32(ringCapacity) : 0
+                var tau: Float = 1.0
+                if isFull && rel.logScalingFloor > 0 {
+                    let n = Float(position + 1)
+                    let floorN = Float(rel.logScalingFloor)
+                    if n > floorN {
+                        tau = 1.0 + Float(rel.logScalingAlpha) * log(n / floorN)
+                    }
+                }
+                inkling.encodeAttentionDecode(commandBuffer: cbA,
+                                              q: qScratch,
+                                              k: kSlot.buffer, v: vSlot.buffer,
+                                              rel: relScratch,
+                                              proj: relProj.buffer,
+                                              projOffset: Int(relProj.offset),
+                                              out: attnOut,
+                                              headDim: UInt32(cfg.headDim),
+                                              numQHeads: UInt32(cfg.numHeads),
+                                              numKVHeads: UInt32(cfg.numKVHeads),
+                                              seqLen: seqLen, kvStart: kvStart,
+                                              relExtent: UInt32(isFull ? rel.extent : cfg.slidingWindow),
+                                              dRel: UInt32(rel.dRel),
+                                              ringCapacity: activeRing,
+                                              scale: Float(cfg.attentionScale),
+                                              tau: tau)
+                int4.encode(commandBuffer: cbA,
+                            weights: o.buffer, weightsOffset: Int(o.offset),
+                            scales:  o.buffer, scalesOffset:  Int(o.scaleOffset),
+                            biases:  o.buffer, biasesOffset:  Int(o.biasOffset),
+                            x: attnOut, y: oOut, m: D, n: qDim)
+                inkling.encodeSconvStepF32Out(commandBuffer: cbA,
+                                              x: oOut, state: conv.attn,
+                                              weight: attnSconvW.buffer,
+                                              weightOffset: Int(attnSconvW.offset),
+                                              out: inklingDeltaF32!,
+                                              channels: D, kernelSize: sconvK)
+                inkling.encodeResidualAddF32Delta(commandBuffer: cbA,
+                                                  hidden: hiddenChunk,
+                                                  hiddenOffset: hOff(i),
+                                                  delta: inklingDeltaF32!,
+                                                  count: D)
+                inkling.encodeRMSF32(commandBuffer: cbA,
+                                     x: hiddenChunk, xOffset: hOff(i),
+                                     weight: mlpNorm.buffer,
+                                     weightOffset: Int(mlpNorm.offset),
+                                     out: routedX, d: D, eps: eps)
+                if isDense {
+                    let proj = inklingDenseProjections[L]!
+                    let gain = model.inklingScalar(
+                        try model.inklingDenseGlobalScale(layer: L))
+                    try! shared.encode(commandBuffer: cbA,
+                                       x: routedX,
+                                       gate: proj.gate, up: proj.up, down: proj.down,
+                                       y: h2Buf,
+                                       scratchGate: denseScratchGate,
+                                       scratchUp: denseScratchUp,
+                                       scratchAct: denseScratchAct)
+                    inkling.encodeScale(commandBuffer: cbA, x: h2Buf,
+                                        by: gain, count: D)
+                    inkling.encodeSconvStepF32Out(commandBuffer: cbA,
+                                                  x: h2Buf, state: conv.mlp,
+                                                  weight: mlpSconvW.buffer,
+                                                  weightOffset: Int(mlpSconvW.offset),
+                                                  out: inklingDeltaF32!,
+                                                  channels: D, kernelSize: sconvK)
+                    inkling.encodeResidualAddF32Delta(commandBuffer: cbA,
+                                                      hidden: hiddenChunk,
+                                                      hiddenOffset: hOff(i),
+                                                      delta: inklingDeltaF32!,
+                                                      count: D)
+                } else {
+                    if let blit = cbA.makeBlitCommandEncoder() {
+                        blit.copy(from: routedX, sourceOffset: 0,
+                                  to: routedXChunk, destinationOffset: xOff(i),
+                                  size: Dh * 2)
+                        blit.endEncoding()
+                    }
+                    let routerW = try model.router(layer: L)
+                    let gateBias = try model.inklingGateBias(layer: L)
+                    let gateScale = try model.inklingGateGlobalScale(layer: L)
+                    inkling.encodeRouter(commandBuffer: cbA,
+                                         weights: routerW.buffer,
+                                         weightsOffset: Int(routerW.offset),
+                                         hidden: routedX,
+                                         onesScale: effectiveScaleBuffers[L],
+                                         gateBias: gateBias.buffer,
+                                         gateBiasOffset: Int(gateBias.offset),
+                                         globalScale: gateScale.buffer,
+                                         globalScaleOffset: Int(gateScale.offset),
+                                         outIndices: idxChunk,
+                                         outIndicesOffset: i * 8 * 4,
+                                         outWeights: wChunk,
+                                         outWeightsOffset: i * 8 * 2,
+                                         gammasOut: gammaChunk,
+                                         gammasOffset: i * 2 * 4,
+                                         numRouted: UInt32(cfg.numExperts),
+                                         numShared: UInt32(cfg.numSharedExperts),
+                                         topK: UInt32(cfg.topKExperts),
+                                         routeScale: Float(cfg.routedScalingFactor)
+                                             / Self.inklingFFNPrescale,
+                                         d: D)
+                }
+            }
+            cbA.commit()
+            waitForCompletion(cbA)
+            if isDense { continue }
+
+            // CPU: routing table for the whole chunk, then expert-major GLUs.
+            let idxPtr = idxChunk.contents().bindMemory(to: UInt32.self,
+                                                        capacity: N * 8)
+            let wPtr = wChunk.contents().bindMemory(to: Float16.self,
+                                                    capacity: N * 8)
+            let gPtr = gammaChunk.contents().bindMemory(to: Float.self,
+                                                        capacity: N * 2)
+            var expertTokens: [Int: [(Int, Float)]] = [:]
+            for i in 0..<N {
+                for s in 0..<cfg.topKExperts {
+                    let e = min(Int(idxPtr[i * 8 + s]), cfg.numExperts - 1)
+                    expertTokens[e, default: []].append((i, Float(wPtr[i * 8 + s])))
+                }
+            }
+            let routedOffsets = model.routedExpertOffsets(layer: L)
+            let F = UInt32(cfg.moeIntermediateSize)
+            func blobProjection(_ blob: TensorView, w: UInt32, sOff: UInt32,
+                                b: UInt32, rows: UInt32, cols: UInt32)
+                -> SharedExpertProjection {
+                SharedExpertProjection(weights: blob.buffer,
+                                       scales: blob.buffer,
+                                       biases: blob.buffer,
+                                       weightsOffset: Int(blob.offset) + Int(w),
+                                       scalesOffset: Int(blob.offset) + Int(sOff),
+                                       biasesOffset: Int(blob.offset) + Int(b),
+                                       rows: rows, cols: cols)
+            }
+            var pendingExpertCB: MTLCommandBuffer?
+            func encodeGLUGroup(gate: SharedExpertProjection,
+                                up: SharedExpertProjection,
+                                down: SharedExpertProjection,
+                                pairs: [(Int, Float)]) {
+                let cb = ctx.queue.makeCommandBuffer()!
+                for (i, w) in pairs {
+                    try! shared.encode(commandBuffer: cb,
+                                       x: routedXChunk, xOffset: xOff(i),
+                                       gate: gate, up: up, down: down,
+                                       y: h2Buf,
+                                       scratchGate: denseScratchGate,
+                                       scratchUp: denseScratchUp,
+                                       scratchAct: denseScratchAct)
+                    inkling.encodeScaleAccum(commandBuffer: cb,
+                                             acc: accChunk, accOffset: hOff(i),
+                                             x: h2Buf, weight: w, count: D)
+                }
+                cb.commit()
+                if let p = pendingExpertCB, let err = p.error {
+                    print("CB error: \(err)")
+                }
+                pendingExpertCB = cb
+            }
+            // Shared experts first (resident; gammas as weights).
+            for s2 in 0..<cfg.numSharedExperts {
+                let projs = inklingSharedProjections[L][s2]
+                let pairs = (0..<N).map { ($0, gPtr[$0 * 2 + s2]) }
+                encodeGLUGroup(gate: projs.gate, up: projs.up, down: projs.down,
+                               pairs: pairs)
+            }
+            // Routed experts, each streamed once for the whole chunk. The
+            // fetch of expert e+1 overlaps the GPU work of expert e.
+            let tIoStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+            for (e, pairs) in expertTokens.sorted(by: { $0.key < $1.key }) {
+                let blob = try await model.fetchRoutedExperts(layer: L,
+                                                              experts: [e])[0]
+                encodeGLUGroup(
+                    gate: blobProjection(blob, w: routedOffsets.gateWOff,
+                                         sOff: routedOffsets.gateSOff,
+                                         b: routedOffsets.gateBOff,
+                                         rows: F, cols: D),
+                    up: blobProjection(blob, w: routedOffsets.upWOff,
+                                       sOff: routedOffsets.upSOff,
+                                       b: routedOffsets.upBOff,
+                                       rows: F, cols: D),
+                    down: blobProjection(blob, w: routedOffsets.downWOff,
+                                         sOff: routedOffsets.downSOff,
+                                         b: routedOffsets.downBOff,
+                                         rows: D, cols: F),
+                    pairs: pairs)
+                // The next fetch may evict this expert's slot; drain first.
+                if let p = pendingExpertCB { waitForCompletion(p) }
+                pendingExpertCB = nil
+            }
+            totalIoNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tIoStart
+            if let p = pendingExpertCB { waitForCompletion(p); pendingExpertCB = nil }
+
+            // Tail: per token IN ORDER (mlp conv state), acc -> sconv -> add.
+            let cbC = ctx.queue.makeCommandBuffer()!
+            for i in 0..<N {
+                inkling.encodeF32ToF16(commandBuffer: cbC,
+                                       src: accChunk, srcOffset: hOff(i),
+                                       dst: h2Buf, count: D)
+                inkling.encodeSconvStepF32Out(commandBuffer: cbC,
+                                              x: h2Buf, state: conv.mlp,
+                                              weight: mlpSconvW.buffer,
+                                              weightOffset: Int(mlpSconvW.offset),
+                                              out: inklingDeltaF32!,
+                                              channels: D, kernelSize: sconvK)
+                inkling.encodeResidualAddF32Delta(commandBuffer: cbC,
+                                                  hidden: hiddenChunk,
+                                                  hiddenOffset: hOff(i),
+                                                  delta: inklingDeltaF32!,
+                                                  count: D,
+                                                  scale: Self.inklingFFNPrescale)
+            }
+            cbC.commit()
+            waitForCompletion(cbC)
+        }
+
+        if emitHead {
+            let fNorm = model.finalNorm
+            let lm = model.lmHead
+            let validVocab = UInt32(cfg.unpaddedVocabSize > 0
+                ? cfg.unpaddedVocabSize : cfg.vocabSize)
+            let muP = Float(1.0 / cfg.logitsWidthMultiplier)
+            runSync { cb in
+                inkling.encodeRMSF32(commandBuffer: cb,
+                                     x: hiddenChunk, xOffset: hOff(N - 1),
+                                     weight: fNorm.buffer,
+                                     weightOffset: Int(fNorm.offset),
+                                     out: self.normed, d: D, eps: eps)
+                self.int4.encode(commandBuffer: cb,
+                                 weights: lm.buffer, weightsOffset: Int(lm.offset),
+                                 scales:  lm.buffer, scalesOffset:  Int(lm.scaleOffset),
+                                 biases:  lm.buffer, biasesOffset:  Int(lm.biasOffset),
+                                 x: self.normed, y: logits,
+                                 m: validVocab, n: D)
+                inkling.encodeHeadEpilogue(commandBuffer: cb,
+                                           logits: logits,
+                                           scale: muP,
+                                           validVocab: validVocab,
+                                           totalVocab: UInt32(self.cfg.vocabSize))
+            }
+            if useFusedGreedyHead && outputMode == .greedyIfAvailable {
+                let lp = logits.contents()
+                    .bindMemory(to: Float16.self, capacity: Int(validVocab))
+                var best: (Int, Float) = (0, -.infinity)
+                for i in 0..<Int(validVocab) {
+                    let vl = Float(lp[i])
+                    if vl > best.1 { best = (i, vl) }
+                }
+                lastGreedyToken = UInt32(best.0)
+            }
+        }
+        kv.advance(by: N)
     }
 
     /// Gated-DeltaNet linear attention (layer mask 2), one decode step.

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -792,6 +792,15 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         kv?.reset()
         gdnState?.reset()
         dsv4State?.reset()
+        // Short-conv history dies with the KV cache, and ONLY with it:
+        // `prepareForContinuation` retains both, so a resumed conversation
+        // keeps the last K-1 conv inputs that match the cached prefix.
+        for state in inklingConvStates {
+            memset(state.k.contents(), 0, state.k.length)
+            memset(state.v.contents(), 0, state.v.length)
+            memset(state.attn.contents(), 0, state.attn.length)
+            memset(state.mlp.contents(), 0, state.mlp.length)
+        }
         resetTransientState()
     }
 
@@ -813,12 +822,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
 
     private func resetTransientState() {
         joinPendingSpeculation()
-        for state in inklingConvStates {
-            memset(state.k.contents(), 0, state.k.length)
-            memset(state.v.contents(), 0, state.v.length)
-            memset(state.attn.contents(), 0, state.attn.length)
-            memset(state.mlp.contents(), 0, state.mlp.length)
-        }
         previousTokenExperts = []
         prefillChunkState.reset()
         rdadviseSkipUntilPosition = -1

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -131,7 +131,17 @@ internal enum PrefillProjectionDispatchPolicy {
 }
 
 public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporting, ContinuableLogitProducer, @unchecked Sendable {
-    private struct LayerSharedExpertProjections {
+    /// Per-layer fp32 short-convolution states, one buffer per conv site.
+    /// k/v carry the last K-1 KV-stream inputs; attn/mlp the last K-1
+    /// sublayer outputs.
+    struct InklingLayerConvState {
+        let k: MTLBuffer
+        let v: MTLBuffer
+        let attn: MTLBuffer
+        let mlp: MTLBuffer
+    }
+
+    struct LayerSharedExpertProjections {
         let gate: SharedExpertInt8Proj
         let up: SharedExpertInt8Proj
         let down: SharedExpertInt8Proj
@@ -190,26 +200,26 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     private let prefillFinalRowHead: PrefillFinalRowHeadInt4
 
     // Scratch — preallocated per spec'd D / F / vocab.
-    private let hidden: MTLBuffer        // [D] FP16
-    private let normed: MTLBuffer        // [D] FP16
-    private let attnOut: MTLBuffer       // [N_HEADS * head_dim] FP16
-    private let qScratch: MTLBuffer      // [N_HEADS * head_dim] FP16
-    private let kStage: MTLBuffer        // [max KV heads * head_dim] FP16, current token
-    private let vStage: MTLBuffer        // [max KV heads * head_dim] FP16, current token
-    private let oOut: MTLBuffer          // [D] FP16
-    private let h1Buf: MTLBuffer         // [D] FP16 (dense MLP output)
-    private let h2Buf: MTLBuffer         // [D] FP16 (routed output)
-    private let routedX: MTLBuffer       // [D] FP16 (pre_feedforward_layernorm_2 output)
-    private let denseX: MTLBuffer        // [D] FP16 (pre_feedforward_layernorm output)
+    let hidden: MTLBuffer        // [D] FP16
+    let normed: MTLBuffer        // [D] FP16
+    let attnOut: MTLBuffer       // [N_HEADS * head_dim] FP16
+    let qScratch: MTLBuffer      // [N_HEADS * head_dim] FP16
+    let kStage: MTLBuffer        // [max KV heads * head_dim] FP16, current token
+    let vStage: MTLBuffer        // [max KV heads * head_dim] FP16, current token
+    let oOut: MTLBuffer          // [D] FP16
+    let h1Buf: MTLBuffer         // [D] FP16 (dense MLP output)
+    let h2Buf: MTLBuffer         // [D] FP16 (routed output)
+    let routedX: MTLBuffer       // [D] FP16 (pre_feedforward_layernorm_2 output)
+    let denseX: MTLBuffer        // [D] FP16 (pre_feedforward_layernorm output)
     private let denseScratchGate: MTLBuffer // [F=2112] FP16
     private let denseScratchUp: MTLBuffer   // [F=2112] FP16
     private let denseScratchAct: MTLBuffer  // [F=2112] FP16
     private let routerInput: MTLBuffer   // [D] FP16 (rmsnorm_no_scale(h))
     private let zeroResidual: MTLBuffer  // [D] FP16 zeros — for routed branch base
-    private let outIndices: MTLBuffer    // [topK] UInt32
-    private let outWeights: MTLBuffer    // [topK] FP16
+    let outIndices: MTLBuffer    // [topK] UInt32
+    let outWeights: MTLBuffer    // [topK] FP16
     // Persistent MoE scratch, allocated once; about 56 KiB at production shape.
-    private let moeActs: MTLBuffer       // [topK * FmoE] FP16
+    let moeActs: MTLBuffer       // [topK * FmoE] FP16
     private let moeHitActiveSlots: MTLBuffer // [topK] UInt32
     private let moeMissActiveSlots: MTLBuffer // [topK] UInt32
     private let greedyTokenBuf: MTLBuffer // 4 B UInt32 fused-head output
@@ -241,6 +251,25 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     private let dsv4IndexerW: MTLBuffer?         // [indexNHeads] FP16
     private let dsv4IndexerScores: MTLBuffer?    // [maxContext / csaRate] FP32
     private let dsv4Selected: MTLBuffer?         // [indexTopK] UInt32
+
+    // Inkling-Small kernels + scratch, keyed off the family so other
+    // architectures pay no PSO compile or allocation cost. Conv states are
+    // fp32 [C, K-1] per site (k/v on the KV streams, attn/mlp on the sublayer
+    // outputs); `inklingSharedProjections[L]` holds one projection set per
+    // shared expert (empty for the leading dense layers, which instead use
+    // `inklingDenseProjections[L]`).
+    let inkling: InklingKernels?
+    let inklingConvStates: [InklingLayerConvState]
+    let inklingRelScratch: MTLBuffer?        // [numHeads * dRel] FP16
+    /// FP32 residual stream: Inkling's hidden state overflows FP16 by layer
+    /// 23 (max channel 55k at L22, cap 65 504). Every consumer is an RMS
+    /// norm, so the stream converts to FP16 only at norm outputs.
+    let inklingHiddenF32: MTLBuffer?         // [D] FP32
+    let inklingDeltaF32: MTLBuffer?          // [D] FP32 sublayer delta
+    let inklingSharedY0: MTLBuffer?          // [D] FP16
+    let inklingSharedY1: MTLBuffer?          // [D] FP16
+    let inklingSharedProjections: [[LayerSharedExpertProjections]]
+    let inklingDenseProjections: [LayerSharedExpertProjections?]
     /// BF16 ones over [numExperts]; neutral per_expert_scale when the router
     /// has no auxiliary scale tensors.
     private let onesPerExpertScale: MTLBuffer?
@@ -393,7 +422,9 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         self.rms       = try RMSNorm(context: context)
         self.int4      = try DequantInt4GEMV(
             context: context,
-            additionalShapes: cfg.decodeInt4GEMVShapes)
+            // Inkling bring-up: the (4096, 4096) constant-folded variant is
+            // under investigation for NaN output; run generic until cleared.
+            additionalShapes: cfg.family == .inklingSmall ? [] : cfg.decodeInt4GEMVShapes)
         self.attention = try Attention(context: context)
         self.shared    = try SharedExpertRuntime(context: context,
                                                   weightBits: model.sharedExpertWeightBits,
@@ -475,18 +506,27 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         self.h2Buf         = try buf(D)
         self.routedX       = try buf(D)
         self.denseX        = try buf(D)
-        self.denseScratchGate = try buf(F)
-        self.denseScratchUp   = try buf(F)
-        self.denseScratchAct  = try buf(F)
+        // Inkling's two leading dense layers run through the shared-expert
+        // kernel at denseIntermediateSize (16 384), so the scratch must cover
+        // the wider of the two FFN widths.
+        let scratchF = max(F, cfg.denseIntermediateSize)
+        self.denseScratchGate = try buf(scratchF)
+        self.denseScratchUp   = try buf(scratchF)
+        self.denseScratchAct  = try buf(scratchF)
         self.routerInput   = try buf(D)
         self.zeroResidual  = try buf(D)
         // The routed MoE kernel seeds y[d] = residual[d]; pinning this buffer
         // to zero once at init makes the routed branch's residual contribution
         // exactly zero (it's combined with the dense MLP downstream).
         memset(self.zeroResidual.contents(), 0, self.zeroResidual.length)
-        self.outIndices    = try buf(cfg.topKExperts, MemoryLayout<UInt32>.size)
-        self.outWeights    = try buf(cfg.topKExperts)
-        self.moeActs       = try buf(cfg.topKExperts * cfg.moeIntermediateSize)
+        let paddedTopK = max(cfg.topKExperts, MoE.maxStreamedExperts)
+        self.outIndices    = try buf(paddedTopK, MemoryLayout<UInt32>.size)
+        self.outWeights    = try buf(paddedTopK)
+        self.moeActs       = try buf(paddedTopK * cfg.moeIntermediateSize)
+        // Families that route fewer than 8 experts (Inkling: 6) pad the
+        // streamed-expert list with duplicates carrying weight 0; zeroing the
+        // weight buffer once makes those pad slots permanent no-ops.
+        memset(self.outWeights.contents(), 0, self.outWeights.length)
         self.moeHitActiveSlots = try buf(cfg.topKExperts, MemoryLayout<UInt32>.size)
         self.moeMissActiveSlots = try buf(cfg.topKExperts, MemoryLayout<UInt32>.size)
         guard let tok = device.makeBuffer(length: MemoryLayout<UInt32>.size,
@@ -587,7 +627,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         }
         var sharedViews: [LayerSharedExpertProjections] = []
         sharedViews.reserveCapacity(cfg.numLayers)
-        for L in 0..<cfg.numLayers {
+        for L in 0..<(cfg.family == .inklingSmall ? 0 : cfg.numLayers) {
             let gate = try model.sharedExpertGate(layer: L)
             let up = try model.sharedExpertUp(layer: L)
             let down = try model.sharedExpertDown(layer: L)
@@ -600,6 +640,78 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                     ? try model.sharedExpertScalarGate(layer: L) : nil))
         }
         self.sharedExpertProjections = sharedViews
+
+        if cfg.family == .inklingSmall {
+            self.inkling = try InklingKernels(context: context,
+                                              numRouted: cfg.numExperts,
+                                              numShared: cfg.numSharedExperts)
+            let dRelWidth = cfg.relativePosition.projDim
+            self.inklingRelScratch = try buf(dRelWidth)
+            self.inklingHiddenF32 = try buf(D, MemoryLayout<Float>.size)
+            self.inklingDeltaF32 = try buf(D, MemoryLayout<Float>.size)
+            self.inklingSharedY0 = try buf(D)
+            self.inklingSharedY1 = try buf(D)
+            var convStates: [InklingLayerConvState] = []
+            convStates.reserveCapacity(cfg.numLayers)
+            let kvDim = cfg.numKVHeads * cfg.headDim
+            let km1 = cfg.sconvKernelSize - 1
+            for _ in 0..<cfg.numLayers {
+                convStates.append(InklingLayerConvState(
+                    k: try buf(kvDim * km1, MemoryLayout<Float>.size),
+                    v: try buf(kvDim * km1, MemoryLayout<Float>.size),
+                    attn: try buf(D * km1, MemoryLayout<Float>.size),
+                    mlp: try buf(D * km1, MemoryLayout<Float>.size)))
+            }
+            self.inklingConvStates = convStates
+            var sharedPerLayer: [[LayerSharedExpertProjections]] = []
+            var densePerLayer: [LayerSharedExpertProjections?] = []
+            for L in 0..<cfg.numLayers {
+                if L < cfg.numDenseLayers {
+                    sharedPerLayer.append([])
+                    let fd = cfg.denseIntermediateSize
+                    densePerLayer.append(LayerSharedExpertProjections(
+                        gate: sharedProj(try model.inklingDenseGate(layer: L),
+                                         rows: UInt32(fd), cols: UInt32(D)),
+                        up: sharedProj(try model.inklingDenseUp(layer: L),
+                                       rows: UInt32(fd), cols: UInt32(D)),
+                        down: sharedProj(try model.inklingDenseDown(layer: L),
+                                         rows: UInt32(D), cols: UInt32(fd)),
+                        postF1: nil, scalarGate: nil))
+                    continue
+                }
+                densePerLayer.append(nil)
+                var experts: [LayerSharedExpertProjections] = []
+                for e in 0..<cfg.numSharedExperts {
+                    experts.append(LayerSharedExpertProjections(
+                        gate: sharedProj(try model.inklingSharedExpert(
+                            "gate_proj", layer: L, expert: e,
+                            of: cfg.numSharedExperts),
+                            rows: UInt32(F), cols: UInt32(D)),
+                        up: sharedProj(try model.inklingSharedExpert(
+                            "up_proj", layer: L, expert: e,
+                            of: cfg.numSharedExperts),
+                            rows: UInt32(F), cols: UInt32(D)),
+                        down: sharedProj(try model.inklingSharedExpert(
+                            "down_proj", layer: L, expert: e,
+                            of: cfg.numSharedExperts),
+                            rows: UInt32(D), cols: UInt32(F)),
+                        postF1: nil, scalarGate: nil))
+                }
+                sharedPerLayer.append(experts)
+            }
+            self.inklingSharedProjections = sharedPerLayer
+            self.inklingDenseProjections = densePerLayer
+        } else {
+            self.inkling = nil
+            self.inklingConvStates = []
+            self.inklingRelScratch = nil
+            self.inklingHiddenF32 = nil
+            self.inklingDeltaF32 = nil
+            self.inklingSharedY0 = nil
+            self.inklingSharedY1 = nil
+            self.inklingSharedProjections = []
+            self.inklingDenseProjections = []
+        }
 
         func bf16OnesBuffer(count: Int, label: String) throws -> MTLBuffer {
             guard let buf = device.makeBuffer(length: count * MemoryLayout<UInt16>.size,
@@ -678,6 +790,12 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
 
     private func resetTransientState() {
         joinPendingSpeculation()
+        for state in inklingConvStates {
+            memset(state.k.contents(), 0, state.k.length)
+            memset(state.v.contents(), 0, state.v.length)
+            memset(state.attn.contents(), 0, state.attn.length)
+            memset(state.mlp.contents(), 0, state.mlp.length)
+        }
         previousTokenExperts = []
         prefillChunkState.reset()
         rdadviseSkipUntilPosition = -1
@@ -1033,6 +1151,31 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         }
         guard !tokens.isEmpty else {
             return PrefillResult(newPosition: startPosition, seed: .logitsWritten)
+        }
+
+        if cfg.family == .inklingSmall {
+            // Inkling prefill v1 replays the decode path token by token — the
+            // same correctness-reference structure DSV4 prefill v1 used. The
+            // short-conv states make out-of-order replay meaningless anyway:
+            // every token's conv output depends on the previous three.
+            var pos = startPosition
+            var index = 0
+            for t in tokens {
+                let isLast = index == tokens.count - 1
+                try await produceTokenInkling(token: t, position: pos,
+                                              into: logits,
+                                              emitHead: isLast,
+                                              outputMode: outputMode)
+                pos += 1
+                index += 1
+                if index % 16 == 0 { onProgress(index) }
+            }
+            onProgress(tokens.count)
+            if outputMode == .greedyIfAvailable, useFusedGreedyHead {
+                return PrefillResult(newPosition: pos,
+                                     seed: .greedyToken(lastGreedyToken))
+            }
+            return PrefillResult(newPosition: pos, seed: .logitsWritten)
         }
 
         if cfg.hasCompressedAttentionLayers {
@@ -2132,6 +2275,12 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                        outputMode: outputMode)
             return
         }
+        if cfg.family == .inklingSmall {
+            try await produceTokenInkling(token: token, position: position,
+                                          into: logits, emitHead: emitHead,
+                                          outputMode: outputMode)
+            return
+        }
         let D    = UInt32(cfg.hiddenSize)
         let FmoE = UInt32(cfg.moeIntermediateSize)
         let eps: Float = 1e-6
@@ -2695,6 +2844,565 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         }
 
         kv?.advance()
+    }
+
+    /// Env-gated numeric probe for the Inkling bring-up: prints value stats
+    /// of a buffer after forcing the queue to drain. Debug only — the extra
+    /// waits serialize the pipeline.
+    private static let inklingDebugEnabled =
+        ProcessInfo.processInfo.environment["MFERENCE_INKLING_DEBUG"] == "1"
+    private func inklingDebugStats(_ label: String, _ buf: MTLBuffer,
+                                   count: Int, fp32: Bool = false) {
+        guard Self.inklingDebugEnabled else { return }
+        let cb = ctx.queue.makeCommandBuffer()!
+        cb.commit()
+        cb.waitUntilCompleted()
+        var mn = Float.greatestFiniteMagnitude
+        var mx = -Float.greatestFiniteMagnitude
+        var sum: Double = 0
+        var bad = 0
+        if fp32 {
+            let p = buf.contents().bindMemory(to: Float.self, capacity: count)
+            for i in 0..<count {
+                let v = p[i]
+                if !v.isFinite { bad += 1; continue }
+                mn = min(mn, v); mx = max(mx, v); sum += Double(v)
+            }
+        } else {
+            let p = buf.contents().bindMemory(to: Float16.self, capacity: count)
+            for i in 0..<count {
+                let v = Float(p[i])
+                if !v.isFinite { bad += 1; continue }
+                mn = min(mn, v); mx = max(mx, v); sum += Double(v)
+            }
+        }
+        let mean = sum / Double(max(count - bad, 1))
+        print("[inkling] \(label) n=\(count) "
+              + String(format: "min=%.4f max=%.4f mean=%.5f", mn, mx, mean)
+              + " nonfinite=\(bad)")
+    }
+
+    /// FFN output pre-scale for the Inkling MoE path: router weights and
+    /// shared-expert gammas are divided by this before the FP16 expert
+    /// pipeline, and the residual add multiplies it back (linear, exact).
+    /// Keeps BF16-magnitude outlier channels (observed > 65k at layer 41)
+    /// inside half range through h1/h2 and the phase-2 reduce.
+    static let inklingFFNPrescale: Float = 32.0
+
+    /// Parity-test helper: advance the KV cursor after a stop-layer run so a
+    /// following produce() at the next position lands in the right slot.
+    func inklingParityAdvanceKV() { kv?.advance() }
+    func inklingParityKSlot(layer: Int, position: Int) -> (buffer: MTLBuffer, offset: Int) {
+        kv!.kSlot(layer: layer, position: position)
+    }
+    func inklingParityVSlot(layer: Int, position: Int) -> (buffer: MTLBuffer, offset: Int) {
+        kv!.vSlot(layer: layer, position: position)
+    }
+
+    /// Debug-only early exit: stop after this layer completes, leaving the
+    /// scratch buffers inspectable (CPU parity tests). -1 = disabled.
+    static let inklingStopLayer: Int =
+        ProcessInfo.processInfo.environment["MFERENCE_INKLING_STOP_LAYER"]
+            .flatMap(Int.init) ?? -1
+    /// Restricts the stop layer to one position so multi-token composition
+    /// tests can run earlier tokens through all 42 layers. -1 = any position.
+    static let inklingStopPosition: Int =
+        ProcessInfo.processInfo.environment["MFERENCE_INKLING_STOP_POSITION"]
+            .flatMap(Int.init) ?? -1
+    /// Forces a full GPU drain after every layer (disables the routed-CB
+    /// pipelining). Debug aid to discriminate ordering hazards.
+    static let inklingSyncMode: Bool =
+        ProcessInfo.processInfo.environment["MFERENCE_INKLING_SYNC"] == "1"
+    /// When set (with MFERENCE_INKLING_DEBUG=1), per-layer FP32 hidden rows
+    /// are dumped as raw f32 files for cross-checking against the reference.
+    static let inklingDumpDir: String? =
+        ProcessInfo.processInfo.environment["MFERENCE_INKLING_DUMP_DIR"]
+
+    /// Inkling-Small decode step. Semantics per docs/INKLING_SMALL.md
+    /// "Forward-pass contract": no RoPE (learned relative-position bias),
+    /// depthwise short convs on K/V and on both sublayer outputs (inside the
+    /// residual), sigmoid router with 2 shared-expert sinks, 2 leading dense
+    /// layers, muP logit scaling, and vocab truncation to the unpadded size.
+    private func produceTokenInkling(token: Int32,
+                                     position: Int,
+                                     into logits: MTLBuffer,
+                                     emitHead: Bool,
+                                     outputMode: PrefillOutputMode) async throws {
+        guard let inkling, let relScratch = inklingRelScratch,
+              let hiddenF32 = inklingHiddenF32,
+              let deltaF32 = inklingDeltaF32,
+              let sharedY0 = inklingSharedY0, let sharedY1 = inklingSharedY1,
+              let kv else {
+            preconditionFailure("Inkling runtime state missing")
+        }
+        let D = UInt32(cfg.hiddenSize)
+        let FmoE = UInt32(cfg.moeIntermediateSize)
+        let eps: Float = Float(1e-6)
+        let qDim = UInt32(cfg.numHeads * cfg.headDim)
+        let kvDim = UInt32(cfg.numKVHeads * cfg.headDim)
+        let seqLen = UInt32(position + 1)
+        let sconvK = UInt32(cfg.sconvKernelSize)
+        let paddedK = MoE.maxStreamedExperts
+        let rel = cfg.relativePosition
+
+        struct PendingInkling {
+            let cb: MTLCommandBuffer
+            let attentionCB: MTLCommandBuffer
+        }
+        var pending: PendingInkling?
+        func finishPending(_ p: PendingInkling, waitIfNeeded: Bool) {
+            if waitIfNeeded {
+                waitForCompletion(p.attentionCB)
+                waitForCompletion(p.cb)
+            } else {
+                if let err = p.cb.error { print("CB error: \(err)") }
+                if let err = p.attentionCB.error { print("CB error: \(err)") }
+            }
+        }
+
+        // Embed lookup, then the family's embed norm (in place).
+        let emb = model.embedding
+        let embedNorm = model.embedNorm
+        runSync { cb in
+            embedInt4.encode(commandBuffer: cb,
+                             table:  emb.buffer, tableOffset:  Int(emb.offset),
+                             scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
+                             biases: emb.buffer, biasesOffset: Int(emb.biasOffset),
+                             out: hidden,
+                             tokenId: UInt32(bitPattern: token),
+                             d: D,
+                             outScale: 1.0)
+            // The embed norm is part of the stream seed itself
+            // (`embed_tokens = embed_norm(embed(ids))`), then the stream
+            // widens to FP32 for the residual accumulation.
+            rms.encodeBF16W(commandBuffer: cb, x: hidden,
+                            weight: embedNorm.buffer,
+                            weightOffset: Int(embedNorm.offset),
+                            out: hidden, d: D, eps: eps)
+            inkling.encodeF16ToF32(commandBuffer: cb, src: hidden,
+                                   dst: hiddenF32, count: D)
+        }
+        inklingDebugStats("embed f32", hiddenF32, count: cfg.hiddenSize, fp32: true)
+
+        for L in 0..<cfg.numLayers {
+            let isFull = cfg.fullAttentionLayerMask[L] == 1
+            let isDense = L < cfg.numDenseLayers
+            let conv = inklingConvStates[L]
+
+            let inNorm = try model.inputNorm(layer: L)
+            let mlpNorm = try model.postAttnNorm(layer: L)
+            let q = try model.inklingWqDu(layer: L)
+            let k = try model.inklingWkDv(layer: L)
+            let v = try model.inklingWvDv(layer: L)
+            let o = try model.inklingWoUd(layer: L)
+            let wr = try model.inklingWrDu(layer: L)
+            let relProj = try model.inklingRelProj(layer: L)
+            let qNorm = try model.inklingQNorm(layer: L)
+            let kNorm = try model.inklingKNorm(layer: L)
+            let kSconvW = try model.inklingKSconv(layer: L)
+            let vSconvW = try model.inklingVSconv(layer: L)
+            let attnSconvW = try model.inklingAttnSconv(layer: L)
+            let mlpSconvW = try model.inklingMlpSconv(layer: L)
+
+            let kSlot = kv.kSlot(layer: L, position: position)
+            let vSlot = kv.vSlot(layer: L, position: position)
+
+            var cb = ctx.queue.makeCommandBuffer()!
+            // Debug-only pipeline cut: drain, probe, continue in a fresh CB.
+            func dbgCut(_ probes: [(String, MTLBuffer, Int)]) {
+                guard Self.inklingDebugEnabled, L == 2 else { return }
+                cb.commit()
+                waitForCompletion(cb)
+                for (label, buffer, count) in probes {
+                    inklingDebugStats("L\(L)* \(label)", buffer, count: count)
+                }
+                cb = ctx.queue.makeCommandBuffer()!
+            }
+            inkling.encodeRMSF32(commandBuffer: cb, x: hiddenF32,
+                                 weight: inNorm.buffer,
+                                 weightOffset: Int(inNorm.offset),
+                                 out: normed, d: D, eps: eps)
+
+            // Q/K/V projections into scratch; K and V then pass through their
+            // short convolutions on the way into the KV slot (the cache stores
+            // the convolved, K-normed values, exactly like the reference's
+            // post-norm cache). Three plain GEMVs rather than the fused QKV
+            // kernel: this family's (4096, 1024, 4096) shape lands on the
+            // fused kernel's generic fallback, which produced NaN Q on
+            // hardware (K/V sections fine) — debugged 2026-08-03, see
+            // docs/INKLING_SMALL.md. Refuse the fusion until that kernel's
+            // generic path is fixed and parity-tested at this shape.
+            int4.encode(commandBuffer: cb,
+                        weights: q.buffer, weightsOffset: Int(q.offset),
+                        scales:  q.buffer, scalesOffset:  Int(q.scaleOffset),
+                        biases:  q.buffer, biasesOffset:  Int(q.biasOffset),
+                        x: normed, y: qScratch, m: qDim, n: D)
+            int4.encode(commandBuffer: cb,
+                        weights: k.buffer, weightsOffset: Int(k.offset),
+                        scales:  k.buffer, scalesOffset:  Int(k.scaleOffset),
+                        biases:  k.buffer, biasesOffset:  Int(k.biasOffset),
+                        x: normed, y: kStage, m: kvDim, n: D)
+            int4.encode(commandBuffer: cb,
+                        weights: v.buffer, weightsOffset: Int(v.offset),
+                        scales:  v.buffer, scalesOffset:  Int(v.scaleOffset),
+                        biases:  v.buffer, biasesOffset:  Int(v.biasOffset),
+                        x: normed, y: vStage, m: kvDim, n: D)
+            dbgCut([("post-qkv qScratch", qScratch, Int(qDim)),
+                    ("post-qkv kStage", kStage, Int(kvDim)),
+                    ("post-qkv vStage", vStage, Int(kvDim))])
+            int4.encode(commandBuffer: cb,
+                        weights: wr.buffer, weightsOffset: Int(wr.offset),
+                        scales:  wr.buffer, scalesOffset:  Int(wr.scaleOffset),
+                        biases:  wr.buffer, biasesOffset:  Int(wr.biasOffset),
+                        x: normed, y: relScratch,
+                        m: UInt32(rel.projDim), n: D)
+            inkling.encodeSconvStep(commandBuffer: cb,
+                                    x: kStage, state: conv.k,
+                                    weight: kSconvW.buffer,
+                                    weightOffset: Int(kSconvW.offset),
+                                    out: kSlot.buffer, outOffset: kSlot.offset,
+                                    channels: kvDim, kernelSize: sconvK)
+            inkling.encodeSconvStep(commandBuffer: cb,
+                                    x: vStage, state: conv.v,
+                                    weight: vSconvW.buffer,
+                                    weightOffset: Int(vSconvW.offset),
+                                    out: vSlot.buffer, outOffset: vSlot.offset,
+                                    channels: kvDim, kernelSize: sconvK)
+            dbgCut([("post-sconv kSlot", kSlot.buffer, Int(kvDim)),
+                    ("post-sconv rel", relScratch, rel.projDim)])
+            inkling.encodeQKNorm(commandBuffer: cb,
+                                 q: qScratch,
+                                 k: kSlot.buffer, kOffset: kSlot.offset,
+                                 qWeight: qNorm.buffer, qWeightOffset: Int(qNorm.offset),
+                                 kWeight: kNorm.buffer, kWeightOffset: Int(kNorm.offset),
+                                 headDim: UInt32(cfg.headDim),
+                                 numQHeads: UInt32(cfg.numHeads),
+                                 numKVHeads: UInt32(cfg.numKVHeads),
+                                 eps: eps)
+            dbgCut([("post-norm qScratch", qScratch, Int(qDim)),
+                    ("post-norm kSlot", kSlot.buffer, Int(kvDim))])
+
+            let window = UInt32(cfg.slidingWindow)
+            let kvStart: UInt32 = isFull ? 0 : (seqLen > window ? seqLen - window : 0)
+            let ringCapacity = kv.ringCapacity(layer: L)
+            let activeRing: UInt32 = (!isFull && ringCapacity > 0 && Int(seqLen) > ringCapacity)
+                ? UInt32(ringCapacity) : 0
+            let relExtent = UInt32(isFull ? rel.extent : cfg.slidingWindow)
+            var tau: Float = 1.0
+            if isFull && rel.logScalingFloor > 0 {
+                let n = Float(position + 1)
+                let floorN = Float(rel.logScalingFloor)
+                if n > floorN {
+                    tau = 1.0 + Float(rel.logScalingAlpha) * log(n / floorN)
+                }
+            }
+            inkling.encodeAttentionDecode(commandBuffer: cb,
+                                          q: qScratch,
+                                          k: kSlot.buffer,
+                                          v: vSlot.buffer,
+                                          rel: relScratch,
+                                          proj: relProj.buffer,
+                                          projOffset: Int(relProj.offset),
+                                          out: attnOut,
+                                          headDim: UInt32(cfg.headDim),
+                                          numQHeads: UInt32(cfg.numHeads),
+                                          numKVHeads: UInt32(cfg.numKVHeads),
+                                          seqLen: seqLen, kvStart: kvStart,
+                                          relExtent: relExtent,
+                                          dRel: UInt32(rel.dRel),
+                                          ringCapacity: activeRing,
+                                          scale: Float(cfg.attentionScale),
+                                          tau: tau)
+            int4.encode(commandBuffer: cb,
+                        weights: o.buffer, weightsOffset: Int(o.offset),
+                        scales:  o.buffer, scalesOffset:  Int(o.scaleOffset),
+                        biases:  o.buffer, biasesOffset:  Int(o.biasOffset),
+                        x: attnOut, y: oOut, m: D, n: qDim)
+            // attn_sconv sits on the attention OUTPUT, inside the residual.
+            // FP32 out: deltas exceed FP16 range deep in the stack.
+            inkling.encodeSconvStepF32Out(commandBuffer: cb,
+                                          x: oOut, state: conv.attn,
+                                          weight: attnSconvW.buffer,
+                                          weightOffset: Int(attnSconvW.offset),
+                                          out: deltaF32,
+                                          channels: D, kernelSize: sconvK)
+            inkling.encodeResidualAddF32Delta(commandBuffer: cb,
+                                              hidden: hiddenF32, delta: deltaF32,
+                                              count: D)
+            inkling.encodeRMSF32(commandBuffer: cb, x: hiddenF32,
+                                 weight: mlpNorm.buffer,
+                                 weightOffset: Int(mlpNorm.offset),
+                                 out: routedX, d: D, eps: eps)
+
+            if isDense {
+                // Dense SwiGLU with a learned scalar output gain, then the
+                // mlp short conv, then the residual.
+                let proj = inklingDenseProjections[L]!
+                let gain = model.inklingScalar(
+                    try model.inklingDenseGlobalScale(layer: L))
+                try! shared.encode(commandBuffer: cb,
+                                   x: routedX,
+                                   gate: proj.gate, up: proj.up, down: proj.down,
+                                   y: h2Buf,
+                                   scratchGate: denseScratchGate,
+                                   scratchUp: denseScratchUp,
+                                   scratchAct: denseScratchAct)
+                inkling.encodeScale(commandBuffer: cb, x: h2Buf,
+                                    by: gain, count: D)
+                inkling.encodeSconvStepF32Out(commandBuffer: cb,
+                                              x: h2Buf, state: conv.mlp,
+                                              weight: mlpSconvW.buffer,
+                                              weightOffset: Int(mlpSconvW.offset),
+                                              out: deltaF32,
+                                              channels: D, kernelSize: sconvK)
+                inkling.encodeResidualAddF32Delta(commandBuffer: cb,
+                                                  hidden: hiddenF32, delta: deltaF32,
+                                                  count: D)
+                cb.commit()
+                if let p = pending { finishPending(p, waitIfNeeded: false); pending = nil }
+                waitForCompletion(cb)
+                inklingDebugStats("L\(L) dense out", hiddenF32, count: cfg.hiddenSize, fp32: true)
+                if let dir = Self.inklingDumpDir, Self.inklingDebugEnabled {
+                    let data = Data(bytes: hiddenF32.contents(),
+                                    count: cfg.hiddenSize * 4)
+                    try? data.write(to: URL(fileURLWithPath:
+                        "\(dir)/pos\(position)_L\(L).f32"))
+                }
+                if L == Self.inklingStopLayer,
+                   Self.inklingStopPosition < 0 || Self.inklingStopPosition == position {
+                    return
+                }
+                continue
+            }
+
+            // MoE layer: sigmoid router (+ signal for the CPU expert fetch),
+            // then both shared experts weighted by their sink gammas while the
+            // routed blobs stream in.
+            let routerW = try model.router(layer: L)
+            let gateBias = try model.inklingGateBias(layer: L)
+            let gateScale = try model.inklingGateGlobalScale(layer: L)
+            inkling.encodeRouter(commandBuffer: cb,
+                                 weights: routerW.buffer,
+                                 weightsOffset: Int(routerW.offset),
+                                 hidden: routedX,
+                                 onesScale: effectiveScaleBuffers[L],
+                                 gateBias: gateBias.buffer,
+                                 gateBiasOffset: Int(gateBias.offset),
+                                 globalScale: gateScale.buffer,
+                                 globalScaleOffset: Int(gateScale.offset),
+                                 outIndices: outIndices,
+                                 outWeights: outWeights,
+                                 numRouted: UInt32(cfg.numExperts),
+                                 numShared: UInt32(cfg.numSharedExperts),
+                                 topK: UInt32(cfg.topKExperts),
+                                 routeScale: Float(cfg.routedScalingFactor)
+                                     / Self.inklingFFNPrescale,
+                                 d: D)
+            let routerSignal = encodeRouterSignal(cb)
+            let sharedProjs = inklingSharedProjections[L]
+            try! shared.encode(commandBuffer: cb,
+                               x: routedX,
+                               gate: sharedProjs[0].gate,
+                               up: sharedProjs[0].up,
+                               down: sharedProjs[0].down,
+                               y: sharedY0,
+                               scratchGate: denseScratchGate,
+                               scratchUp: denseScratchUp,
+                               scratchAct: denseScratchAct)
+            try! shared.encode(commandBuffer: cb,
+                               x: routedX,
+                               gate: sharedProjs[1].gate,
+                               up: sharedProjs[1].up,
+                               down: sharedProjs[1].down,
+                               y: sharedY1,
+                               scratchGate: denseScratchGate,
+                               scratchUp: denseScratchUp,
+                               scratchAct: denseScratchAct)
+            inkling.encodeGammaCombine(commandBuffer: cb,
+                                       a: sharedY0, b: sharedY1,
+                                       y: h1Buf, count: D)
+            cb.commit()
+            waitForRouterSignal(routerSignal, fallback: cb)
+            if let p = pending { finishPending(p, waitIfNeeded: false); pending = nil }
+
+            // CPU readback of the 6 routed experts; the streamed list pads to
+            // the MoE contract's 8 slots with duplicates whose weight slots
+            // were pinned to zero at init.
+            let idxPtr = outIndices.contents().bindMemory(to: UInt32.self,
+                                                          capacity: cfg.topKExperts)
+            var experts = [Int](repeating: 0, count: cfg.topKExperts)
+            for i in 0..<cfg.topKExperts {
+                experts[i] = min(Int(idxPtr[i]), cfg.numExperts - 1)
+            }
+            let tIoStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+            let blobs = try await model.fetchRoutedExperts(layer: L, experts: experts)
+            totalIoNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tIoStart
+            var routedBufs = blobs.map { $0.buffer }
+            while routedBufs.count < paddedK { routedBufs.append(routedBufs[0]) }
+
+            let routedOffsets = model.routedExpertOffsets(layer: L)
+            let routedCB = ctx.queue.makeCommandBuffer()!
+            let argBuf = moe.makeReusedRoutedArgumentBuffer(
+                routedBlobs: routedBufs, topK: UInt32(paddedK))
+            moe.encodeRoutedPersistentPhase1U16Load(commandBuffer: routedCB,
+                                                    routedArgBuffer: argBuf,
+                                                    routedBlobs: routedBufs,
+                                                    routedOffsets: routedOffsets,
+                                                    x: routedX,
+                                                    acts: moeActs,
+                                                    d: D, f: FmoE,
+                                                    topK: UInt32(paddedK))
+            // Phase 2 seeds y with the shared-expert branch, so the sum is
+            // routed + shared exactly as the reference computes it.
+            moe.encodeRoutedPersistentPhase2Reduce(commandBuffer: routedCB,
+                                                   routedArgBuffer: argBuf,
+                                                   routedBlobs: routedBufs,
+                                                   routedOffsets: routedOffsets,
+                                                   acts: moeActs,
+                                                   routingWeights: outWeights,
+                                                   residual: h1Buf,
+                                                   y: h2Buf,
+                                                   d: D, f: FmoE,
+                                                   topK: UInt32(paddedK))
+            inkling.encodeSconvStepF32Out(commandBuffer: routedCB,
+                                          x: h2Buf, state: conv.mlp,
+                                          weight: mlpSconvW.buffer,
+                                          weightOffset: Int(mlpSconvW.offset),
+                                          out: deltaF32,
+                                          channels: D, kernelSize: sconvK)
+            inkling.encodeResidualAddF32Delta(commandBuffer: routedCB,
+                                              hidden: hiddenF32, delta: deltaF32,
+                                              count: D,
+                                              scale: Self.inklingFFNPrescale)
+            routedCB.commit()
+            if Self.inklingDebugEnabled {
+                waitForCompletion(routedCB)
+                if !(L <= 6 || L == 41) {
+                    inklingDebugStats("L\(L) hidden", hiddenF32, count: cfg.hiddenSize, fp32: true)
+                }
+                if let dir = Self.inklingDumpDir {
+                    let data = Data(bytes: hiddenF32.contents(),
+                                    count: cfg.hiddenSize * 4)
+                    try? data.write(to: URL(fileURLWithPath:
+                        "\(dir)/pos\(position)_L\(L).f32"))
+                }
+            }
+            if Self.inklingDebugEnabled, (18...21).contains(L) {
+                inklingDebugStats("L\(L) normed", normed, count: cfg.hiddenSize)
+                inklingDebugStats("L\(L) oOut", oOut, count: cfg.hiddenSize)
+                inklingDebugStats("L\(L) attn delta", deltaF32, count: cfg.hiddenSize, fp32: true)
+                inklingDebugStats("L\(L) routedX", routedX, count: cfg.hiddenSize)
+            }
+            if Self.inklingDebugEnabled, L <= 6 || L == 41 {
+                inklingDebugStats("L\(L) normed", normed, count: cfg.hiddenSize)
+                inklingDebugStats("L\(L) qScratch", qScratch, count: Int(qDim))
+                inklingDebugStats("L\(L) kStage", kStage, count: Int(kvDim))
+                inklingDebugStats("L\(L) kSlot", kSlot.buffer, count: Int(kvDim))
+                inklingDebugStats("L\(L) relScratch", relScratch, count: rel.projDim)
+                inklingDebugStats("L\(L) moeActs", moeActs, count: 8 * Int(FmoE))
+                inklingDebugStats("L\(L) attnOut", attnOut, count: Int(qDim))
+                inklingDebugStats("L\(L) oOut", oOut, count: cfg.hiddenSize)
+                inklingDebugStats("L\(L) sharedY", h1Buf, count: cfg.hiddenSize)
+                inklingDebugStats("L\(L) moe h2", h2Buf, count: cfg.hiddenSize)
+                inklingDebugStats("L\(L) hidden", hiddenF32, count: cfg.hiddenSize, fp32: true)
+                let g = inkling.sharedGammas.contents()
+                    .bindMemory(to: Float.self, capacity: 2)
+                let w = outWeights.contents()
+                    .bindMemory(to: Float16.self, capacity: 8)
+                let idx = outIndices.contents()
+                    .bindMemory(to: UInt32.self, capacity: 6)
+                print("[inkling] L\(L) gammas=(\(g[0]), \(g[1])) " +
+                      "w=\((0..<8).map { Float(w[$0]) }) " +
+                      "idx=\((0..<6).map { idx[$0] })")
+            }
+            pending = PendingInkling(cb: routedCB, attentionCB: cb)
+            if Self.inklingSyncMode {
+                finishPending(pending!, waitIfNeeded: true)
+                pending = nil
+            }
+            if L == Self.inklingStopLayer,
+               Self.inklingStopPosition < 0 || Self.inklingStopPosition == position {
+                finishPending(pending!, waitIfNeeded: true)
+                return
+            }
+        }
+        if let p = pending { finishPending(p, waitIfNeeded: true); pending = nil }
+
+        if emitHead {
+            let fNorm = model.finalNorm
+            let lm = model.lmHead
+            let validVocab = UInt32(cfg.unpaddedVocabSize > 0
+                ? cfg.unpaddedVocabSize : cfg.vocabSize)
+            let muP = Float(1.0 / cfg.logitsWidthMultiplier)
+            if useFusedGreedyHead && outputMode == .greedyIfAvailable {
+                // Greedy argmax is invariant to the positive muP scale, so
+                // only the vocab truncation matters. The final norm runs from
+                // the FP32 stream first; the fused chain then consumes the
+                // pre-normed row via unit gains (fNorm already applied).
+                runSync { cb in
+                    inkling.encodeRMSF32(commandBuffer: cb, x: hiddenF32,
+                                         weight: fNorm.buffer,
+                                         weightOffset: Int(fNorm.offset),
+                                         out: self.normed, d: D, eps: eps)
+                    self.int4.encode(commandBuffer: cb,
+                                     weights: lm.buffer, weightsOffset: Int(lm.offset),
+                                     scales:  lm.buffer, scalesOffset:  Int(lm.scaleOffset),
+                                     biases:  lm.buffer, biasesOffset:  Int(lm.biasOffset),
+                                     x: self.normed, y: logits,
+                                     m: validVocab, n: D)
+                    inkling.encodeHeadEpilogue(commandBuffer: cb,
+                                               logits: logits,
+                                               scale: muP,
+                                               validVocab: validVocab,
+                                               totalVocab: UInt32(self.cfg.vocabSize))
+                }
+                // Argmax on CPU over the truncated logits (bring-up path;
+                // the fused-head chain is FP16-hidden and not yet FP32-aware).
+                let lp = logits.contents()
+                    .bindMemory(to: Float16.self, capacity: Int(validVocab))
+                var best: (Int, Float) = (0, -.infinity)
+                for i in 0..<Int(validVocab) {
+                    let v = Float(lp[i])
+                    if v > best.1 { best = (i, v) }
+                }
+                lastGreedyToken = UInt32(best.0)
+            } else {
+                runSync { cb in
+                    inkling.encodeRMSF32(commandBuffer: cb, x: hiddenF32,
+                                         weight: fNorm.buffer,
+                                         weightOffset: Int(fNorm.offset),
+                                         out: self.normed, d: D, eps: eps)
+                    self.int4.encode(commandBuffer: cb,
+                                     weights: lm.buffer, weightsOffset: Int(lm.offset),
+                                     scales:  lm.buffer, scalesOffset:  Int(lm.scaleOffset),
+                                     biases:  lm.buffer, biasesOffset:  Int(lm.biasOffset),
+                                     x: self.normed, y: logits,
+                                     m: validVocab, n: D)
+                    inkling.encodeHeadEpilogue(commandBuffer: cb,
+                                               logits: logits,
+                                               scale: muP,
+                                               validVocab: validVocab,
+                                               totalVocab: UInt32(self.cfg.vocabSize))
+                }
+                if Self.inklingDebugEnabled {
+                    inklingDebugStats("head normed", normed, count: cfg.hiddenSize)
+                    let lp = logits.contents()
+                        .bindMemory(to: Float16.self, capacity: Int(validVocab))
+                    var top: [(Int, Float)] = []
+                    for i in 0..<Int(validVocab) {
+                        let v = Float(lp[i])
+                        if top.count < 8 {
+                            top.append((i, v)); top.sort { $0.1 > $1.1 }
+                        } else if v > top[7].1 {
+                            top[7] = (i, v); top.sort { $0.1 > $1.1 }
+                        }
+                    }
+                    print("[inkling] head top8 = \(top)")
+                }
+            }
+        }
+
+        kv.advance()
     }
 
     /// Gated-DeltaNet linear attention (layer mask 2), one decode step.

--- a/Sources/Mference/Tokenization/Tokenizer.swift
+++ b/Sources/Mference/Tokenization/Tokenizer.swift
@@ -28,6 +28,7 @@ public enum ChatDialect: String, Sendable {
     case gemma
     case chatml
     case deepseek
+    case inkling
 }
 
 /// Tokenizer wrapper for the supported model families (Gemma 4, ChatML/Qwen,
@@ -126,7 +127,9 @@ public struct MFTokenizer: @unchecked Sendable {
         self.tokenizer = tokenizer
 
         let dialect: ChatDialect =
-            if Self.specialTokenID(tokenizer, Self.deepseekUserMark) != nil {
+            if Self.specialTokenID(tokenizer, Self.inklingUserMark) != nil {
+                .inkling
+            } else if Self.specialTokenID(tokenizer, Self.deepseekUserMark) != nil {
                 .deepseek
             } else if Self.specialTokenID(tokenizer, Self.imEndMark) != nil {
                 .chatml
@@ -137,6 +140,7 @@ public struct MFTokenizer: @unchecked Sendable {
         case .gemma: try Self.resolveGemmaTokens(tokenizer)
         case .chatml: try Self.resolveChatMLTokens(tokenizer)
         case .deepseek: try Self.resolveDeepseekTokens(tokenizer)
+        case .inkling: try Self.resolveInklingTokens(tokenizer)
         }
 
         self.dialect = dialect
@@ -409,12 +413,105 @@ public struct MFTokenizer: @unchecked Sendable {
     /// from the user branch AND one from the assistant branch).
     private static let deepseekThinkCloseMark = "</think>"
 
+    // Inkling message framing (see the checkpoint's chat_template.jinja):
+    // each turn is `<role token><|content_text|>CONTENT<|end_message|>`, an
+    // assistant turn additionally closes with `<|content_model_end_sampling|>`
+    // (the sampling stop), a thinking-effort system line precedes the first
+    // non-system message, and the generation prompt is a bare
+    // `<|message_model|>`. No BOS anywhere (the reference encodes prompts
+    // with add_special_tokens=False).
+    private static let inklingUserMark    = "<|message_user|>"
+    private static let inklingModelMark   = "<|message_model|>"
+    private static let inklingSystemMark  = "<|message_system|>"
+    private static let inklingContentText = "<|content_text|>"
+    private static let inklingEndMessage  = "<|end_message|>"
+    private static let inklingEndSampling = "<|content_model_end_sampling|>"
+    /// v1 pins reasoning effort to 0 ("none"): the decode path has no
+    /// thinking-block post-processing for this dialect yet, and 0 is a
+    /// first-class template value.
+    private static let inklingEffortLine =
+        inklingSystemMark + inklingContentText
+        + "Thinking effort level: 0" + inklingEndMessage
+
+    private static func resolveInklingTokens(
+        _ tokenizer: any Tokenizer
+    ) throws -> ResolvedSpecialTokens {
+        func id(_ token: String) throws -> Int32 {
+            guard let value = specialTokenID(tokenizer, token) else {
+                throw MFTokenizerError.missingSpecialToken(token)
+            }
+            return Int32(value)
+        }
+        let bos = try id("<|begin_of_text|>")
+        let eos = try id(Self.inklingEndSampling)
+        let thinkStart = try id("<|content_thinking|>")
+        let endMessage = try id(Self.inklingEndMessage)
+        _ = try id(Self.inklingUserMark)
+        _ = try id(Self.inklingModelMark)
+        return ResolvedSpecialTokens(
+            bosID: bos,
+            // The reference never prepends BOS; encode() stays bare.
+            bosPrefixID: nil,
+            eosID: eos,
+            padID: eos,
+            endOfTurnID: eos,
+            toolCallStartID: noSuchTokenID,
+            toolCallEndID: noSuchTokenID,
+            toolResponseID: noSuchTokenID,
+            toolResponseEndID: noSuchTokenID,
+            channelStartID: thinkStart,
+            channelEndID: endMessage,
+            thinkStartID: thinkStart,
+            thinkEndID: endMessage,
+            stopTokenIDs: [eos],
+            vocabSize: 201_024)
+    }
+
     public func applyChatTemplate(_ messages: [Message]) throws -> String {
         switch dialect {
         case .gemma: return try gemmaChatTemplate(messages)
         case .chatml: return try chatMLChatTemplate(messages)
         case .deepseek: return try deepseekChatTemplate(messages)
+        case .inkling: return try inklingChatTemplate(messages)
         }
+    }
+
+    /// Text-only, no-tool rendering byte-matched to the shipped Jinja:
+    /// content is never trimmed, the effort line precedes the first
+    /// non-system message (or closes the render when every message is
+    /// system), and the generation prompt is always appended.
+    private func inklingChatTemplate(_ messages: [Message]) throws -> String {
+        var s = ""
+        var effortEmitted = false
+        for (index, message) in messages.enumerated() {
+            guard let content = message.content else {
+                throw MFTokenizerError.invalidChatTemplate("text-only messages require content")
+            }
+            if message.role == .system && index != 0 {
+                throw MFTokenizerError.invalidChatTemplate("system message must be first")
+            }
+            if !effortEmitted && message.role != .system {
+                s += Self.inklingEffortLine
+                effortEmitted = true
+            }
+            switch message.role {
+            case .system:
+                s += Self.inklingSystemMark + Self.inklingContentText
+                    + content + Self.inklingEndMessage
+            case .user, .developer:
+                s += Self.inklingUserMark + Self.inklingContentText
+                    + content + Self.inklingEndMessage
+            case .assistant:
+                s += Self.inklingModelMark + Self.inklingContentText
+                    + content + Self.inklingEndMessage + Self.inklingEndSampling
+            case .tool:
+                throw MFTokenizerError.invalidChatTemplate(
+                    "inkling tool turns are not supported by the text-only encoder")
+            }
+        }
+        if !effortEmitted { s += Self.inklingEffortLine }
+        s += Self.inklingModelMark
+        return s
     }
 
     private func gemmaChatTemplate(_ messages: [Message]) throws -> String {
@@ -716,6 +813,15 @@ public struct MFTokenizer: @unchecked Sendable {
             // continuation must produce the same bytes a fresh render would.
             return [endOfTurnID] + encode(
                 Self.deepseekUserMark + userContent + Self.deepseekGenerationSuffix,
+                addBOS: false)
+        case .inkling:
+            // The cached assistant turn stopped just before
+            // `<|content_model_end_sampling|>` (== endOfTurnID); supply it,
+            // then the next user turn and the generation prompt. Untrimmed,
+            // matching the full render.
+            return [endOfTurnID] + encode(
+                Self.inklingUserMark + Self.inklingContentText + userContent
+                    + Self.inklingEndMessage + Self.inklingModelMark,
                 addBOS: false)
         }
     }

--- a/Sources/MferenceApp/Core/Installation/AppModelInstallDescriptor.swift
+++ b/Sources/MferenceApp/Core/Installation/AppModelInstallDescriptor.swift
@@ -76,12 +76,30 @@ public struct AppModelInstallDescriptor: Equatable, Sendable {
         rangeStagingBytes: UInt64(RemoteChunkPolicy.defaultBytes),
         reserveBytes: 2_147_483_648)
 
+    /// Revision and index digest verified against the published repo; the byte
+    /// counts are the repo's own totals and remain estimates for the installed
+    /// `.gturbo` until a first install confirms them. Installing this family
+    /// still fails in the repacker until `ArchInfo` learns
+    /// `model_type: "inkling_mm_model"`. See `docs/INKLING_SMALL.md`.
+    public static let inklingSmall = AppModelInstallDescriptor(
+        family: .inklingSmall,
+        displayName: "Inkling-Small 276B-A12B 4-bit",
+        repoID: "pipenetwork/Inkling-Small-MLX-4bit",
+        revision: "9d6e4720ab7002af25d6129c88ccea6cd9f19372",
+        sourceIndexSHA256:
+            "fe16aec3cef12438f1d0ff657f7e785781b61271528a66b3b7160fcf1aaca30c",
+        approximateDownloadBytes: 148_441_426_867,
+        installedBytes: 149_000_000_000,
+        rangeStagingBytes: UInt64(RemoteChunkPolicy.defaultBytes),
+        reserveBytes: 2_147_483_648)
+
     /// The shipped descriptor for a model family, if one exists.
     public static func descriptor(for family: ModelFamily) -> AppModelInstallDescriptor? {
         switch family {
         case .gemma4: return .default
         case .qwen36: return .qwen36
         case .deepseekV4Flash: return .deepseekV4Flash
+        case .inklingSmall: return .inklingSmall
         }
     }
 
@@ -91,6 +109,7 @@ public struct AppModelInstallDescriptor: Equatable, Sendable {
         case .gemma4: return "gemma4.gturbo"
         case .qwen36: return "qwen36.gturbo"
         case .deepseekV4Flash: return "deepseekv4flash.gturbo"
+        case .inklingSmall: return "inklingsmall.gturbo"
         }
     }
 
@@ -106,6 +125,7 @@ public struct AppModelInstallDescriptor: Equatable, Sendable {
         switch environmentValue ?? preferenceValue {
         case "qwen36": return .qwen36
         case "deepseekv4flash", "dsv4": return .deepseekV4Flash
+        case "inklingsmall", "inkling": return .inklingSmall
         default: return .default
         }
     }

--- a/Sources/MferenceRepack/Command/main.swift
+++ b/Sources/MferenceRepack/Command/main.swift
@@ -3,7 +3,7 @@ import MferenceRepackCore
 
 private let usage = """
 Usage:
-  MferenceRepack [--model <gemma4|qwen36|deepseekv4flash>] --output <model.gturbo> [--overwrite] [--resume] [--base-url <url>]
+  MferenceRepack [--dry-run] [--model <gemma4|qwen36|deepseekv4flash|inklingsmall>] --output <model.gturbo> [--overwrite] [--resume] [--base-url <url>]
   MferenceRepack --discard-partial --output <model.gturbo>
   MferenceRepack --verify-install --input-gturbo <model.gturbo>
   MferenceRepack --help
@@ -24,6 +24,7 @@ private struct Arguments {
     var verifyInstall = false
     var inputGTurbo: String?
     var baseURL: URL?
+    var dryRun = false
 
     static func parse(_ values: [String]) throws -> Arguments {
         var parsed = Arguments()
@@ -38,6 +39,9 @@ private struct Arguments {
                 index += 1
             case "--resume":
                 parsed.resume = true
+                index += 1
+            case "--dry-run":
+                parsed.dryRun = true
                 index += 1
             case "--discard-partial":
                 parsed.discardPartial = true
@@ -178,9 +182,22 @@ private func run(_ values: [String]) async -> Int32 {
         overwrite: arguments.overwrite,
         token: ProcessInfo.processInfo.environment["HF_TOKEN"],
         resume: arguments.resume,
-        baseURL: arguments.baseURL)
+        baseURL: arguments.baseURL,
+        dryRunSpaceCheck: arguments.dryRun)
     do {
         let result = try await RemoteStreamingRepacker(options: options).run()
+        if result.dryRun {
+            print("Dry run for \(source.displayName)")
+            print("Source revision: \(result.resolvedCommit)")
+            print("Range requests: \(result.rangeRequestCount)")
+            print("Source bytes to read: \(result.remoteBytesToDownload)")
+            print("Output bytes: \(result.outputBytes)")
+            print("Resident entries: \(result.residentEntryCount)")
+            print("Expert layers: \(result.expertLayerCount)")
+            print("Excluded multimodal tensors: "
+                + "\(result.excludedMultimodalTensorCount)")
+            return 0
+        }
         print("Installed \(source.displayName)")
         print("Source revision: \(result.resolvedCommit)")
         print("Model: \(result.outputDir)")

--- a/Sources/MferenceRepack/Core/Format/ArchInfo.swift
+++ b/Sources/MferenceRepack/Core/Format/ArchInfo.swift
@@ -7,6 +7,7 @@ enum RepackModelFamily: String, Sendable, Equatable {
     case gemma4 = "gemma4"
     case qwen36 = "qwen36"
     case deepseekV4Flash = "deepseekV4Flash"
+    case inklingSmall = "inklingSmall"
 }
 
 /// Architecture facts mirrored into `manifest.json -> arch`. Cross-checked by
@@ -81,6 +82,28 @@ struct ArchInfo: Sendable, Equatable {
     let routedScalingFactor: Double
     let swigluLimit: Double
 
+    // Inkling extensions: learned relative-attention position encoding (no
+    // RoPE), depthwise short convolutions, multiple shared experts that sink
+    // their own router logits, and leading dense-FFN layers. Zeroed defaults
+    // (one shared expert, unit logit scale) keep the other three families'
+    // manifest output unchanged.
+    let relDRel: Int
+    let relExtent: Int
+    let relProjDim: Int
+    let relLogScalingFloor: Int
+    let relLogScalingAlpha: Double
+    let sconvKernelSize: Int
+    let numSharedExperts: Int
+    let numDenseLayers: Int
+    let denseIntermediateSize: Int
+    let sharedExpertSink: Bool
+    let embedNormEnabled: Bool
+    let logitsWidthMultiplier: Double
+    let routerGateBias: Bool
+    let routerNormAfterTopK: Bool
+    let routerGlobalScale: Bool
+    let unpaddedVocabSize: Int
+
     init(hiddenSize: Int,
          intermediateSize: Int,
          moeIntermediateSize: Int,
@@ -135,7 +158,23 @@ struct ArchInfo: Sendable, Equatable {
          numHashRoutedLayers: Int = 0,
          routerScoringFunc: String = "softmax",
          routedScalingFactor: Double = 1.0,
-         swigluLimit: Double = 0.0) {
+         swigluLimit: Double = 0.0,
+         relDRel: Int = 0,
+         relExtent: Int = 0,
+         relProjDim: Int = 0,
+         relLogScalingFloor: Int = 0,
+         relLogScalingAlpha: Double = 0,
+         sconvKernelSize: Int = 0,
+         numSharedExperts: Int = 1,
+         numDenseLayers: Int = 0,
+         denseIntermediateSize: Int = 0,
+         sharedExpertSink: Bool = false,
+         embedNormEnabled: Bool = false,
+         logitsWidthMultiplier: Double = 1.0,
+         routerGateBias: Bool = false,
+         routerNormAfterTopK: Bool = false,
+         routerGlobalScale: Bool = false,
+         unpaddedVocabSize: Int = 0) {
         self.hiddenSize = hiddenSize
         self.intermediateSize = intermediateSize
         self.moeIntermediateSize = moeIntermediateSize
@@ -191,6 +230,22 @@ struct ArchInfo: Sendable, Equatable {
         self.routerScoringFunc = routerScoringFunc
         self.routedScalingFactor = routedScalingFactor
         self.swigluLimit = swigluLimit
+        self.relDRel = relDRel
+        self.relExtent = relExtent
+        self.relProjDim = relProjDim
+        self.relLogScalingFloor = relLogScalingFloor
+        self.relLogScalingAlpha = relLogScalingAlpha
+        self.sconvKernelSize = sconvKernelSize
+        self.numSharedExperts = numSharedExperts
+        self.numDenseLayers = numDenseLayers
+        self.denseIntermediateSize = denseIntermediateSize
+        self.sharedExpertSink = sharedExpertSink
+        self.embedNormEnabled = embedNormEnabled
+        self.logitsWidthMultiplier = logitsWidthMultiplier
+        self.routerGateBias = routerGateBias
+        self.routerNormAfterTopK = routerNormAfterTopK
+        self.routerGlobalScale = routerGlobalScale
+        self.unpaddedVocabSize = unpaddedVocabSize
     }
 
     static func load(configPath: String) throws -> ArchInfo {
@@ -209,7 +264,195 @@ struct ArchInfo: Sendable, Equatable {
         if (root["model_type"] as? String) == "qwen3_5_moe" {
             return try loadQwen36(configPath: configPath, tc: tc)
         }
+        if (root["model_type"] as? String) == "inkling_mm_model" {
+            return try loadInklingSmall(configPath: configPath, tc: tc)
+        }
         return try loadGemma4(configPath: configPath, tc: tc)
+    }
+
+    // MARK: - Inkling Small
+
+    /// Inkling carries no RoPE at all — position rides on a learned
+    /// relative-attention bias — so `ropeTheta` and `partialRotaryFactor` are
+    /// deliberately zero rather than parsed. Attention layers are named by
+    /// exclusion: `local_layer_ids` lists the sliding-window layers and every
+    /// other layer is full attention.
+    ///
+    /// `relExtent` is the *global*-layer bias width; sliding layers use
+    /// `sliding_window_size` instead (the reference picks
+    /// `sliding_window_size if is_sliding else rel_extent`), which is why the
+    /// checkpoint ships `rel_logits_proj.proj` as `[16, 512]` on local layers
+    /// and `[16, 1024]` on layers 5, 11, 17, 23, 29, 35 and 41. `relProjDim`
+    /// is `num_attention_heads * d_rel`, the output width of `attn.wr_du`.
+    private static func loadInklingSmall(configPath: String,
+                                         tc: [String: Any]) throws -> ArchInfo {
+        func i(_ k: String) throws -> Int {
+            guard let n = (tc[k] as? Int) ?? (tc[k] as? NSNumber)?.intValue else {
+                throw RepackError.configJsonInvalid(path: configPath, detail: "missing \(k)")
+            }
+            return n
+        }
+        func d(_ k: String) throws -> Double {
+            guard let n = (tc[k] as? Double) ?? (tc[k] as? NSNumber)?.doubleValue else {
+                throw RepackError.configJsonInvalid(path: configPath, detail: "missing \(k)")
+            }
+            return n
+        }
+        let numLayers = try i("num_hidden_layers")
+        guard let localIDs = tc["local_layer_ids"] as? [Int] else {
+            throw RepackError.configJsonInvalid(
+                path: configPath, detail: "missing local_layer_ids")
+        }
+        let localSet = Set(localIDs)
+        if let bad = localSet.first(where: { $0 < 0 || $0 >= numLayers }) {
+            throw RepackError.configJsonInvalid(
+                path: configPath,
+                detail: "local_layer_ids entry \(bad) out of range for \(numLayers) layers")
+        }
+        // 0 = sliding-window, 1 = full attention.
+        let mask: [UInt8] = (0..<numLayers).map { localSet.contains($0) ? 0 : 1 }
+
+        guard (tc["use_sconv"] as? Bool) == true else {
+            throw RepackError.configJsonInvalid(
+                path: configPath, detail: "use_sconv must be true for Inkling")
+        }
+        guard let gateActivation = tc["gate_activation"] as? String else {
+            throw RepackError.configJsonInvalid(
+                path: configPath, detail: "missing gate_activation")
+        }
+        guard gateActivation == "sigmoid" else {
+            throw RepackError.configJsonInvalid(
+                path: configPath,
+                detail: "unsupported gate_activation \"\(gateActivation)\"")
+        }
+        let headDim = try i("head_dim")
+        let swaHeadDim = try i("swa_head_dim")
+        guard swaHeadDim == headDim else {
+            throw RepackError.configJsonInvalid(
+                path: configPath,
+                detail: "swa_head_dim \(swaHeadDim) != head_dim \(headDim); "
+                    + "the runtime carries a single head dimension")
+        }
+
+        let arch = ArchInfo(
+            hiddenSize: try i("hidden_size"),
+            intermediateSize: try i("intermediate_size"),
+            moeIntermediateSize: try i("intermediate_size"),
+            numHeads: try i("num_attention_heads"),
+            numKVHeads: try i("num_key_value_heads"),
+            numFullKVHeads: try i("num_key_value_heads"),
+            headDim: headDim,
+            fullHeadDim: headDim,
+            vocabSize: try i("vocab_size"),
+            slidingWindow: try i("sliding_window_size"),
+            finalLogitSoftcap: 0.0,
+            ropeTheta: 0.0,
+            fullRopeTheta: 0.0,
+            partialRotaryFactor: 0.0,
+            numLayers: numLayers,
+            numExperts: try i("n_routed_experts"),
+            topKExperts: try i("num_experts_per_tok"),
+            tieWordEmbeddings: false,
+            attentionKEqV: false,
+            fullAttentionLayerMask: mask,
+            hiddenActivation: "silu",
+            family: .inklingSmall,
+            attnOutputGate: false,
+            // Inkling RMS-normalizes q and k per head, so the reference uses
+            // `1 / head_dim`, NOT the usual `1 / sqrt(head_dim)`
+            // (`inkling_mlx/attention.py`: "q/k are per-head RMS-normalized,
+            // hence 1/d rather than 1/sqrt(d)").
+            attentionScale: 1.0 / Double(headDim),
+            embeddingScaledBySqrtHidden: false,
+            routerScaled: false,
+            ffnSandwichNorms: false,
+            sharedExpertGated: false,
+            ropeNeoxSubdim: false,
+            linearNumKHeads: 0,
+            linearNumVHeads: 0,
+            linearKeyHeadDim: 0,
+            linearValueHeadDim: 0,
+            linearConvKernelSize: 0,
+            routerScoringFunc: gateActivation,
+            routedScalingFactor: try d("route_scale"),
+            relDRel: try i("d_rel"),
+            relExtent: try i("rel_extent"),
+            relProjDim: try i("num_attention_heads") * (try i("d_rel")),
+            relLogScalingFloor: try i("log_scaling_n_floor"),
+            relLogScalingAlpha: try d("log_scaling_alpha"),
+            sconvKernelSize: try i("sconv_kernel_size"),
+            numSharedExperts: try i("n_shared_experts"),
+            numDenseLayers: try i("dense_mlp_idx"),
+            denseIntermediateSize: try i("dense_intermediate_size"),
+            sharedExpertSink: (tc["shared_expert_sink"] as? Bool) ?? false,
+            embedNormEnabled: (tc["use_embed_norm"] as? Bool) ?? false,
+            logitsWidthMultiplier: try d("logits_mup_width_multiplier"),
+            routerGateBias: (tc["use_gate_bias"] as? Bool) ?? false,
+            routerNormAfterTopK: (tc["norm_after_topk"] as? Bool) ?? false,
+            routerGlobalScale: (tc["use_global_scale"] as? Bool) ?? false,
+            unpaddedVocabSize: (tc["unpadded_vocab_size"] as? Int)
+                ?? (tc["unpadded_vocab_size"] as? NSNumber)?.intValue ?? 0)
+        try crossCheckProductionInklingSmall(arch, configPath: configPath)
+        return arch
+    }
+
+    /// Production Inkling-Small 276B-A12B baseline (mirrors the runtime's
+    /// `ArchConfig.inklingSmall_276B_A12B`). A config matching the production
+    /// shape (hidden 4096, 42 layers, 256 experts) must agree on every field;
+    /// toy/synthetic configs are exempt.
+    private static func crossCheckProductionInklingSmall(
+        _ a: ArchInfo, configPath: String) throws {
+        guard a.hiddenSize == 4096, a.numLayers == 42, a.numExperts == 256 else {
+            return
+        }
+        let expectedMask: [UInt8] = (0..<42).map { $0 % 6 == 5 ? 1 : 0 }
+        func fail(_ field: String, _ actual: String, _ expected: String) -> RepackError {
+            .configJsonInvalid(
+                path: configPath,
+                detail: "production Inkling-Small \(field) is \(actual), expected \(expected)")
+        }
+        guard a.fullAttentionLayerMask == expectedMask else {
+            throw fail("local_layer_ids",
+                       a.fullAttentionLayerMask.description,
+                       expectedMask.description)
+        }
+        guard a.vocabSize == 201_024 else {
+            throw fail("vocabSize", "\(a.vocabSize)", "201024")
+        }
+        guard a.numHeads == 32, a.numKVHeads == 8, a.headDim == 128 else {
+            throw fail("attention shape",
+                       "\(a.numHeads)/\(a.numKVHeads)/\(a.headDim)", "32/8/128")
+        }
+        guard a.topKExperts == 6, a.numSharedExperts == 2 else {
+            throw fail("routing", "\(a.topKExperts)/\(a.numSharedExperts)", "6/2")
+        }
+        guard a.moeIntermediateSize == 2048, a.denseIntermediateSize == 16_384 else {
+            throw fail("FFN widths",
+                       "\(a.moeIntermediateSize)/\(a.denseIntermediateSize)",
+                       "2048/16384")
+        }
+        guard a.slidingWindow == 512 else {
+            throw fail("sliding_window_size", "\(a.slidingWindow)", "512")
+        }
+        guard a.numDenseLayers == 2 else {
+            throw fail("dense_mlp_idx", "\(a.numDenseLayers)", "2")
+        }
+        guard a.sconvKernelSize == 4 else {
+            throw fail("sconv_kernel_size", "\(a.sconvKernelSize)", "4")
+        }
+        guard a.relDRel == 16, a.relExtent == 1024 else {
+            throw fail("relative position", "\(a.relDRel)/\(a.relExtent)", "16/1024")
+        }
+        guard a.routedScalingFactor == 8.0 else {
+            throw fail("route_scale", "\(a.routedScalingFactor)", "8.0")
+        }
+        guard a.logitsWidthMultiplier == 16.0 else {
+            throw fail("logits_mup_width_multiplier",
+                       "\(a.logitsWidthMultiplier)", "16.0")
+        }
+        guard a.ropeTheta == 0, a.partialRotaryFactor == 0 else {
+            throw fail("rope", "non-zero", "zero (relative position only)")
+        }
     }
 
     // MARK: - Gemma 4

--- a/Sources/MferenceRepack/Core/Format/GTurboJSON.swift
+++ b/Sources/MferenceRepack/Core/Format/GTurboJSON.swift
@@ -99,6 +99,29 @@ enum GTurboJSON {
             archDict["routedScalingFactor"] = arch.routedScalingFactor
             archDict["swigluLimit"] = arch.swigluLimit
         }
+        // Inkling extension fields, gated on the family for the same reason:
+        // the other three manifests stay byte-identical, and the reader treats
+        // absence as the defaults those families already hold.
+        if arch.family == .inklingSmall {
+            archDict["routerScoringFunc"] = arch.routerScoringFunc
+            archDict["routedScalingFactor"] = arch.routedScalingFactor
+            archDict["relDRel"] = arch.relDRel
+            archDict["relExtent"] = arch.relExtent
+            archDict["relProjDim"] = arch.relProjDim
+            archDict["relLogScalingFloor"] = arch.relLogScalingFloor
+            archDict["relLogScalingAlpha"] = arch.relLogScalingAlpha
+            archDict["sconvKernelSize"] = arch.sconvKernelSize
+            archDict["numSharedExperts"] = arch.numSharedExperts
+            archDict["numDenseLayers"] = arch.numDenseLayers
+            archDict["denseIntermediateSize"] = arch.denseIntermediateSize
+            archDict["sharedExpertSink"] = arch.sharedExpertSink
+            archDict["embedNormEnabled"] = arch.embedNormEnabled
+            archDict["logitsWidthMultiplier"] = arch.logitsWidthMultiplier
+            archDict["routerGateBias"] = arch.routerGateBias
+            archDict["routerNormAfterTopK"] = arch.routerNormAfterTopK
+            archDict["routerGlobalScale"] = arch.routerGlobalScale
+            archDict["unpaddedVocabSize"] = arch.unpaddedVocabSize
+        }
         let quantBits = [
             "embedding": bitWidths.embedding,
             "attention": bitWidths.attention,
@@ -191,7 +214,11 @@ enum GTurboJSON {
         let obj: [String: Any] = [
             "expertStride": expertStride,
             "numLayers": arch.numLayers,
-            "expertsPerLayer": plan.layers.first?.expertsPerLayer ?? 0,
+            // Skip leading dense-FFN layers, which carry no routed experts
+            // (Inkling's layers 0-1). Taking `layers.first` would publish 0
+            // here and contradict the manifest, which selects the same way.
+            "expertsPerLayer": plan.layers.first(where: { $0.expertsPerLayer > 0 })?
+                .expertsPerLayer ?? 0,
             "layers": layersArr
         ]
         return try JSONSerialization.data(withJSONObject: obj,

--- a/Sources/MferenceRepack/Core/Planning/RepackPlanner.swift
+++ b/Sources/MferenceRepack/Core/Planning/RepackPlanner.swift
@@ -132,6 +132,11 @@ enum RepackPlanner {
             return name.hasPrefix("language_model.")
         case .deepseekV4Flash:
             return name.hasPrefix("model.") || name.hasPrefix("lm_head.")
+        case .inklingSmall:
+            // Inkling is multimodal but names its towers as siblings, so the
+            // text tower is exactly `model.llm.`; `model.visual.` and
+            // `model.audio.` fall through to the multimodal exclusion.
+            return name.hasPrefix("model.llm.")
         }
     }
 
@@ -142,6 +147,9 @@ enum RepackPlanner {
         case .gemma4:          routedContainer = ".experts.switch_glu."
         case .qwen36:          routedContainer = ".mlp.switch_mlp."
         case .deepseekV4Flash: routedContainer = ".ffn.switch_mlp."
+        // `.mlp.experts.` does not match the shared experts, which sit under
+        // `.mlp.shared_experts.`.
+        case .inklingSmall:    routedContainer = ".mlp.experts."
         }
         guard name.contains(routedContainer) else { return nil }
         if name.contains(".gate_proj.") { return "gate" }
@@ -267,7 +275,9 @@ enum RepackPlanner {
     private static func isMultimodalTensorName(_ name: String) -> Bool {
         name.hasPrefix("vision_tower.") ||
             name.hasPrefix("embed_vision.") ||
-            name.hasPrefix("audio_tower.")
+            name.hasPrefix("audio_tower.") ||
+            name.hasPrefix("model.visual.") ||
+            name.hasPrefix("model.audio.")
     }
 
     // MARK: - Resident planning
@@ -486,6 +496,11 @@ enum RepackPlanner {
                 if n == "model.embed_tokens.weight" { return (0, 0, 0, n) }
                 if n == "model.norm.weight"          { return (3, 0, 0, n) }
                 if n == "lm_head.weight"             { return (4, 0, 0, n) }
+            case .inklingSmall:
+                if n == "model.llm.embed.weight"      { return (0, 0, 0, n) }
+                if n == "model.llm.embed_norm.weight" { return (0, 0, 1, n) }
+                if n == "model.llm.norm.weight"       { return (3, 0, 0, n) }
+                if n == "model.llm.unembed.weight"    { return (4, 0, 0, n) }
             }
             if let li = layerIndex(in: n) {
                 let slot: Int
@@ -493,6 +508,7 @@ enum RepackPlanner {
                 case .gemma4:          slot = slotRank(in: n)
                 case .qwen36:          slot = qwenSlotRank(in: n)
                 case .deepseekV4Flash: slot = deepseekV4SlotRank(in: n)
+                case .inklingSmall:    slot = inklingSlotRank(in: n)
                 }
                 return (1, li, slot, n)
             }
@@ -505,6 +521,42 @@ enum RepackPlanner {
             if ka.2 != kb.2 { return ka.2 < kb.2 }
             return ka.3 < kb.3
         }
+    }
+
+    /// Within-layer slot order for Inkling: the attention bundle (QKV/O, the
+    /// relative-position projection and its profile bank, the per-head norms,
+    /// and the K/V short convs), then the router, then the shared experts,
+    /// then the dense FFN carried by layers 0–1, then the block short convs
+    /// and the two layer norms.
+    ///
+    /// Ordered before `.mlp.gate_proj` so the dense-FFN checks cannot swallow
+    /// the shared-expert tensors, which share the `.mlp.` segment.
+    private static func inklingSlotRank(in n: String) -> Int {
+        if n.contains(".attn.wq_du.weight")                 { return 0 }
+        if n.contains(".attn.wk_dv.weight")                 { return 1 }
+        if n.contains(".attn.wv_dv.weight")                 { return 2 }
+        if n.contains(".attn.wo_ud.weight")                 { return 3 }
+        if n.contains(".attn.wr_du.weight")                 { return 4 }
+        if n.hasSuffix(".attn.rel_logits_proj.proj")        { return 5 }
+        if n.contains(".attn.q_norm.weight")                { return 6 }
+        if n.contains(".attn.k_norm.weight")                { return 7 }
+        if n.contains(".attn.k_sconv.weight")               { return 8 }
+        if n.contains(".attn.v_sconv.weight")               { return 9 }
+        if n.contains(".mlp.gate.weight")                   { return 10 }
+        if n.hasSuffix(".mlp.gate.bias")                    { return 11 }
+        if n.hasSuffix(".mlp.gate.global_scale")            { return 12 }
+        if n.contains(".mlp.shared_experts.gate_proj.weight") { return 13 }
+        if n.contains(".mlp.shared_experts.up_proj.weight")   { return 14 }
+        if n.contains(".mlp.shared_experts.down_proj.weight") { return 15 }
+        if n.contains(".mlp.gate_proj.weight")              { return 16 }
+        if n.contains(".mlp.up_proj.weight")                { return 17 }
+        if n.contains(".mlp.down_proj.weight")              { return 18 }
+        if n.hasSuffix(".mlp.global_scale")                 { return 19 }
+        if n.contains(".attn_sconv.weight")                 { return 20 }
+        if n.contains(".mlp_sconv.weight")                  { return 21 }
+        if n.hasSuffix(".attn_norm.weight")                 { return 22 }
+        if n.hasSuffix(".mlp_norm.weight")                  { return 23 }
+        return 99
     }
 
     /// Within-layer slot order for the Qwen 3.6 family: full-attention

--- a/Sources/MferenceRepack/Core/Remote/RemoteStreamingRepacker.swift
+++ b/Sources/MferenceRepack/Core/Remote/RemoteStreamingRepacker.swift
@@ -63,6 +63,17 @@ public struct RemoteStreamingRepackResult: Sendable {
     public let reusedBytes: UInt64
     public let downloadedThisRunBytes: UInt64
     public let dryRun: Bool
+
+    /// Bytes the install writes: the resident file plus every packed-expert
+    /// layer blob. Sidecars (manifest, layout, tokenizer) are negligible.
+    public var outputBytes: UInt64 {
+        plan.resident.totalSize + plan.layers.reduce(UInt64(0)) { $0 + $1.fileSize }
+    }
+    public var residentEntryCount: Int { plan.resident.entries.count }
+    public var expertLayerCount: Int { plan.layers.count }
+    public var excludedMultimodalTensorCount: Int {
+        plan.excludedMultimodalTensorNames.count
+    }
 }
 
 public final class RemoteStreamingRepacker {
@@ -572,12 +583,14 @@ public final class RemoteStreamingRepacker {
             routedExpert: 4)
         for e in plan.resident.entries {
             if e.name == "language_model.model.embed_tokens.weight"
-                || e.name == "model.embed_tokens.weight",
+                || e.name == "model.embed_tokens.weight"
+                || e.name == "model.llm.embed.weight",
                let s = e.quantSpec {
                 bits.embedding = s.bits
             }
             if e.name.hasSuffix(".self_attn.q_proj.weight")
                 || e.name.hasSuffix(".attn.wq_a.weight")
+                || e.name.hasSuffix(".attn.wq_du.weight")
                 || e.name.hasSuffix(".linear_attn.in_proj_qkv.weight"),
                let s = e.quantSpec {
                 bits.attention = s.bits
@@ -588,9 +601,18 @@ public final class RemoteStreamingRepacker {
                let s = e.quantSpec {
                 bits.router = s.bits
             }
-            if e.name.hasSuffix(".mlp.gate_proj.weight")
-                || e.name.hasSuffix(".mlp.shared_expert.gate_proj.weight")
+            if e.name.hasSuffix(".mlp.shared_expert.gate_proj.weight")
+                || e.name.hasSuffix(".mlp.shared_experts.gate_proj.weight")
                 || e.name.hasSuffix(".ffn.shared_experts.gate_proj.weight"),
+               let s = e.quantSpec {
+                bits.sharedExpert = s.bits
+            }
+            // Gemma folds the shared expert into the bare `.mlp.` names.
+            // Inkling uses those same names for its two dense-FFN layers, so
+            // trusting them everywhere would make the recorded shared-expert
+            // width depend on tensor iteration order.
+            if plan.arch.family == .gemma4,
+               e.name.hasSuffix(".mlp.gate_proj.weight"),
                let s = e.quantSpec {
                 bits.sharedExpert = s.bits
             }

--- a/Sources/MferenceRepack/Core/Remote/SupportedModelSource.swift
+++ b/Sources/MferenceRepack/Core/Remote/SupportedModelSource.swift
@@ -28,7 +28,8 @@ public struct SupportedModelSource: Sendable, Equatable {
                                overwrite: Bool,
                                token: String?,
                                resume: Bool = false,
-                               baseURL: URL? = nil)
+                               baseURL: URL? = nil,
+                               dryRunSpaceCheck: Bool = false)
         -> RemoteStreamingRepackOptions {
         if let baseURL {
             return RemoteStreamingRepackOptions(
@@ -40,6 +41,7 @@ public struct SupportedModelSource: Sendable, Equatable {
                 minFreeReserveBytes: reserveBytes,
                 overwrite: overwrite,
                 resume: resume,
+                dryRunSpaceCheck: dryRunSpaceCheck,
                 baseURL: baseURL)
         }
         return RemoteStreamingRepackOptions(
@@ -50,7 +52,8 @@ public struct SupportedModelSource: Sendable, Equatable {
             requireKnownSource: true,
             minFreeReserveBytes: reserveBytes,
             overwrite: overwrite,
-            resume: resume)
+            resume: resume,
+            dryRunSpaceCheck: dryRunSpaceCheck)
     }
 
     public static let gemma4 = SupportedModelSource(
@@ -99,10 +102,29 @@ public struct SupportedModelSource: Sendable, Equatable {
         installedBytes: 97_500_000_000,
         reserveBytes: 2_147_483_648)
 
+    /// Revision and index digest verified against the published repo. The
+    /// download estimate is the repo's own total (148.4 GB); the vision and
+    /// audio towers are excluded by the planner but they are only 18 tensors,
+    /// so the saving is immaterial. Installed bytes carry headroom for the
+    /// resident index and per-expert page rounding. See docs/INKLING_SMALL.md.
+    public static let inklingSmall = SupportedModelSource(
+        name: "inklingsmall",
+        displayName: "Inkling-Small 276B-A12B 4-bit",
+        repoID: "pipenetwork/Inkling-Small-MLX-4bit",
+        revision: "9d6e4720ab7002af25d6129c88ccea6cd9f19372",
+        sourceIndexSHA256:
+            "fe16aec3cef12438f1d0ff657f7e785781b61271528a66b3b7160fcf1aaca30c",
+        modelID: "inkling-small-4bit",
+        approximateDownloadBytes: 148_441_426_867,
+        installedBytes: 149_000_000_000,
+        reserveBytes: 2_147_483_648)
+
     /// Default source when no `--model` selector is given.
     public static let `default` = gemma4
 
-    public static let all: [SupportedModelSource] = [gemma4, qwen36, deepseekV4Flash]
+    public static let all: [SupportedModelSource] = [
+        gemma4, qwen36, deepseekV4Flash, inklingSmall,
+    ]
 
     public static func named(_ name: String) -> SupportedModelSource? {
         all.first { $0.name == name }

--- a/Sources/MferenceRepack/Core/Verification/VerifiedInstallTool.swift
+++ b/Sources/MferenceRepack/Core/Verification/VerifiedInstallTool.swift
@@ -156,6 +156,16 @@ public enum VerifiedInstallTool {
             guard layer.layer >= 0 && layer.layer < layout.numLayers else {
                 throw RepackError.configurationInvalid(detail: "packed expert layer index out of range")
             }
+            // Leading dense-FFN layers carry no routed experts, so the writer
+            // emits an empty layout entry and no blob for them (Inkling's
+            // layers 0-1). There is nothing to size- or hash-check.
+            if layer.experts.isEmpty {
+                guard manifest.files["packed_experts/\(layer.file)"] == nil else {
+                    throw RepackError.configurationInvalid(
+                        detail: "packed_experts/\(layer.file) has no experts but is in the manifest")
+                }
+                continue
+            }
             guard layer.experts.count == layout.expertsPerLayer else {
                 throw RepackError.configurationInvalid(
                     detail: "packed_experts/\(layer.file) expert count mismatch")

--- a/Sources/MferenceRepack/Core/Verification/VerifiedInstallTool.swift
+++ b/Sources/MferenceRepack/Core/Verification/VerifiedInstallTool.swift
@@ -78,12 +78,17 @@ public enum VerifiedInstallTool {
         let sha256: String
     }
 
+    private struct ManifestArchSubset: Decodable {
+        let numDenseLayers: Int?
+    }
+
     private struct Manifest: Decodable {
         let files: [String: ManifestFileEntry]
         let expertsPerLayer: Int
         let numLayers: Int
         let expertStride: UInt64
         let sourceSnapshotHash: String?
+        let arch: ManifestArchSubset?
     }
 
     private struct PackedExpertsLayout: Decodable {
@@ -158,8 +163,17 @@ public enum VerifiedInstallTool {
             }
             // Leading dense-FFN layers carry no routed experts, so the writer
             // emits an empty layout entry and no blob for them (Inkling's
-            // layers 0-1). There is nothing to size- or hash-check.
+            // layers 0-1). The exception is bounded by the manifest's declared
+            // dense-layer count: an empty ROUTED layer means a broken install
+            // that the runtime loader would reject, and verification must not
+            // certify it.
             if layer.experts.isEmpty {
+                let denseLayers = manifest.arch?.numDenseLayers ?? 0
+                guard layer.layer < denseLayers else {
+                    throw RepackError.configurationInvalid(
+                        detail: "packed_experts/\(layer.file) has no experts but layer "
+                            + "\(layer.layer) is outside the declared \(denseLayers) dense layers")
+                }
                 guard manifest.files["packed_experts/\(layer.file)"] == nil else {
                     throw RepackError.configurationInvalid(
                         detail: "packed_experts/\(layer.file) has no experts but is in the manifest")

--- a/Sources/MferenceServer/Core/ServerInference.swift
+++ b/Sources/MferenceServer/Core/ServerInference.swift
@@ -174,6 +174,7 @@ public actor ServerModelSession: ServerInferenceBackend {
         case .gemma4: return "gemma-4-26b-a4b-it"
         case .qwen36: return "qwen3.6-35b-a3b"
         case .deepseekV4Flash: return "deepseek-v4-flash-2bit-dq"
+        case .inklingSmall: return "inkling-small-4bit"
         }
     }
     private nonisolated let modelFamily: ModelFamily

--- a/Tests/Mference/Core/Infrastructure/ModelIO/InklingInstalledModelTests.swift
+++ b/Tests/Mference/Core/Infrastructure/ModelIO/InklingInstalledModelTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import Mference
+
+/// Integration check against a real installed Inkling-Small `.gturbo`.
+/// Skipped unless `MFERENCE_INKLING_GTURBO` points at one, so the suite stays
+/// runnable without the 148 GB checkpoint.
+@Suite struct InklingInstalledModelTests {
+
+    @Test func installedManifestValidatesAgainstBaseline() throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"] else { return }
+        let url = URL(fileURLWithPath: path)
+
+        #expect(try ManifestReader.peekFamily(directoryURL: url) == .inklingSmall)
+
+        // `load(directoryURL:expecting:)` cross-checks every arch and quant
+        // field against the compiled baseline and throws on any divergence.
+        let expected = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let manifest = try ManifestReader.load(directoryURL: url,
+                                               expecting: expected)
+
+        #expect(manifest.arch.numLayers == 42)
+        #expect(manifest.arch.family == "inklingSmall")
+        #expect(manifest.arch.relDRel == 16)
+        #expect(manifest.arch.sconvKernelSize == 4)
+        #expect(manifest.arch.numSharedExperts == 2)
+        let quant = try #require(manifest.quant)
+        #expect(quant.routedExpert.weightBits == 4)
+        #expect(quant.attention.weightBits == 4)
+        #expect(quant.embedding.weightBits == 4)
+        #expect(quant.routedExpert.groupSize == 64)
+        #expect(quant.routedExpert.scheme.lowercased() == "affine")
+        #expect(manifest.expertsPerLayer == 256)
+    }
+}
+
+extension InklingInstalledModelTests {
+    /// Bring-up probe: CPU-decode the scales/biases of the L2 attention
+    /// projections straight from the resident file. Run with
+    /// MFERENCE_INKLING_GTURBO pointing at a real install.
+    @Test func dumpWqDuScales() throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"] else { return }
+        let ctx = try MetalContext()
+        let expected = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: expected)
+        for (label, view) in [
+            ("wq_du", try model.inklingWqDu(layer: 2)),
+            ("wk_dv", try model.inklingWkDv(layer: 2)),
+            ("wo_ud", try model.inklingWoUd(layer: 2)),
+        ] {
+            print("[dump] \(label) off=\(view.offset) len=\(view.length) "
+                + "scaleOff=\(view.scaleOffset) scaleLen=\(view.scaleLength) "
+                + "biasOff=\(view.biasOffset) biasLen=\(view.biasLength) "
+                + "dtype=\(view.dtype) shape=\(view.shape)")
+            let scaleCount = Int(view.scaleLength) / 2
+            let sp = view.buffer.contents().advanced(by: Int(view.scaleOffset))
+                .assumingMemoryBound(to: UInt16.self)
+            var bad = 0
+            var mx: Float = 0
+            for i in 0..<scaleCount {
+                let v = Quantization.bf16ToFloat(sp[i])
+                if !v.isFinite { bad += 1 } else { mx = max(mx, abs(v)) }
+            }
+            let first = (0..<8).map { Quantization.bf16ToFloat(sp[$0]) }
+            print("[dump] \(label) scales n=\(scaleCount) nonfinite=\(bad) "
+                + "maxAbs=\(mx) first=\(first)")
+        }
+        for L in [7, 20, 28] {
+            for (name, view) in [
+                ("attn_sconv", try model.inklingAttnSconv(layer: L)),
+                ("mlp_sconv", try model.inklingMlpSconv(layer: L)),
+                ("k_sconv", try model.inklingKSconv(layer: L)),
+            ] {
+                let n = Int(view.length) / 2
+                let p = view.buffer.contents().advanced(by: Int(view.offset))
+                    .assumingMemoryBound(to: UInt16.self)
+                var mx: Float = 0
+                var sum: Float = 0
+                for i in 0..<n {
+                    let v = Quantization.bf16ToFloat(p[i])
+                    mx = max(mx, abs(v)); sum += abs(v)
+                }
+                print("[taps] L\(L) \(name) n=\(n) maxAbs=\(mx) meanAbs=\(sum / Float(n)) "
+                    + "first8=\((0..<8).map { Quantization.bf16ToFloat(p[$0]) })")
+            }
+        }
+    }
+}

--- a/Tests/Mference/Core/Infrastructure/ModelIO/ModelTypesTests.swift
+++ b/Tests/Mference/Core/Infrastructure/ModelIO/ModelTypesTests.swift
@@ -24,6 +24,66 @@ import Foundation
         }
     }
 
+    /// Pins the baseline against `pipenetwork/Inkling-Small-MLX-4bit`
+    /// revision `9d6e4720` `config.json -> text_config`.
+    @Test func archConfigInklingSmallBaselineMatchesCheckpoint() {
+        let a = ArchConfig.inklingSmall_276B_A12B
+        #expect(a.hiddenSize == 4096)
+        #expect(a.numLayers == 42)
+        #expect(a.vocabSize == 201024)
+        #expect(a.numHeads == 32)
+        #expect(a.numKVHeads == 8)
+        #expect(a.headDim == 128)
+        #expect(a.slidingWindow == 512)
+        #expect(a.numExperts == 256)
+        #expect(a.topKExperts == 6)
+        #expect(a.moeIntermediateSize == 2048)
+        #expect(a.tieWordEmbeddings == false)
+
+        // Position is carried entirely by the learned relative bias, so the
+        // RoPE knobs must stay zeroed or the attention path would apply both.
+        #expect(a.ropeTheta == 0.0)
+        #expect(a.partialRotaryFactor == 0.0)
+        #expect(a.relativePosition.dRel == 16)
+        #expect(a.relativePosition.extent == 1024)
+        #expect(a.relativePosition.projDim == 512)
+        #expect(a.relativePosition.logScalingFloor == 128_000)
+
+        #expect(a.sconvKernelSize == 4)
+        #expect(a.numSharedExperts == 2)
+        #expect(a.sharedExpertSink == true)
+        #expect(a.numDenseLayers == 2)
+        #expect(a.denseIntermediateSize == 16_384)
+        #expect(a.embedNormEnabled == true)
+        #expect(a.logitsWidthMultiplier == 16.0)
+        // Per-head RMS-normalized q/k: scale is 1/d, not 1/sqrt(d).
+        #expect(a.attentionScale == 1.0 / 128.0)
+        #expect(a.unpaddedVocabSize == 200_058)
+        #expect(a.routerScoringFunc == "sigmoid")
+        #expect(a.routedScalingFactor == 8.0)
+        #expect(a.routerGateBias == true)
+        #expect(a.routerNormAfterTopK == true)
+        #expect(a.routerGlobalScale == true)
+
+        // `local_layer_ids` lists every layer except 5, 11, 17, 23, 29, 35, 41.
+        #expect(a.fullAttentionLayerMask.count == 42)
+        let localIDs: Set<Int> = [
+            0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 18, 19, 20, 21,
+            22, 24, 25, 26, 27, 28, 30, 31, 32, 33, 34, 36, 37, 38, 39, 40]
+        for L in 0..<42 {
+            let expected: UInt8 = localIDs.contains(L) ? 0 : 1
+            #expect(a.fullAttentionLayerMask[L] == expected,
+                    "layer \(L) attention kind")
+        }
+        #expect(a.fullAttentionLayerMask.reduce(0) { $0 + Int($1) } == 7)
+    }
+
+    @Test func inklingSmallIsRegisteredForAutoDetection() {
+        #expect(ArchConfig.knownArchitectures[.inklingSmall]?.family
+                == .inklingSmall)
+        #expect(ModelFamily(rawValue: "inklingSmall") == .inklingSmall)
+    }
+
     @Test func modelErrorDescriptionsContainKeyFacts() {
         let e1 = ModelError.archMismatch(field: "hiddenSize", expected: "2816", actual: "4096")
         #expect(e1.description.contains("2816") && e1.description.contains("4096"))

--- a/Tests/Mference/Core/Kernels/Inkling/InklingKernelTests.swift
+++ b/Tests/Mference/Core/Kernels/Inkling/InklingKernelTests.swift
@@ -1,0 +1,306 @@
+import Foundation
+import Metal
+import Testing
+@testable import Mference
+import MferenceValidationSupport
+
+/// CPU-reference parity tests for the Inkling family kernels. The references
+/// implement the semantics transcribed from the checkpoint's `inkling_mlx`
+/// package (docs/INKLING_SMALL.md "Forward-pass contract"); every kernel is
+/// validated on random data before it touches real weights.
+@Suite struct InklingKernelTests {
+
+    private static func makeKernels(_ context: MetalContext) throws -> InklingKernels {
+        try InklingKernels(context: context, numRouted: 256, numShared: 2)
+    }
+
+    private static func randomHalf(_ n: Int, _ rng: inout SplitMix64,
+                                   scale: Float = 1.0) -> [Float16] {
+        (0..<n).map { _ in Float16(rng.uniform(0, 1) * 2 * scale - scale) }
+    }
+
+    private static func bf16(_ v: Float) -> UInt16 {
+        UInt16(truncatingIfNeeded: v.bitPattern >> 16)
+    }
+    private static func bf16ToFloat(_ b: UInt16) -> Float {
+        Float(bitPattern: UInt32(b) << 16)
+    }
+
+    private static func buffer<T>(_ device: MTLDevice, _ values: [T]) -> MTLBuffer {
+        values.withUnsafeBytes { raw in
+            device.makeBuffer(bytes: raw.baseAddress!, length: raw.count,
+                              options: .storageModeShared)!
+        }
+    }
+
+    private static func run(_ context: MetalContext,
+                            _ body: (MTLCommandBuffer) -> Void) {
+        let cb = context.queue.makeCommandBuffer()!
+        body(cb)
+        cb.commit()
+        cb.waitUntilCompleted()
+    }
+
+    // MARK: - Short convolution
+
+    /// Streams a random sequence one step at a time through the kernel and
+    /// compares each step against a full causal depthwise conv (+ residual)
+    /// computed on the CPU — this covers both the tap math and the state
+    /// shifting across steps.
+    @Test func sconvStepMatchesCausalConvAcrossSteps() throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        var rng = SplitMix64(seed: 0x11C_0001)
+        let C = 96, K = 4, steps = 7
+
+        let wF: [Float] = (0..<C * K).map { _ in rng.uniform(0, 1) - 0.5 }
+        let wBuf = Self.buffer(context.device, wF.map(Self.bf16))
+        let stateBuf = context.device.makeBuffer(
+            length: C * (K - 1) * MemoryLayout<Float>.size,
+            options: .storageModeShared)!
+        memset(stateBuf.contents(), 0, stateBuf.length)
+
+        let xs: [[Float16]] = (0..<steps).map { _ in Self.randomHalf(C, &rng) }
+        let outBuf = context.device.makeBuffer(
+            length: C * MemoryLayout<Float16>.size, options: .storageModeShared)!
+
+        for t in 0..<steps {
+            let xBuf = Self.buffer(context.device, xs[t])
+            Self.run(context) { cb in
+                kernels.encodeSconvStep(commandBuffer: cb,
+                                        x: xBuf, state: stateBuf,
+                                        weight: wBuf, weightOffset: 0,
+                                        out: outBuf,
+                                        channels: UInt32(C), kernelSize: UInt32(K))
+            }
+            let got = outBuf.contents().bindMemory(to: Float16.self, capacity: C)
+            for c in 0..<C {
+                // Reference: causal conv over the sequence with zero left pad,
+                // taps applied oldest-input-first, plus the residual.
+                var acc = Float(0)
+                for j in 0..<K {
+                    let src = t - (K - 1) + j
+                    let xv = src >= 0 ? Float(xs[src][c]) : 0
+                    acc += Self.bf16ToFloat(Self.bf16(wF[c * K + j])) * xv
+                }
+                let expected = acc + Float(xs[t][c])
+                #expect(abs(Float(got[c]) - expected) < 2e-2,
+                        "step \(t) channel \(c): got \(Float(got[c])), want \(expected)")
+            }
+        }
+    }
+
+    // MARK: - Q/K per-head RMS norm
+
+    @Test func qkNormMatchesReference() throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        var rng = SplitMix64(seed: 0xBEEF_0002)
+        let HD = 128, NQ = 4, NKV = 2
+        let eps: Float = 1e-6
+
+        let q = Self.randomHalf(NQ * HD, &rng, scale: 2)
+        let k = Self.randomHalf(NKV * HD, &rng, scale: 2)
+        let qw: [Float] = (0..<HD).map { _ in rng.uniform(0, 1) + 0.5 }
+        let kw: [Float] = (0..<HD).map { _ in rng.uniform(0, 1) + 0.5 }
+
+        let qBuf = Self.buffer(context.device, q)
+        let kBuf = Self.buffer(context.device, k)
+        Self.run(context) { cb in
+            kernels.encodeQKNorm(commandBuffer: cb,
+                                 q: qBuf, k: kBuf, kOffset: 0,
+                                 qWeight: Self.buffer(context.device, qw.map(Self.bf16)),
+                                 qWeightOffset: 0,
+                                 kWeight: Self.buffer(context.device, kw.map(Self.bf16)),
+                                 kWeightOffset: 0,
+                                 headDim: UInt32(HD), numQHeads: UInt32(NQ),
+                                 numKVHeads: UInt32(NKV), eps: eps)
+        }
+
+        func check(_ buf: MTLBuffer, _ src: [Float16], _ w: [Float], heads: Int, label: String) {
+            let got = buf.contents().bindMemory(to: Float16.self, capacity: heads * HD)
+            for h in 0..<heads {
+                var ss = Float(0)
+                for i in 0..<HD { ss += Float(src[h * HD + i]) * Float(src[h * HD + i]) }
+                let inv = 1.0 / (ss / Float(HD) + eps).squareRoot()
+                for i in 0..<HD {
+                    let expected = Float(src[h * HD + i]) * inv
+                        * Self.bf16ToFloat(Self.bf16(w[i]))
+                    #expect(abs(Float(got[h * HD + i]) - expected) < 1.5e-2,
+                            "\(label) head \(h) elem \(i)")
+                }
+            }
+        }
+        check(qBuf, q, qw, heads: NQ, label: "q")
+        check(kBuf, k, kw, heads: NKV, label: "k")
+    }
+
+    // MARK: - Attention with relative-position bias
+
+    private static func attentionReference(
+        q: [Float16], k: [Float16], v: [Float16], rel: [Float16], proj: [Float],
+        HD: Int, NQ: Int, NKV: Int, seqLen: Int, kvStart: Int,
+        relExtent: Int, dRel: Int, ringCap: Int,
+        scale: Float, tau: Float) -> [Float] {
+        var out = [Float](repeating: 0, count: NQ * HD)
+        let qPos = seqLen - 1
+        for h in 0..<NQ {
+            let kvHead = h / (NQ / NKV)
+            var logits: [Float] = []
+            for p in kvStart..<seqLen {
+                let phys = ringCap > 0 ? p % ringCap : p
+                var qk = Float(0)
+                for i in 0..<HD {
+                    qk += Float(q[h * HD + i]) * Float(k[(phys * NKV + kvHead) * HD + i])
+                }
+                var bias = Float(0)
+                let dist = qPos - p
+                if dist < relExtent {
+                    for i in 0..<dRel {
+                        bias += Float(rel[h * dRel + i])
+                            * Self.bf16ToFloat(Self.bf16(proj[i * relExtent + dist]))
+                    }
+                }
+                logits.append(tau * (qk * scale + bias))
+            }
+            let mx = logits.max() ?? 0
+            let exps = logits.map { expf($0 - mx) }
+            let denom = exps.reduce(0, +)
+            for (idx, p) in (kvStart..<seqLen).enumerated() {
+                let phys = ringCap > 0 ? p % ringCap : p
+                let w = exps[idx] / denom
+                for i in 0..<HD {
+                    out[h * HD + i] += w * Float(v[(phys * NKV + kvHead) * HD + i])
+                }
+            }
+        }
+        return out
+    }
+
+    @Test(arguments: [
+        // (seqLen, kvStart, relExtent, ringCap, tau) — full layer, short ctx
+        (9, 0, 16, 0, Float(1.0)),
+        // full layer with log-scaling active
+        (12, 0, 16, 0, Float(1.37)),
+        // sliding layer with ring wrap: window 8 over 21 tokens, ring cap 8
+        (21, 13, 8, 8, Float(1.0)),
+    ] as [(Int, Int, Int, Int, Float)])
+    func attentionDecodeMatchesReference(
+        _ arg: (seqLen: Int, kvStart: Int, relExtent: Int, ringCap: Int, tau: Float)
+    ) throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        var rng = SplitMix64(seed: 0xA77E_0003 &+ UInt64(arg.seqLen))
+        let HD = 64, NQ = 4, NKV = 2, dRel = 16
+        let scale = 1.0 / Float(HD)
+        let slots = arg.ringCap > 0 ? arg.ringCap : arg.seqLen
+
+        let q = Self.randomHalf(NQ * HD, &rng)
+        let k = Self.randomHalf(slots * NKV * HD, &rng)
+        let v = Self.randomHalf(slots * NKV * HD, &rng)
+        let rel = Self.randomHalf(NQ * dRel, &rng)
+        let proj: [Float] = (0..<dRel * arg.relExtent).map { _ in
+            rng.uniform(0, 1) - 0.5
+        }
+
+        let outBuf = context.device.makeBuffer(
+            length: NQ * HD * MemoryLayout<Float16>.size, options: .storageModeShared)!
+        Self.run(context) { cb in
+            kernels.encodeAttentionDecode(
+                commandBuffer: cb,
+                q: Self.buffer(context.device, q),
+                k: Self.buffer(context.device, k),
+                v: Self.buffer(context.device, v),
+                rel: Self.buffer(context.device, rel),
+                proj: Self.buffer(context.device, proj.map(Self.bf16)), projOffset: 0,
+                out: outBuf,
+                headDim: UInt32(HD), numQHeads: UInt32(NQ), numKVHeads: UInt32(NKV),
+                seqLen: UInt32(arg.seqLen), kvStart: UInt32(arg.kvStart),
+                relExtent: UInt32(arg.relExtent), dRel: UInt32(dRel),
+                ringCapacity: UInt32(arg.ringCap),
+                scale: scale, tau: arg.tau)
+        }
+
+        let expected = Self.attentionReference(
+            q: q, k: k, v: v, rel: rel, proj: proj,
+            HD: HD, NQ: NQ, NKV: NKV, seqLen: arg.seqLen, kvStart: arg.kvStart,
+            relExtent: arg.relExtent, dRel: dRel, ringCap: arg.ringCap,
+            scale: scale, tau: arg.tau)
+        let got = outBuf.contents().bindMemory(to: Float16.self, capacity: NQ * HD)
+        for i in 0..<NQ * HD {
+            #expect(abs(Float(got[i]) - expected[i]) < 2e-2,
+                    "elem \(i): got \(Float(got[i])), want \(expected[i])")
+        }
+    }
+
+    // MARK: - Sigmoid router
+
+    @Test func routerSelectMatchesReference() throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        var rng = SplitMix64(seed: 0x60D_0004)
+        let nRouted = 256, nShared = 2, topK = 6
+        let routeScale: Float = 8.0
+        let globalScale: Float = 1.25
+
+        for trial in 0..<8 {
+            let logits: [Float] = (0..<nRouted + nShared).map { _ in
+                rng.uniform(0, 1) * 8 - 4
+            }
+            let bias: [Float] = (0..<nRouted).map { _ in
+                rng.uniform(0, 1) * 0.5 - 0.25
+            }
+            // GEMV is exercised separately; feed logits directly by writing
+            // into the kernel's logits buffer and encoding only the select.
+            kernels.routerLogits.contents().copyMemory(
+                from: logits, byteCount: logits.count * 4)
+
+            let outIdx = context.device.makeBuffer(length: topK * 4,
+                                                   options: .storageModeShared)!
+            let outW = context.device.makeBuffer(length: topK * 2,
+                                                 options: .storageModeShared)!
+            Self.run(context) { cb in
+                kernels.encodeRouterSelectOnly(
+                    commandBuffer: cb,
+                    gateBias: Self.buffer(context.device, bias), gateBiasOffset: 0,
+                    globalScale: Self.buffer(context.device, [globalScale]),
+                    globalScaleOffset: 0,
+                    outIndices: outIdx, outWeights: outW,
+                    numRouted: UInt32(nRouted), numShared: UInt32(nShared),
+                    topK: UInt32(topK), routeScale: routeScale)
+            }
+
+            // CPU reference.
+            let scores = (0..<nRouted).map { 1 / (1 + expf(-logits[$0])) + bias[$0] }
+            let refIdx = scores.enumerated()
+                .sorted { $0.element > $1.element }.prefix(topK).map(\.offset)
+            func logsigmoid(_ x: Float) -> Float { min(x, 0) - log1pf(expf(-abs(x))) }
+            let sel = refIdx.map { logsigmoid(logits[$0]) }
+                + (0..<nShared).map { logsigmoid(logits[nRouted + $0]) }
+            let mx = sel.max()!
+            let exps = sel.map { expf($0 - mx) }
+            let denom = exps.reduce(0, +)
+            let refWeights = exps.map { $0 / denom * routeScale * globalScale }
+
+            let gotIdx = outIdx.contents().bindMemory(to: UInt32.self, capacity: topK)
+            let gotW = outW.contents().bindMemory(to: Float16.self, capacity: topK)
+            let gotGammas = kernels.sharedGammas.contents()
+                .bindMemory(to: Float.self, capacity: nShared)
+
+            #expect(Set((0..<topK).map { Int(gotIdx[$0]) }) == Set(refIdx),
+                    "trial \(trial) expert set")
+            // Weights follow the kernel's index order; compare via lookup.
+            var refByIdx: [Int: Float] = [:]
+            for (i, e) in refIdx.enumerated() { refByIdx[e] = refWeights[i] }
+            for i in 0..<topK {
+                let e = Int(gotIdx[i])
+                #expect(abs(Float(gotW[i]) - (refByIdx[e] ?? -1)) < 1e-2,
+                        "trial \(trial) weight for expert \(e)")
+            }
+            for s in 0..<nShared {
+                #expect(abs(gotGammas[s] - refWeights[topK + s]) < 1e-3,
+                        "trial \(trial) gamma \(s)")
+            }
+        }
+    }
+}

--- a/Tests/Mference/Core/Runtime/InklingLayerParityTests.swift
+++ b/Tests/Mference/Core/Runtime/InklingLayerParityTests.swift
@@ -820,3 +820,39 @@ extension InklingLayerParityTests {
         print("[stage] dumped to \(outDir)")
     }
 }
+
+extension InklingLayerParityTests {
+    /// Teacher-forced logits dump for the KLD eval: feeds the token list in
+    /// MFERENCE_KLD_IDS through produce() and appends each position's logits
+    /// (unpadded vocab, f32) to MFERENCE_KLD_OUT.
+    @Test func teacherForcedLogitsDump() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            let idsPath = ProcessInfo.processInfo.environment["MFERENCE_KLD_IDS"],
+            let outPath = ProcessInfo.processInfo.environment["MFERENCE_KLD_OUT"]
+        else { return }
+        let idsData = try Data(contentsOf: URL(fileURLWithPath: idsPath))
+        let ids = try JSONDecoder().decode([Int32].self, from: idsData)
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 4096)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        let valid = cfg.unpaddedVocabSize
+        FileManager.default.createFile(atPath: outPath, contents: nil)
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: outPath))
+        for (p, t) in ids.enumerated() {
+            try await runner.produce(token: t, position: p, into: logits)
+            let lp = logits.contents().bindMemory(to: Float16.self, capacity: valid)
+            let row = (0..<valid).map { Float(lp[$0]) }
+            row.withUnsafeBytes { handle.write(Data($0)) }
+        }
+        try handle.close()
+        print("[kld] wrote \(ids.count) x \(valid) logits to \(outPath)")
+    }
+}

--- a/Tests/Mference/Core/Runtime/InklingLayerParityTests.swift
+++ b/Tests/Mference/Core/Runtime/InklingLayerParityTests.swift
@@ -856,3 +856,41 @@ extension InklingLayerParityTests {
         print("[kld] wrote \(ids.count) x \(valid) logits to \(outPath)")
     }
 }
+
+extension InklingLayerParityTests {
+    /// Conv-state lifecycle: `reset()` clears the short-conv history (it dies
+    /// with the KV cache), but `prepareForContinuation` must PRESERVE it —
+    /// the retained KV prefix and the conv history describe the same cached
+    /// tokens (PR #4 review, Codex P1).
+    @Test func convStateSurvivesContinuationButNotReset() throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"] else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        func fillSentinel() {
+            for st in runner.inklingConvStates {
+                for b in [st.k, st.v, st.attn, st.mlp] {
+                    memset(b.contents(), 0x3C, b.length)
+                }
+            }
+        }
+        func firstWord() -> UInt32 {
+            runner.inklingConvStates[0].k.contents().load(as: UInt32.self)
+        }
+        // reset() zeroes.
+        fillSentinel()
+        runner.reset()
+        #expect(firstWord() == 0, "reset() must clear conv history")
+        // continuation preserves.
+        fillSentinel()
+        runner.inklingParityAdvanceKV()   // kv.position = 1
+        try runner.prepareForContinuation(expectedPosition: 1)
+        #expect(firstWord() == 0x3C3C_3C3C,
+                "prepareForContinuation must keep conv history")
+    }
+}

--- a/Tests/Mference/Core/Runtime/InklingLayerParityTests.swift
+++ b/Tests/Mference/Core/Runtime/InklingLayerParityTests.swift
@@ -1,0 +1,822 @@
+import Testing
+import Foundation
+import Metal
+@testable import Mference
+
+/// CPU cross-check of the Inkling GPU forward pass against the real
+/// installed weights, one layer at a time. Scalar reference implements the
+/// contract in docs/INKLING_SMALL.md directly from the resident tensors;
+/// the GPU side runs `produce()` with MFERENCE_INKLING_STOP_LAYER so the
+/// scratch buffers stay inspectable at the boundary.
+///
+/// Env-gated on MFERENCE_INKLING_GTURBO (and the stop layer set by the test
+/// runner command line); skipped otherwise.
+@Suite struct InklingLayerParityTests {
+
+    // MARK: - CPU reference primitives
+
+    private static func bf16(_ bits: UInt16) -> Float { Quantization.bf16ToFloat(bits) }
+
+    /// Dequantized row `r` of an INT4 affine [m, n] tensor.
+    private static func dequantRow(_ v: TensorView, row: Int, n: Int) -> [Float] {
+        let base = v.buffer.contents()
+        let wRow = base.advanced(by: Int(v.offset) + row * n / 2)
+            .assumingMemoryBound(to: UInt8.self)
+        let sRow = base.advanced(by: Int(v.scaleOffset) + row * (n / 64) * 2)
+            .assumingMemoryBound(to: UInt16.self)
+        let bRow = base.advanced(by: Int(v.biasOffset) + row * (n / 64) * 2)
+            .assumingMemoryBound(to: UInt16.self)
+        var out = [Float](repeating: 0, count: n)
+        for g in 0..<(n / 64) {
+            let scale = bf16(sRow[g]), bias = bf16(bRow[g])
+            for k in 0..<64 {
+                let b = wRow[g * 32 + k / 2]
+                let nib = (k & 1) == 0 ? Int(b & 0x0F) : Int(b >> 4)
+                out[g * 64 + k] = Float(nib) * scale + bias
+            }
+        }
+        return out
+    }
+
+    private static func gemv(_ v: TensorView, x: [Float], m: Int, n: Int) -> [Float] {
+        var y = [Float](repeating: 0, count: m)
+        for r in 0..<m {
+            let w = dequantRow(v, row: r, n: n)
+            var acc: Float = 0
+            for i in 0..<n { acc += w[i] * x[i] }
+            y[r] = acc
+        }
+        return y
+    }
+
+    private static func rms(_ x: [Float], _ w: TensorView, eps: Float = 1e-6) -> [Float] {
+        let wp = w.buffer.contents().advanced(by: Int(w.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        var ss: Float = 0
+        for v in x { ss += v * v }
+        let inv = 1.0 / (ss / Float(x.count) + eps).squareRoot()
+        return (0..<x.count).map { x[$0] * inv * bf16(wp[$0]) }
+    }
+
+    private static func perHeadRMS(_ x: [Float], heads: Int, hd: Int,
+                                   _ w: TensorView, eps: Float = 1e-6) -> [Float] {
+        let wp = w.buffer.contents().advanced(by: Int(w.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        var out = x
+        for h in 0..<heads {
+            var ss: Float = 0
+            for i in 0..<hd { ss += x[h * hd + i] * x[h * hd + i] }
+            let inv = 1.0 / (ss / Float(hd) + eps).squareRoot()
+            for i in 0..<hd { out[h * hd + i] = x[h * hd + i] * inv * bf16(wp[i]) }
+        }
+        return out
+    }
+
+    /// Zero-state sconv step: out = taps[K-1]*x + x (history is zero).
+    private static func sconvZeroState(_ x: [Float], _ w: TensorView, k: Int) -> [Float] {
+        let wp = w.buffer.contents().advanced(by: Int(w.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        return (0..<x.count).map { c in
+            x[c] * bf16(wp[c * k + (k - 1)]) + x[c]
+        }
+    }
+
+    private static func readF16(_ b: MTLBuffer, _ n: Int) -> [Float] {
+        let p = b.contents().bindMemory(to: Float16.self, capacity: n)
+        return (0..<n).map { Float(p[$0]) }
+    }
+    private static func readF32(_ b: MTLBuffer, _ n: Int) -> [Float] {
+        let p = b.contents().bindMemory(to: Float.self, capacity: n)
+        return (0..<n).map { p[$0] }
+    }
+
+    private static func compare(_ label: String, gpu: [Float], cpu: [Float],
+                                tol: Float) -> Bool {
+        var dot: Float = 0, ng: Float = 0, nc: Float = 0
+        var maxAbsDiff: Float = 0
+        for i in 0..<gpu.count {
+            dot += gpu[i] * cpu[i]; ng += gpu[i] * gpu[i]; nc += cpu[i] * cpu[i]
+            maxAbsDiff = max(maxAbsDiff, abs(gpu[i] - cpu[i]))
+        }
+        let cos = dot / (ng.squareRoot() * nc.squareRoot() + 1e-20)
+        print("[parity] \(label): cos=\(cos) maxAbsDiff=\(maxAbsDiff) "
+            + "gpuNorm=\(ng.squareRoot()) cpuNorm=\(nc.squareRoot())")
+        return cos > tol
+    }
+
+    // MARK: - Layer 0 (dense) parity, token 0
+
+    @Test func layer0DenseParity() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            RealForwardRunner.inklingStopLayer == 0 else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        let token: Int32 = 3575   // "The"
+        try await runner.produce(token: token, position: 0, into: logits)
+
+        let D = cfg.hiddenSize
+        let HD = cfg.headDim, NQ = cfg.numHeads, NKV = cfg.numKVHeads
+        let K = cfg.sconvKernelSize
+
+        // CPU reference, layer 0.
+        let embedRow = Self.dequantRow(model.embedding, row: Int(token), n: D)
+        let h0 = Self.rms(embedRow, model.embedNorm)
+        let normed = Self.rms(h0, try model.inputNorm(layer: 0))
+        #expect(Self.compare("L0 normed", gpu: Self.readF16(runner.normed, D),
+                             cpu: normed, tol: 0.999))
+
+        let qRaw = Self.gemv(try model.inklingWqDu(layer: 0), x: normed,
+                             m: NQ * HD, n: D)
+        let kRaw = Self.gemv(try model.inklingWkDv(layer: 0), x: normed,
+                             m: NKV * HD, n: D)
+        let vRaw = Self.gemv(try model.inklingWvDv(layer: 0), x: normed,
+                             m: NKV * HD, n: D)
+        let kConv = Self.sconvZeroState(kRaw, try model.inklingKSconv(layer: 0), k: K)
+        let vConv = Self.sconvZeroState(vRaw, try model.inklingVSconv(layer: 0), k: K)
+        let q = Self.perHeadRMS(qRaw, heads: NQ, hd: HD,
+                                try model.inklingQNorm(layer: 0))
+        _ = Self.perHeadRMS(kConv, heads: NKV, hd: HD,
+                            try model.inklingKNorm(layer: 0))
+        #expect(Self.compare("L0 q(post-norm)",
+                             gpu: Self.readF16(runner.qScratch, NQ * HD),
+                             cpu: q, tol: 0.999))
+
+        // Position 0 attention: softmax over one key == that key's V row
+        // (per kv head, replicated over its 4 query heads).
+        var attnOut = [Float](repeating: 0, count: NQ * HD)
+        for h in 0..<NQ {
+            let kvh = h / (NQ / NKV)
+            for i in 0..<HD { attnOut[h * HD + i] = vConv[kvh * HD + i] }
+        }
+        #expect(Self.compare("L0 attnOut",
+                             gpu: Self.readF16(runner.attnOut, NQ * HD),
+                             cpu: attnOut, tol: 0.999))
+
+        let oOut = Self.gemv(try model.inklingWoUd(layer: 0), x: attnOut,
+                             m: D, n: NQ * HD)
+        #expect(Self.compare("L0 oOut", gpu: Self.readF16(runner.oOut, D),
+                             cpu: oOut, tol: 0.999))
+
+        let attnDelta = Self.sconvZeroState(oOut, try model.inklingAttnSconv(layer: 0), k: K)
+        var hidden1 = (0..<D).map { h0[$0] + attnDelta[$0] }
+
+        // Dense MLP.
+        let routedX = Self.rms(hidden1, try model.postAttnNorm(layer: 0))
+        #expect(Self.compare("L0 routedX",
+                             gpu: Self.readF16(runner.routedX, D),
+                             cpu: routedX, tol: 0.999))
+        let FD = cfg.denseIntermediateSize
+        let g = Self.gemv(try model.inklingDenseGate(layer: 0), x: routedX,
+                          m: FD, n: D)
+        let u = Self.gemv(try model.inklingDenseUp(layer: 0), x: routedX,
+                          m: FD, n: D)
+        var act = [Float](repeating: 0, count: FD)
+        for i in 0..<FD { act[i] = g[i] / (1 + exp(-g[i])) * u[i] }
+        var mlp = Self.gemv(try model.inklingDenseDown(layer: 0), x: act,
+                            m: D, n: FD)
+        let gain = model.inklingScalar(try model.inklingDenseGlobalScale(layer: 0))
+        for i in 0..<D { mlp[i] *= gain }
+        let mlpDelta = Self.sconvZeroState(mlp, try model.inklingMlpSconv(layer: 0), k: K)
+        for i in 0..<D { hidden1[i] += mlpDelta[i] }
+
+        #expect(Self.compare("L0 hidden(final)",
+                             gpu: Self.readF32(runner.inklingHiddenF32!, D),
+                             cpu: hidden1, tol: 0.999))
+    }
+}
+
+extension InklingLayerParityTests {
+    /// Layer-2 (first MoE) parity for token 0: router selection + weights,
+    /// shared-expert combine, routed experts from the streamed blob, and the
+    /// final residual. Requires MFERENCE_INKLING_STOP_LAYER=2.
+    @Test func layer2MoEParity() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            RealForwardRunner.inklingStopLayer == 2 else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        try await runner.produce(token: 3575, position: 0, into: logits)
+
+        let D = cfg.hiddenSize
+        let F = cfg.moeIntermediateSize
+
+        // GPU state at the layer-2 boundary.
+        let routedX = Self.readF16(runner.routedX, D)
+        let gpuIdx = runner.outIndices.contents()
+            .bindMemory(to: UInt32.self, capacity: 6)
+        let gpuW = Self.readF16(runner.outWeights, 8)
+        let gammas = Self.readF32(runner.inkling!.sharedGammas, 2)
+
+        // --- CPU router over the same routedX (fp32).
+        let routerW = try model.router(layer: 2)
+        let wp = routerW.buffer.contents().advanced(by: Int(routerW.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        var logitsR = [Float](repeating: 0, count: 258)
+        for e in 0..<258 {
+            var acc: Float = 0
+            for i in 0..<D { acc += Self.bf16(wp[e * D + i]) * routedX[i] }
+            logitsR[e] = acc
+        }
+        let biasV = try model.inklingGateBias(layer: 2)
+        let bp = biasV.buffer.contents().advanced(by: Int(biasV.offset))
+            .assumingMemoryBound(to: Float.self)
+        let scores = (0..<256).map { 1 / (1 + exp(-logitsR[$0])) + bp[$0] }
+        let refIdx = scores.enumerated().sorted { $0.element > $1.element }
+            .prefix(6).map(\.offset)
+        func logsigmoid(_ x: Float) -> Float { min(x, 0) - log(1 + exp(-abs(x))) }
+        let sel = refIdx.map { logsigmoid(logitsR[$0]) }
+            + [logsigmoid(logitsR[256]), logsigmoid(logitsR[257])]
+        let mx = sel.max()!
+        let exps = sel.map { expf($0 - mx) }
+        let denom = exps.reduce(0, +)
+        let gScale = model.inklingScalar(try model.inklingGateGlobalScale(layer: 2))
+        let refW = exps.map { $0 / denom * 8.0 * gScale }
+        print("[parity] L2 router idx gpu=\((0..<6).map { Int(gpuIdx[$0]) }) cpu=\(refIdx)")
+        print("[parity] L2 router w gpu=\(gpuW) cpu=\(refW) gammas gpu=\(gammas)")
+        #expect(Set((0..<6).map { Int(gpuIdx[$0]) }) == Set(refIdx))
+
+        // --- CPU shared experts + routed experts.
+        func switchGLU(_ gate: TensorView, _ up: TensorView, _ down: TensorView,
+                       x: [Float]) -> [Float] {
+            let g = Self.gemv(gate, x: x, m: F, n: D)
+            let u = Self.gemv(up, x: x, m: F, n: D)
+            var act = [Float](repeating: 0, count: F)
+            for i in 0..<F { act[i] = g[i] / (1 + exp(-g[i])) * u[i] }
+            return Self.gemv(down, x: act, m: D, n: F)
+        }
+        var cpuOut = [Float](repeating: 0, count: D)
+        for s in 0..<2 {
+            let y = switchGLU(
+                try model.inklingSharedExpert("gate_proj", layer: 2, expert: s, of: 2),
+                try model.inklingSharedExpert("up_proj", layer: 2, expert: s, of: 2),
+                try model.inklingSharedExpert("down_proj", layer: 2, expert: s, of: 2),
+                x: routedX)
+            for i in 0..<D { cpuOut[i] += refW[6 + s] * y[i] }
+        }
+        #expect(Self.compare("L2 shared(h1)", gpu: Self.readF16(runner.h1Buf, D),
+                             cpu: cpuOut, tol: 0.995))
+
+        let offs = model.routedExpertOffsets(layer: 2)
+        let blobs = try await model.fetchRoutedExperts(
+            layer: 2, experts: (0..<6).map { Int(gpuIdx[$0]) })
+        func blobView(_ blob: TensorView, w: UInt32, s: UInt32, b: UInt32,
+                      m: Int, n: Int) -> TensorView {
+            TensorView(buffer: blob.buffer,
+                       offset: blob.offset + UInt64(w), length: UInt64(m * n / 2),
+                       scaleOffset: blob.offset + UInt64(s),
+                       scaleLength: UInt64(m * n / 64 * 2),
+                       biasOffset: blob.offset + UInt64(b),
+                       biasLength: UInt64(m * n / 64 * 2),
+                       shape: (UInt32(m), UInt32(n), 1, 1), dtype: 0)
+        }
+        for (slot, blob) in blobs.enumerated() {
+            let y = switchGLU(
+                blobView(blob, w: offs.gateWOff, s: offs.gateSOff, b: offs.gateBOff, m: F, n: D),
+                blobView(blob, w: offs.upWOff, s: offs.upSOff, b: offs.upBOff, m: F, n: D),
+                blobView(blob, w: offs.downWOff, s: offs.downSOff, b: offs.downBOff, m: D, n: F),
+                x: routedX)
+            for i in 0..<D { cpuOut[i] += Float(gpuW[slot]) * y[i] }
+        }
+        #expect(Self.compare("L2 moe out(h2)", gpu: Self.readF16(runner.h2Buf, D),
+                             cpu: cpuOut, tol: 0.995))
+    }
+}
+
+extension InklingLayerParityTests {
+    /// Head parity: full 42-layer pass, then CPU logits for probe ids from
+    /// the final normed row. No stop layer.
+    @Test func headParity() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            RealForwardRunner.inklingStopLayer == -1 else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        try await runner.produce(token: 3575, position: 0, into: logits)
+
+        let D = cfg.hiddenSize
+        let normed = Self.readF16(runner.normed, D)
+        // CPU: recompute final norm from the FP32 stream and cross-check.
+        let hiddenF32 = Self.readF32(runner.inklingHiddenF32!, D)
+        let cpuNormed = Self.rms(hiddenF32, model.finalNorm)
+        #expect(Self.compare("final normed", gpu: normed, cpu: cpuNormed,
+                             tol: 0.999))
+
+        let lp = logits.contents().bindMemory(to: Float16.self,
+                                              capacity: cfg.vocabSize)
+        let probeIDs = [0, 2, 410, 877, 12194, 100000, 199999]
+        for id in probeIDs {
+            let row = Self.dequantRow(model.lmHead, row: id, n: D)
+            var acc: Float = 0
+            for i in 0..<D { acc += row[i] * cpuNormed[i] }
+            let cpuLogit = acc / 16.0
+            print("[parity] logit[\(id)]: gpu=\(Float(lp[id])) cpu=\(cpuLogit)")
+        }
+        // Padding tail must be -inf.
+        print("[parity] pad logit[200100]=\(Float(lp[200100])) [201000]=\(Float(lp[201000]))")
+    }
+}
+
+extension InklingLayerParityTests {
+    /// Token-1 parity at layer 0: exercises everything position 0 cannot —
+    /// conv-state carry across tokens, the KV cache, 2-position softmax, and
+    /// (critically) the relative-position bias. Requires
+    /// MFERENCE_INKLING_STOP_LAYER=0.
+    @Test func token1AttentionParity() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            RealForwardRunner.inklingStopLayer == 0 else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        let t0: Int32 = 3575, t1: Int32 = 6746
+        try await runner.produce(token: t0, position: 0, into: logits)
+        // Stop-layer returns early WITHOUT kv.advance(); advance manually so
+        // position 1 lands in the next slot exactly as a full pass would.
+        runner.inklingParityAdvanceKV()
+        try await runner.produce(token: t1, position: 1, into: logits)
+
+        let D = cfg.hiddenSize, HD = cfg.headDim
+        let NQ = cfg.numHeads, NKV = cfg.numKVHeads, K = cfg.sconvKernelSize
+        let dRel = cfg.relativePosition.dRel
+        let scale = Float(cfg.attentionScale)
+
+        func layer0Proj(_ token: Int32) -> (normed: [Float], kRaw: [Float],
+                                            vRaw: [Float], qRaw: [Float],
+                                            rel: [Float], h0: [Float]) {
+            let e = Self.dequantRow(model.embedding, row: Int(token), n: D)
+            let h0 = Self.rms(e, model.embedNorm)
+            let nrm = Self.rms(h0, try! model.inputNorm(layer: 0))
+            return (nrm,
+                    Self.gemv(try! model.inklingWkDv(layer: 0), x: nrm, m: NKV * HD, n: D),
+                    Self.gemv(try! model.inklingWvDv(layer: 0), x: nrm, m: NKV * HD, n: D),
+                    Self.gemv(try! model.inklingWqDu(layer: 0), x: nrm, m: NQ * HD, n: D),
+                    Self.gemv(try! model.inklingWrDu(layer: 0), x: nrm, m: NQ * dRel, n: D),
+                    h0)
+        }
+        let p0 = layer0Proj(t0)
+        let p1 = layer0Proj(t1)
+
+        let kSconv = try model.inklingKSconv(layer: 0)
+        let vSconv = try model.inklingVSconv(layer: 0)
+        let kTaps = kSconv.buffer.contents().advanced(by: Int(kSconv.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        let vTaps = vSconv.buffer.contents().advanced(by: Int(vSconv.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        func conv(_ taps: UnsafePointer<UInt16>, _ prev: [Float]?, _ x: [Float]) -> [Float] {
+            (0..<x.count).map { c in
+                let t2 = Self.bf16(taps[c * K + (K - 2)])
+                let t3 = Self.bf16(taps[c * K + (K - 1)])
+                return (prev.map { t2 * $0[c] } ?? 0) + t3 * x[c] + x[c]
+            }
+        }
+        let k0 = Self.perHeadRMS(conv(kTaps, nil, p0.kRaw), heads: NKV, hd: HD,
+                                 try model.inklingKNorm(layer: 0))
+        let v0 = conv(vTaps, nil, p0.vRaw)
+        let k1 = Self.perHeadRMS(conv(kTaps, p0.kRaw, p1.kRaw), heads: NKV, hd: HD,
+                                 try model.inklingKNorm(layer: 0))
+        let v1 = conv(vTaps, p0.vRaw, p1.vRaw)
+        let q1 = Self.perHeadRMS(p1.qRaw, heads: NQ, hd: HD,
+                                 try model.inklingQNorm(layer: 0))
+        #expect(Self.compare("t1 q(post-norm)",
+                             gpu: Self.readF16(runner.qScratch, NQ * HD),
+                             cpu: q1, tol: 0.999))
+
+        // Attention at q_pos=1 over kv 0..1 with the relative bias.
+        let relProj = try model.inklingRelProj(layer: 0)
+        let projPtr = relProj.buffer.contents().advanced(by: Int(relProj.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        let extent = cfg.slidingWindow   // local layer bias width
+        var attnOut = [Float](repeating: 0, count: NQ * HD)
+        for h in 0..<NQ {
+            let kvh = h / (NQ / NKV)
+            var lg = [Float](repeating: 0, count: 2)
+            for (idx, kv) in [(0, k0), (1, k1)].map({ ($0.0, $0.1) }) {
+                var qk: Float = 0
+                for i in 0..<HD { qk += q1[h * HD + i] * kv[kvh * HD + i] }
+                let dist = 1 - idx
+                var bias: Float = 0
+                for i in 0..<dRel {
+                    bias += p1.rel[h * dRel + i]
+                        * Self.bf16(projPtr[i * extent + dist])
+                }
+                lg[idx] = qk * scale + bias
+            }
+            let m = max(lg[0], lg[1])
+            let e0 = expf(lg[0] - m), e1 = expf(lg[1] - m)
+            let w0 = e0 / (e0 + e1), w1 = e1 / (e0 + e1)
+            for i in 0..<HD {
+                attnOut[h * HD + i] = w0 * v0[kvh * HD + i] + w1 * v1[kvh * HD + i]
+            }
+        }
+        #expect(Self.compare("t1 attnOut",
+                             gpu: Self.readF16(runner.attnOut, NQ * HD),
+                             cpu: attnOut, tol: 0.999))
+    }
+}
+
+extension InklingLayerParityTests {
+    /// Global-layer (L5) attention isolation: takes the GPU's own q/k/v/rel
+    /// at the stop boundary and CPU-computes the expected attention output
+    /// with global semantics (extent 1024, no window). Requires
+    /// MFERENCE_INKLING_STOP_LAYER=5.
+    @Test func layer5GlobalAttentionParity() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            RealForwardRunner.inklingStopLayer == 5 else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        try await runner.produce(token: 976, position: 0, into: logits)
+        runner.inklingParityAdvanceKV()
+        try await runner.produce(token: 9029, position: 1, into: logits)
+
+        let HD = cfg.headDim, NQ = cfg.numHeads, NKV = cfg.numKVHeads
+        let dRel = cfg.relativePosition.dRel
+        let extent = cfg.relativePosition.extent   // 1024 on global layers
+        let scale = Float(cfg.attentionScale)
+        let L = 5
+
+        let q = Self.readF16(runner.qScratch, NQ * HD)
+        let rel = Self.readF16(runner.inklingRelScratch!, NQ * dRel)
+        func slotRow(_ s: (buffer: MTLBuffer, offset: Int)) -> [Float] {
+            let p = s.buffer.contents().advanced(by: s.offset)
+                .bindMemory(to: Float16.self, capacity: NKV * HD)
+            return (0..<NKV * HD).map { Float(p[$0]) }
+        }
+        let k0 = slotRow(runner.inklingParityKSlot(layer: L, position: 0))
+        let k1 = slotRow(runner.inklingParityKSlot(layer: L, position: 1))
+        let v0 = slotRow(runner.inklingParityVSlot(layer: L, position: 0))
+        let v1 = slotRow(runner.inklingParityVSlot(layer: L, position: 1))
+
+        let relProj = try model.inklingRelProj(layer: L)
+        // Sanity: global proj bank is [dRel, 1024] BF16.
+        #expect(Int(relProj.length) == dRel * extent * 2,
+                "L5 proj length \(relProj.length) != \(dRel * extent * 2)")
+        let projPtr = relProj.buffer.contents().advanced(by: Int(relProj.offset))
+            .assumingMemoryBound(to: UInt16.self)
+
+        var attnOut = [Float](repeating: 0, count: NQ * HD)
+        for h in 0..<NQ {
+            let kvh = h / (NQ / NKV)
+            var lg = [Float](repeating: 0, count: 2)
+            for (idx, kk) in [k0, k1].enumerated() {
+                var qk: Float = 0
+                for i in 0..<HD { qk += q[h * HD + i] * kk[kvh * HD + i] }
+                let dist = 1 - idx
+                var bias: Float = 0
+                for i in 0..<dRel {
+                    bias += rel[h * dRel + i] * Self.bf16(projPtr[i * extent + dist])
+                }
+                lg[idx] = qk * scale + bias
+            }
+            let m = max(lg[0], lg[1])
+            let e0 = expf(lg[0] - m), e1 = expf(lg[1] - m)
+            let w0 = e0 / (e0 + e1), w1 = e1 / (e0 + e1)
+            for i in 0..<HD {
+                attnOut[h * HD + i] = w0 * v0[kvh * HD + i] + w1 * v1[kvh * HD + i]
+            }
+        }
+        #expect(Self.compare("L5 attnOut",
+                             gpu: Self.readF16(runner.attnOut, NQ * HD),
+                             cpu: attnOut, tol: 0.999))
+    }
+}
+
+extension InklingLayerParityTests {
+    /// Composition parity: 5-token prompt, tokens 0-3 run all 42 layers, the
+    /// last token stops after L1. The CPU then computes token 4's ENTIRE
+    /// layer 2 (attention with 5-position history + deep conv states + MoE)
+    /// from the captured GPU state. Requires MFERENCE_INKLING_STOP_LAYER=1
+    /// MFERENCE_INKLING_STOP_POSITION=4. Prints the CPU layer output for the
+    /// companion run (stop layer 2) to diff externally.
+    @Test func token4Layer2CompositionParity() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            RealForwardRunner.inklingStopLayer == 1,
+            RealForwardRunner.inklingStopPosition == 4 else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        let prompt: [Int32] = [976, 9029, 328, 10128, 382]
+        for (p, t) in prompt.enumerated() {
+            try await runner.produce(token: t, position: p, into: logits)
+            if p < prompt.count - 1 { /* full pass advanced internally */ }
+        }
+        // Token 4 stopped after L1 (no kv.advance).
+
+        let D = cfg.hiddenSize, HD = cfg.headDim
+        let NQ = cfg.numHeads, NKV = cfg.numKVHeads, K = cfg.sconvKernelSize
+        let F = cfg.moeIntermediateSize
+        let dRel = cfg.relativePosition.dRel
+        let scale = Float(cfg.attentionScale)
+        let L = 2
+
+        let hin = Self.readF32(runner.inklingHiddenF32!, D)
+        let normed = Self.rms(hin, try model.inputNorm(layer: L))
+        let qRaw = Self.gemv(try model.inklingWqDu(layer: L), x: normed, m: NQ * HD, n: D)
+        let kRaw = Self.gemv(try model.inklingWkDv(layer: L), x: normed, m: NKV * HD, n: D)
+        let vRaw = Self.gemv(try model.inklingWvDv(layer: L), x: normed, m: NKV * HD, n: D)
+        let rel = Self.gemv(try model.inklingWrDu(layer: L), x: normed, m: NQ * dRel, n: D)
+
+        // Conv states for L2 hold t1-t3 history (t0 shifted out for K-1=3).
+        let st = runner.inklingConvStates[L]
+        func state(_ b: MTLBuffer, c: Int) -> [[Float]] {
+            let p = b.contents().bindMemory(to: Float.self, capacity: c * (K - 1))
+            return (0..<c).map { ch in (0..<(K - 1)).map { p[ch * (K - 1) + $0] } }
+        }
+        let kSt = state(st.k, c: NKV * HD)
+        let vSt = state(st.v, c: NKV * HD)
+        func convStep(_ w: TensorView, _ stt: [[Float]], _ x: [Float]) -> [Float] {
+            let wp = w.buffer.contents().advanced(by: Int(w.offset))
+                .assumingMemoryBound(to: UInt16.self)
+            return (0..<x.count).map { c in
+                var acc = x[c] * Self.bf16(wp[c * K + (K - 1)])
+                for j in 0..<(K - 1) { acc += stt[c][j] * Self.bf16(wp[c * K + j]) }
+                return acc + x[c]
+            }
+        }
+        let k4 = Self.perHeadRMS(convStep(try model.inklingKSconv(layer: L), kSt, kRaw),
+                                 heads: NKV, hd: HD, try model.inklingKNorm(layer: L))
+        let v4 = convStep(try model.inklingVSconv(layer: L), vSt, vRaw)
+        let q4 = Self.perHeadRMS(qRaw, heads: NQ, hd: HD, try model.inklingQNorm(layer: L))
+
+        // Cached slots 0-3 (written by the full passes) + this token.
+        var ks: [[Float]] = []
+        var vs: [[Float]] = []
+        for p in 0..<4 {
+            let kp = runner.inklingParityKSlot(layer: L, position: p)
+            let vp = runner.inklingParityVSlot(layer: L, position: p)
+            let kptr = kp.buffer.contents().advanced(by: kp.offset)
+                .bindMemory(to: Float16.self, capacity: NKV * HD)
+            let vptr = vp.buffer.contents().advanced(by: vp.offset)
+                .bindMemory(to: Float16.self, capacity: NKV * HD)
+            ks.append((0..<NKV * HD).map { Float(kptr[$0]) })
+            vs.append((0..<NKV * HD).map { Float(vptr[$0]) })
+        }
+        ks.append(k4)
+        vs.append(v4)
+
+        let relProj = try model.inklingRelProj(layer: L)
+        let projPtr = relProj.buffer.contents().advanced(by: Int(relProj.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        let extent = cfg.slidingWindow
+        var attnOut = [Float](repeating: 0, count: NQ * HD)
+        for h in 0..<NQ {
+            let kvh = h / (NQ / NKV)
+            var lgs = [Float]()
+            for p in 0...4 {
+                var qk: Float = 0
+                for i in 0..<HD { qk += q4[h * HD + i] * ks[p][kvh * HD + i] }
+                let dist = 4 - p
+                var bias: Float = 0
+                for i in 0..<dRel {
+                    bias += rel[h * dRel + i] * Self.bf16(projPtr[i * extent + dist])
+                }
+                lgs.append(qk * scale + bias)
+            }
+            let m = lgs.max()!
+            let es = lgs.map { expf($0 - m) }
+            let den = es.reduce(0, +)
+            for p in 0...4 {
+                let w = es[p] / den
+                for i in 0..<HD { attnOut[h * HD + i] += w * vs[p][kvh * HD + i] }
+            }
+        }
+        let oOut = Self.gemv(try model.inklingWoUd(layer: L), x: attnOut, m: D, n: NQ * HD)
+        let aSt = state(st.attn, c: D)
+        let attnDelta = convStep(try model.inklingAttnSconv(layer: L), aSt, oOut)
+        var hidden = (0..<D).map { hin[$0] + attnDelta[$0] }
+
+        let routedX = Self.rms(hidden, try model.postAttnNorm(layer: L))
+        // Router.
+        let routerW = try model.router(layer: L)
+        let wp = routerW.buffer.contents().advanced(by: Int(routerW.offset))
+            .assumingMemoryBound(to: UInt16.self)
+        var lgr = [Float](repeating: 0, count: 258)
+        for e in 0..<258 {
+            var acc: Float = 0
+            for i in 0..<D { acc += Self.bf16(wp[e * D + i]) * routedX[i] }
+            lgr[e] = acc
+        }
+        let biasV = try model.inklingGateBias(layer: L)
+        let bp = biasV.buffer.contents().advanced(by: Int(biasV.offset))
+            .assumingMemoryBound(to: Float.self)
+        let scores = (0..<256).map { 1 / (1 + exp(-lgr[$0])) + bp[$0] }
+        let refIdx = scores.enumerated().sorted { $0.element > $1.element }
+            .prefix(6).map(\.offset)
+        func logsigmoid(_ x: Float) -> Float { min(x, 0) - log(1 + exp(-abs(x))) }
+        let sel = refIdx.map { logsigmoid(lgr[$0]) } + [logsigmoid(lgr[256]), logsigmoid(lgr[257])]
+        let mxx = sel.max()!
+        let exps = sel.map { expf($0 - mxx) }
+        let den2 = exps.reduce(0, +)
+        let gScale = model.inklingScalar(try model.inklingGateGlobalScale(layer: L))
+        let refW = exps.map { $0 / den2 * 8.0 * gScale }
+
+        func switchGLU(_ g: TensorView, _ u: TensorView, _ d: TensorView, x: [Float]) -> [Float] {
+            let gv = Self.gemv(g, x: x, m: F, n: D)
+            let uv = Self.gemv(u, x: x, m: F, n: D)
+            var act = [Float](repeating: 0, count: F)
+            for i in 0..<F { act[i] = gv[i] / (1 + exp(-gv[i])) * uv[i] }
+            return Self.gemv(d, x: act, m: D, n: F)
+        }
+        var ffn = [Float](repeating: 0, count: D)
+        for s2 in 0..<2 {
+            let y = switchGLU(
+                try model.inklingSharedExpert("gate_proj", layer: L, expert: s2, of: 2),
+                try model.inklingSharedExpert("up_proj", layer: L, expert: s2, of: 2),
+                try model.inklingSharedExpert("down_proj", layer: L, expert: s2, of: 2),
+                x: routedX)
+            for i in 0..<D { ffn[i] += refW[6 + s2] * y[i] }
+        }
+        let offs = model.routedExpertOffsets(layer: L)
+        let blobs = try await model.fetchRoutedExperts(layer: L, experts: refIdx)
+        func bv(_ blob: TensorView, w: UInt32, s: UInt32, b: UInt32, m: Int, n: Int) -> TensorView {
+            TensorView(buffer: blob.buffer, offset: blob.offset + UInt64(w),
+                       length: UInt64(m * n / 2),
+                       scaleOffset: blob.offset + UInt64(s), scaleLength: UInt64(m * n / 32),
+                       biasOffset: blob.offset + UInt64(b), biasLength: UInt64(m * n / 32),
+                       shape: (UInt32(m), UInt32(n), 1, 1), dtype: 0)
+        }
+        for (i, blob) in blobs.enumerated() {
+            let y = switchGLU(
+                bv(blob, w: offs.gateWOff, s: offs.gateSOff, b: offs.gateBOff, m: F, n: D),
+                bv(blob, w: offs.upWOff, s: offs.upSOff, b: offs.upBOff, m: F, n: D),
+                bv(blob, w: offs.downWOff, s: offs.downSOff, b: offs.downBOff, m: D, n: F),
+                x: routedX)
+            for j in 0..<D { ffn[j] += refW[i] * y[j] }
+        }
+        // The GPU stores the mlp conv state pre-scaled by 1/32 (the FFN
+        // prescale); un-scale it to compare against this unscaled reference.
+        let mSt = state(st.mlp, c: D).map { $0.map { $0 * RealForwardRunner.inklingFFNPrescale } }
+        let mlpDelta = convStep(try model.inklingMlpSconv(layer: L), mSt, ffn)
+        for i in 0..<D { hidden[i] += mlpDelta[i] }
+
+        // Persist for the companion GPU run to diff against.
+        func dump(_ name: String, _ v: [Float]) throws {
+            try v.map { String($0) }.joined(separator: "\n")
+                .write(toFile: NSTemporaryDirectory() + "inkling_t4L2_\(name).txt",
+                       atomically: true, encoding: .utf8)
+        }
+        try dump("cpu", hidden)
+        try dump("normed", normed)
+        try dump("q", q4)
+        try dump("attn", attnOut)
+        try dump("routedX", routedX)
+        print("[parity] CPU t4/L2 intermediates written")
+        print("[parity] CPU router idx=\(refIdx)")
+    }
+
+    /// Companion: same prompt, stop layer 2 at position 4; diffs GPU hidden
+    /// against the CPU file from token4Layer2CompositionParity.
+    @Test func token4Layer2CompositionGPU() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            RealForwardRunner.inklingStopLayer == 2,
+            RealForwardRunner.inklingStopPosition == 4 else { return }
+        let cpuPath = NSTemporaryDirectory() + "inkling_t4L2_cpu.txt"
+        guard let txt = try? String(contentsOfFile: cpuPath, encoding: .utf8) else {
+            Issue.record("run token4Layer2CompositionParity first")
+            return
+        }
+        let cpu = txt.split(separator: "\n").map { Float($0)! }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        for (p, t) in [Int32(976), 9029, 328, 10128, 382].enumerated() {
+            try await runner.produce(token: t, position: p, into: logits)
+        }
+        func load(_ name: String) -> [Float] {
+            let t = try! String(contentsOfFile: NSTemporaryDirectory()
+                + "inkling_t4L2_\(name).txt", encoding: .utf8)
+            return t.split(separator: "\n").map { Float($0)! }
+        }
+        let D = cfg.hiddenSize
+        _ = Self.compare("t4/L2 normed", gpu: Self.readF16(runner.normed, D),
+                         cpu: load("normed"), tol: 0.999)
+        _ = Self.compare("t4/L2 q", gpu: Self.readF16(runner.qScratch,
+                                                      cfg.numHeads * cfg.headDim),
+                         cpu: load("q"), tol: 0.999)
+        _ = Self.compare("t4/L2 attnOut", gpu: Self.readF16(runner.attnOut,
+                                                            cfg.numHeads * cfg.headDim),
+                         cpu: load("attn"), tol: 0.999)
+        _ = Self.compare("t4/L2 routedX", gpu: Self.readF16(runner.routedX, D),
+                         cpu: load("routedX"), tol: 0.999)
+        let idxPtr = runner.outIndices.contents()
+            .bindMemory(to: UInt32.self, capacity: 6)
+        print("[parity] GPU router idx=\((0..<6).map { Int(idxPtr[$0]) })")
+        let gpu = Self.readF32(runner.inklingHiddenF32!, cfg.hiddenSize)
+        #expect(Self.compare("t4/L2 hidden (composition)",
+                             gpu: gpu, cpu: cpu, tol: 0.999))
+    }
+}
+
+extension InklingLayerParityTests {
+    /// Dumps the engine's layer-0 sub-stage buffers for token 4 of the fixed
+    /// 5-token prompt, for diffing against the reference oracle. Requires
+    /// MFERENCE_INKLING_STOP_LAYER=0 MFERENCE_INKLING_STOP_POSITION=4.
+    @Test func token4Layer0StageDump() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"],
+            let outDir = ProcessInfo.processInfo.environment["MFERENCE_STAGE_OUT"],
+            RealForwardRunner.inklingStopLayer == 0,
+            RealForwardRunner.inklingStopPosition == 4 else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                           maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        for (p, t) in [Int32(976), 9029, 328, 10128, 382].enumerated() {
+            try await runner.produce(token: t, position: p, into: logits)
+        }
+        try FileManager.default.createDirectory(
+            atPath: outDir, withIntermediateDirectories: true)
+        func dumpF16(_ name: String, _ b: MTLBuffer, _ n: Int, offset: Int = 0) throws {
+            let p = b.contents().advanced(by: offset)
+                .bindMemory(to: Float16.self, capacity: n)
+            let v = (0..<n).map { Float(p[$0]) }
+            try v.withUnsafeBytes { raw in
+                try Data(raw).write(to: URL(fileURLWithPath: "\(outDir)/\(name).f32raw"))
+            }
+        }
+        let D = cfg.hiddenSize
+        let kvDim = cfg.numKVHeads * cfg.headDim
+        try dumpF16("normed", runner.normed, D)
+        try dumpF16("q_normed", runner.qScratch, cfg.numHeads * cfg.headDim)
+        try dumpF16("rel", runner.inklingRelScratch!, cfg.relativePosition.projDim)
+        try dumpF16("attn_out", runner.attnOut, cfg.numHeads * cfg.headDim)
+        try dumpF16("o_out", runner.oOut, D)
+        for p in 0...4 {
+            let ks = runner.inklingParityKSlot(layer: 0, position: p)
+            let vs = runner.inklingParityVSlot(layer: 0, position: p)
+            try dumpF16("k_slot\(p)", ks.buffer, kvDim, offset: ks.offset)
+            try dumpF16("v_slot\(p)", vs.buffer, kvDim, offset: vs.offset)
+        }
+        // FP32 dumps: the mlp delta (deltaF32 holds the last sconv output at
+        // the stop point) and the final layer output.
+        func dumpF32(_ name: String, _ b: MTLBuffer, _ n: Int) throws {
+            try Data(bytes: b.contents(), count: n * 4)
+                .write(to: URL(fileURLWithPath: "\(outDir)/\(name).f32raw"))
+        }
+        try dumpF32("mlp_delta", runner.inklingDeltaF32!, D)
+        try dumpF32("layer_out", runner.inklingHiddenF32!, D)
+        print("[stage] dumped to \(outDir)")
+    }
+}

--- a/Tests/MferenceRepack/Core/Planning/InklingRepackPlannerTests.swift
+++ b/Tests/MferenceRepack/Core/Planning/InklingRepackPlannerTests.swift
@@ -233,3 +233,64 @@ struct InklingRepackPlannerTests {
         #expect(SupportedModelSource.all.contains { $0.name == "inklingsmall" })
     }
 }
+
+extension InklingRepackPlannerTests {
+    /// `--verify-install` accepts empty expert layouts ONLY inside the
+    /// manifest's declared dense-layer prefix; an empty ROUTED layer is a
+    /// broken install the runtime would reject, and verification must not
+    /// certify it (PR #4 review, Codex P2).
+    @Test func verifyRejectsEmptyLayoutOutsideDenseLayers() throws {
+        func makeInstall(numDenseLayers: Int, emptyLayer: Int) throws -> String {
+            let dir = NSTemporaryDirectory() + "vfy-\(UUID().uuidString)"
+            let pe = dir + "/packed_experts"
+            try FileManager.default.createDirectory(
+                atPath: pe, withIntermediateDirectories: true)
+            let stride: UInt64 = 16384
+            let numLayers = 3
+            var layers: [[String: Any]] = []
+            var files: [String: Any] = [
+                "packed_experts/layout.json": ["size": 1, "sha256": "00"],
+            ]
+            for L in 0..<numLayers {
+                let file = String(format: "layer_%02d.bin", L)
+                if L == emptyLayer || L < numDenseLayers {
+                    layers.append(["layer": L, "file": file, "experts": []])
+                    continue
+                }
+                layers.append(["layer": L, "file": file,
+                               "experts": [["expert": 0, "offset": 0,
+                                            "size": stride,
+                                            "tensors": [String: Any]()]]])
+                let data = Data(count: Int(stride))
+                try data.write(to: URL(fileURLWithPath: "\(pe)/\(file)"))
+                files["packed_experts/\(file)"] = ["size": stride, "sha256": "00"]
+            }
+            let layout: [String: Any] = [
+                "expertStride": stride, "numLayers": numLayers,
+                "expertsPerLayer": 1, "layers": layers,
+            ]
+            try JSONSerialization.data(withJSONObject: layout)
+                .write(to: URL(fileURLWithPath: "\(pe)/layout.json"))
+            let manifest: [String: Any] = [
+                "files": files, "expertsPerLayer": 1, "numLayers": numLayers,
+                "expertStride": stride,
+                "arch": ["numDenseLayers": numDenseLayers],
+            ]
+            try JSONSerialization.data(withJSONObject: manifest)
+                .write(to: URL(fileURLWithPath: "\(dir)/manifest.json"))
+            return dir
+        }
+
+        // Empty layout confined to the dense prefix: accepted.
+        let ok = try makeInstall(numDenseLayers: 2, emptyLayer: 1)
+        defer { try? FileManager.default.removeItem(atPath: ok) }
+        try VerifiedInstallTool.validatePackedExpertLayout(inputGTurbo: ok)
+
+        // Empty layout on a ROUTED layer: rejected.
+        let bad = try makeInstall(numDenseLayers: 1, emptyLayer: 2)
+        defer { try? FileManager.default.removeItem(atPath: bad) }
+        #expect(throws: RepackError.self) {
+            try VerifiedInstallTool.validatePackedExpertLayout(inputGTurbo: bad)
+        }
+    }
+}

--- a/Tests/MferenceRepack/Core/Planning/InklingRepackPlannerTests.swift
+++ b/Tests/MferenceRepack/Core/Planning/InklingRepackPlannerTests.swift
@@ -1,0 +1,235 @@
+import Foundation
+import Testing
+@testable import MferenceRepackCore
+
+@Suite
+struct InklingRepackPlannerTests {
+
+    /// `text_config` of `pipenetwork/Inkling-Small-MLX-4bit` revision
+    /// `9d6e4720`, trimmed to the fields the repacker reads. Shaped like the
+    /// production checkpoint so the cross-check is exercised.
+    private static func productionConfigJSON(
+        overrides: [String: Any] = [:]) -> String {
+        var tc: [String: Any] = [
+            "hidden_size": 4096,
+            "num_hidden_layers": 42,
+            "vocab_size": 201_024,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "swa_head_dim": 128,
+            "sliding_window_size": 512,
+            "d_rel": 16,
+            "rel_extent": 1024,
+            "log_scaling_n_floor": 128_000,
+            "log_scaling_alpha": 0.1,
+            "use_sconv": true,
+            "sconv_kernel_size": 4,
+            "n_routed_experts": 256,
+            "num_experts_per_tok": 6,
+            "n_shared_experts": 2,
+            "shared_expert_sink": true,
+            "dense_mlp_idx": 2,
+            "dense_intermediate_size": 16_384,
+            "intermediate_size": 2048,
+            "route_scale": 8.0,
+            "use_gate_bias": true,
+            "gate_activation": "sigmoid",
+            "norm_after_topk": true,
+            "use_global_scale": true,
+            "use_embed_norm": true,
+            "logits_mup_width_multiplier": 16.0,
+            "unpadded_vocab_size": 200_058,
+            "local_layer_ids": (0..<42).filter { $0 % 6 != 5 },
+        ]
+        for (k, v) in overrides { tc[k] = v }
+        let root: [String: Any] = [
+            "model_type": "inkling_mm_model",
+            "text_config": tc,
+            "quantization": ["group_size": 64, "bits": 4, "recipe": "uniform"],
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: root)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func writeConfig(_ json: String, label: String) throws -> String {
+        let dir = NSTemporaryDirectory() + "inkling-\(label)-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        let path = (dir as NSString).appendingPathComponent("config.json")
+        try json.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    @Test func inklingArchInfoLoadsFromProductionConfig() throws {
+        let path = try writeConfig(Self.productionConfigJSON(), label: "arch")
+        defer { try? FileManager.default.removeItem(
+            atPath: (path as NSString).deletingLastPathComponent) }
+
+        let arch = try ArchInfo.load(configPath: path)
+
+        #expect(arch.family == .inklingSmall)
+        #expect(arch.hiddenSize == 4096)
+        #expect(arch.numLayers == 42)
+        #expect(arch.vocabSize == 201_024)
+        #expect(arch.numHeads == 32)
+        #expect(arch.numKVHeads == 8)
+        #expect(arch.headDim == 128)
+        #expect(arch.fullHeadDim == 128)
+        #expect(arch.slidingWindow == 512)
+        #expect(arch.numExperts == 256)
+        #expect(arch.topKExperts == 6)
+        #expect(arch.intermediateSize == 2048)
+        #expect(arch.moeIntermediateSize == 2048)
+        #expect(arch.hiddenActivation == "silu")
+        // q/k are per-head RMS-normalized, so the reference scales by 1/d.
+        #expect(arch.attentionScale == 1.0 / 128.0)
+        #expect(arch.unpaddedVocabSize == 200_058)
+        #expect(arch.tieWordEmbeddings == false)
+
+        // Position comes entirely from the relative bias; no RoPE.
+        #expect(arch.ropeTheta == 0.0)
+        #expect(arch.fullRopeTheta == 0.0)
+        #expect(arch.partialRotaryFactor == 0.0)
+        #expect(arch.relDRel == 16)
+        #expect(arch.relExtent == 1024)
+        #expect(arch.relProjDim == 512)      // num_attention_heads * d_rel
+        #expect(arch.relLogScalingFloor == 128_000)
+        #expect(arch.relLogScalingAlpha == 0.1)
+
+        #expect(arch.sconvKernelSize == 4)
+        #expect(arch.numSharedExperts == 2)
+        #expect(arch.sharedExpertSink == true)
+        #expect(arch.numDenseLayers == 2)
+        #expect(arch.denseIntermediateSize == 16_384)
+        #expect(arch.embedNormEnabled == true)
+        #expect(arch.logitsWidthMultiplier == 16.0)
+        #expect(arch.routerScoringFunc == "sigmoid")
+        #expect(arch.routedScalingFactor == 8.0)
+        #expect(arch.routerGateBias == true)
+        #expect(arch.routerNormAfterTopK == true)
+        #expect(arch.routerGlobalScale == true)
+
+        // Layers 5, 11, 17, 23, 29, 35, 41 are full attention; rest sliding.
+        #expect(arch.fullAttentionLayerMask.count == 42)
+        #expect(arch.fullAttentionLayerMask.reduce(0) { $0 + Int($1) } == 7)
+        for L in [5, 11, 17, 23, 29, 35, 41] {
+            #expect(arch.fullAttentionLayerMask[L] == 1, "layer \(L) full")
+        }
+        for L in [0, 4, 6, 34, 40] {
+            #expect(arch.fullAttentionLayerMask[L] == 0, "layer \(L) sliding")
+        }
+    }
+
+    /// The runtime pins every hyperparameter, so a checkpoint that claims the
+    /// production shape but disagrees must fail at convert time rather than
+    /// producing a `.gturbo` the loader will reject much later.
+    @Test func productionCrossCheckRejectsDivergentConfig() throws {
+        let path = try writeConfig(
+            Self.productionConfigJSON(overrides: ["num_experts_per_tok": 8]),
+            label: "topk")
+        defer { try? FileManager.default.removeItem(
+            atPath: (path as NSString).deletingLastPathComponent) }
+
+        #expect(throws: RepackError.self) {
+            _ = try ArchInfo.load(configPath: path)
+        }
+    }
+
+    @Test func nonProductionShapeSkipsCrossCheck() throws {
+        // A toy config keeps its own (non-production) values.
+        let path = try writeConfig(
+            Self.productionConfigJSON(overrides: [
+                "hidden_size": 256,
+                "num_hidden_layers": 6,
+                "n_routed_experts": 8,
+                "num_experts_per_tok": 2,
+                "local_layer_ids": [0, 1, 2, 3, 4],
+            ]),
+            label: "toy")
+        defer { try? FileManager.default.removeItem(
+            atPath: (path as NSString).deletingLastPathComponent) }
+
+        let arch = try ArchInfo.load(configPath: path)
+        #expect(arch.hiddenSize == 256)
+        #expect(arch.numLayers == 6)
+        #expect(arch.fullAttentionLayerMask == [0, 0, 0, 0, 0, 1])
+    }
+
+    @Test func rejectsOutOfRangeLocalLayerIDs() throws {
+        let path = try writeConfig(
+            Self.productionConfigJSON(overrides: [
+                "hidden_size": 256,
+                "num_hidden_layers": 4,
+                "local_layer_ids": [0, 9],
+            ]),
+            label: "badlocal")
+        defer { try? FileManager.default.removeItem(
+            atPath: (path as NSString).deletingLastPathComponent) }
+
+        #expect(throws: RepackError.self) {
+            _ = try ArchInfo.load(configPath: path)
+        }
+    }
+
+    @Test func inklingClassificationBucketsNames() {
+        let f = RepackModelFamily.inklingSmall
+        // Routed experts stream; everything else in the text tower is resident.
+        #expect(RepackPlanner.classify(
+            "model.llm.layers.3.mlp.experts.gate_proj.weight",
+            numLayers: 42, family: f)
+            == .routedExpert(role: "gate", layer: 3))
+        #expect(RepackPlanner.classify(
+            "model.llm.layers.40.mlp.experts.down_proj.weight",
+            numLayers: 42, family: f)
+            == .routedExpert(role: "down", layer: 40))
+
+        // Shared experts sit under `.mlp.shared_experts.` and must NOT be
+        // mistaken for routed experts.
+        #expect(RepackPlanner.classify(
+            "model.llm.layers.3.mlp.shared_experts.gate_proj.weight",
+            numLayers: 42, family: f) == .lmResident)
+        // Dense-FFN layers use the bare `.mlp.` names.
+        #expect(RepackPlanner.classify(
+            "model.llm.layers.0.mlp.gate_proj.weight",
+            numLayers: 42, family: f) == .lmResident)
+        #expect(RepackPlanner.classify(
+            "model.llm.layers.7.attn.wr_du.weight",
+            numLayers: 42, family: f) == .lmResident)
+        #expect(RepackPlanner.classify(
+            "model.llm.layers.7.attn.rel_logits_proj.proj",
+            numLayers: 42, family: f) == .lmResident)
+        #expect(RepackPlanner.classify(
+            "model.llm.layers.7.attn_sconv.weight",
+            numLayers: 42, family: f) == .lmResident)
+        #expect(RepackPlanner.classify(
+            "model.llm.embed.weight", numLayers: 42, family: f) == .lmResident)
+        #expect(RepackPlanner.classify(
+            "model.llm.unembed.weight", numLayers: 42, family: f) == .lmResident)
+
+        // The vision and audio towers are excluded from the text path.
+        #expect(RepackPlanner.classify(
+            "model.visual.layers.linear_0.weight",
+            numLayers: 42, family: f) == .excludedMultimodal)
+        #expect(RepackPlanner.classify(
+            "model.audio.encoder.weight",
+            numLayers: 42, family: f) == .excludedMultimodal)
+
+        // Other families' prefixes are not this family's contract.
+        #expect(RepackPlanner.classify(
+            "model.layers.0.ffn.switch_mlp.gate_proj.weight",
+            numLayers: 42, family: f) == .unknown)
+        #expect(RepackPlanner.classify(
+            "model.llm.layers.0.mlp.experts.gate_proj.weight",
+            numLayers: 42, family: .deepseekV4Flash) == .lmResident)
+    }
+
+    @Test func inklingSourceIsPinnedAndRegistered() throws {
+        let s = try #require(SupportedModelSource.named("inklingsmall"))
+        #expect(s.repoID == "pipenetwork/Inkling-Small-MLX-4bit")
+        #expect(s.revision == "9d6e4720ab7002af25d6129c88ccea6cd9f19372")
+        #expect(s.sourceIndexSHA256
+                == "fe16aec3cef12438f1d0ff657f7e785781b61271528a66b3b7160fcf1aaca30c")
+        #expect(SupportedModelSource.all.contains { $0.name == "inklingsmall" })
+    }
+}

--- a/docs/INKLING_SMALL.md
+++ b/docs/INKLING_SMALL.md
@@ -1,0 +1,370 @@
+# Inkling-Small on Mference
+
+Checkpoint selection, memory budget, and the architecture gap list for running
+[pipenetwork/Inkling-Small-MLX-4bit](https://huggingface.co/pipenetwork/Inkling-Small-MLX-4bit)
+(276B total, ~12B active, natively multimodal) with SSD-streamed experts. This
+document is the architecture contract for the `inklingSmall` family.
+
+Conversion has been run and verified against the real checkpoint (see
+**Status**). Throughput numbers remain *estimates* calibrated against measured
+DSV4-Flash performance on the same machine — no Inkling token has been
+generated yet, because the forward pass is not implemented.
+
+## Checkpoint selection
+
+Thinking Machines published Inkling-Small under Apache 2.0 in July 2026. Roughly
+a dozen MLX conversions exist. Only one of them matches the quantization
+contract Mference already enforces in `ManifestReader.validateQuant`
+(`Sources/Mference/Infrastructure/ModelIO/ManifestReader.swift:206`).
+
+| Candidate | Routed experts | Attention / embeddings | Disk | Verdict |
+|---|---|---|---|---|
+| `pipenetwork/Inkling-Small-MLX-4bit` | affine 4-bit g64 | affine 4-bit g64 | 148 GB | **Selected** |
+| `mlx-community/Inkling-Small-mlx-3bit` | affine 3-bit g64 | BF16 | 121 GB | No INT3 kernel; no BF16 resident path |
+| `Sawfwair/Inkling-Small-MLX-Mixed-2bit` | affine 2-bit **g128** | BF16 | 84.5 GB | g128 unsupported; 12 GB resident |
+| `mlx-community/Inkling-Small-mxfp4` | MXFP4 | mixed | 140 GB | Non-affine number format |
+| `pipenetwork/…-MLX-6bit` / `-8bit` | 6/8-bit | 6/8-bit | 200 GB+ | Exceeds free disk |
+| `unsloth/…-GGUF`, `…-EXL3-*`, `…-NVFP4`, `…-AWQ-INT4` | — | — | — | Format not readable by the repacker |
+
+Verified against revision `9d6e4720` by reading the safetensors headers
+directly: `embed`, `unembed`, `attn.{wq_du,wk_dv,wv_dv,wo_ud,wr_du}`,
+`mlp.experts.*`, `mlp.shared_experts.*`, the two dense MLP layers, and the
+vision/audio projections are all **affine 4-bit, group 64, BF16 scales and
+biases** — e.g. routed `gate_proj` is `U32 [256, 2048, 512]` with
+`scales/biases BF16 [256, 2048, 64]` (512 × 32 ÷ 4096 = 4 bits, 4096 ÷ 64 = 64
+groups). The router gate (`mlp.gate.weight`, `BF16 [258, 4096]`) is
+**unquantized**, as it is in the DSV4 checkpoint.
+
+That maps onto Mference's slot table with exactly one deviation:
+
+| Slot | Mference allows | Inkling-Small 4-bit |
+|---|---|---|
+| embedding | 4 | 4 ✓ |
+| attention | 4 | 4 ✓ |
+| sharedExpert | 4, 8 | 4 ✓ |
+| routedExpert | 2, 4 | 4 ✓ |
+| router | 8 | BF16 ✗ |
+
+The router deviation is cosmetic — 42 MB total across 40 layers. DSV4 ships a
+BF16 router too, so whatever the repacker does there already applies.
+
+### Why not the smaller quants
+
+The 3-bit and mixed-2-bit builds are genuinely attractive on decode bandwidth
+(see below), and the 3-bit build in particular protects the every-token path.
+Both are rejected for the same structural reason rather than a quality one:
+they leave attention and embeddings in **BF16**, and Mference has no resident
+BF16 matmul path — the attention slot is required to be INT4 and every decode
+GEMV is an INT4 or INT8 kernel. Adopting either means adding a BF16 weight path
+*and* (for 3-bit) an INT3 unpack kernel whose weights straddle `u32` word
+boundaries (3 does not divide 32). That is a second project layered on top of
+an already large one.
+
+Revisit once the text path is working: a 2-bit-routed / 4-bit-core build in the
+shape of the DSV4 dynamic quant would reuse the existing INT2 MoE kernels and
+roughly double decode throughput (see the budget table). No such checkpoint
+exists publicly today; producing one means quantizing from the 527 GB BF16
+release ourselves.
+
+## Architecture summary
+
+42 decoder layers, hidden 4096, vocab 201 024 (200 058 unpadded), untied
+`unembed`, `model_max_length` 1 048 576.
+
+- **Layers 0–1 are dense** (`dense_mlp_idx: 2`, intermediate 16 384). The
+  remaining 40 are MoE: 256 routed experts of intermediate width 2048, top-6,
+  plus **2 shared experts** with `shared_expert_sink: true` — the router emits
+  258 logits, so the shared experts compete in the same softmax as sinks.
+- **Router**: `gate_activation: sigmoid` with a learned bias (`use_gate_bias`),
+  `norm_after_topk: true`, a per-layer learned `global_scale`, and
+  `route_scale: 8.0`.
+- **Attention is hybrid local/global**: 35 of 42 layers are sliding-window 512
+  (`local_layer_ids`); the other 7 (layers 5, 11, 17, 23, 29, 35, 41) are
+  global. 32 query heads over 8 KV heads, head dim 128, no q/o bias, per-head
+  `q_norm`/`k_norm`.
+- **No RoPE.** Position is encoded by a relative-attention bias. Each layer
+  projects the residual through `wr_du` (4096 → `num_heads * d_rel` = 512) and
+  reshapes it to a per-head 16-dim relative state, which mixes a bank of
+  bias-vs-distance profiles (`rel_logits_proj.proj`, shape `[d_rel, extent]`)
+  into one bias per backward distance; the bias is zero outside
+  `0 ..< extent`.
+
+  **The extent is per layer kind.** The reference takes
+  `sliding_window_size if is_sliding else rel_extent`, so local layers ship
+  `proj [16, 512]` and the 7 global layers ship `[16, 1024]` — confirmed
+  against the checkpoint's safetensors headers (layers 5, 11 and 41 are 1024;
+  layers 2, 4, 6, 7, 9, 10, 24 and 39 are 512). The `log_scaling` correction
+  is likewise applied **only on global layers**.
+- **Short convolutions** (`use_sconv`, `sconv_kernel_size: 4`) at four sites
+  per layer: `attn_sconv` and `mlp_sconv` on the block inputs, and
+  `attn.k_sconv` / `attn.v_sconv` on the K and V streams.
+- **Log-scaled attention** beyond 128 K positions (`log_scaling_n_floor:
+  128000`, `log_scaling_alpha: 0.1`).
+- `use_embed_norm: true`; logits scaled by `logits_mup_width_multiplier: 16.0`;
+  `rms_norm_eps: 1e-6`.
+- 8 MTP (multi-token-prediction) layers and the vision (hMLP, 40 px patches)
+  and audio (dMel) towers are present in the checkpoint and are **out of scope
+  for v1**.
+
+## Memory budget
+
+Parameter counts derived from the config, byte counts at 4.5 bits effective
+(4-bit payload + BF16 scale and bias per 64 weights = 0.5625 B/param).
+
+| Group | Params | Bytes |
+|---|---|---|
+| `embed` + `unembed` | 1.647 B | 0.93 GB |
+| attention (42 layers) | 1.850 B | 1.04 GB |
+| shared experts (40 × 2) | 2.013 B | 1.13 GB |
+| dense MLP (layers 0–1) | 0.403 B | 0.23 GB |
+| router (BF16) + norms + sconv | 0.052 B | 0.10 GB |
+| **Resident total** | **5.96 B** | **≈ 3.4 GB** |
+| routed experts (40 × 256 × 3) | 257.7 B | 145.0 GB |
+| **On disk** | | **≈ 148 GB** |
+
+The 3.4 GB resident set is what makes this viable on a 24 GB machine, and it is
+the strongest practical argument for the 4-bit build: the 3-bit build's BF16
+attention and embeddings push resident to ≈ 8.3 GB, and the mixed-2-bit build
+to ≈ 12 GB, on a box that also has to hold the KV cache, activations, and the
+expert staging ring.
+
+### KV cache
+
+8 KV heads × 128 dims = 1024 per K and V, so 4 KB/token/layer. The 35 local
+layers are pinned at window 512 (71.7 MB total, fixed). Only the 7 global
+layers grow: **28.7 KB/token**.
+
+| Context | Global-layer KV |
+|---|---|
+| 32 K | 0.94 GB |
+| 128 K | 3.76 GB |
+| 1 M | 28.7 GB — not feasible |
+
+The advertised 1 M context cannot be served on 24 GB. Cap the context option at
+128 K.
+
+### Decode throughput
+
+Per token the router touches 6 of 256 experts across 40 MoE layers:
+40 × 6 × 3 × (2048 × 4096) = **6.040 B params**, i.e. **3.40 GB/token** at 4.5
+bits — this is the decode bottleneck, exactly as it is for DSV4.
+
+Calibrating against the measured DSV4 number rather than raw SSD bandwidth:
+DSV4 reads 43 × 6 × 3 × 8.389 M = 6.493 B params/token at ~2.667 bits average
+(g32 `gate_proj`) = 2.164 GB/token, and sustains 4.8 tok/s with 16 slots +
+adaptive expert caching — an effective ~10.4 GB/s.
+
+| Variant | Bytes/token | Projected |
+|---|---|---|
+| 4-bit (selected) | 3.40 GB | **≈ 3 tok/s** |
+| hypothetical 2-bit routed / 4-bit core | 1.89 GB | ≈ 5.5 tok/s |
+
+So expect roughly 60 % of DSV4's decode rate. That is the price of 4-bit
+experts, and it is the main reason to revisit a 2-bit-routed build later.
+
+## Forward-pass contract
+
+Transcribed from the reference `inkling_mlx` package shipped in the checkpoint
+repo (`attention.py`, `layers.py`, `moe.py`, `text.py`, `common.py`). This is
+the spec the kernels must satisfy.
+
+**Decoder layer** (`layers.py`) — note both short convs sit on the *sublayer
+output*, inside the residual:
+
+```
+r = x;  h = attn_norm(x);  h = attn(h);  h = attn_sconv(h);  x = r + h
+r = x;  h = mlp_norm(x);   h = mlp(h);   h = mlp_sconv(h);   x = r + h
+```
+
+**Short convolution** (`common.py`) — depthwise causal, `groups == channels`,
+kernel 4, **no bias, no activation, and a residual add**, held in fp32
+regardless of model dtype. Weight layout `[C, K, 1]`. Four independent conv
+states per layer (`k_conv`, `v_conv`, `attn_conv`, `mlp_conv`), each carrying
+the last `K-1 = 3` inputs; zero-filled at sequence start.
+
+```
+out = depthwise_causal_conv1d(x, w) + x        # fp32
+```
+
+**Attention** (`attention.py`):
+
+- `q = wq_du(h)`; `k = k_sconv(wk_dv(h))`; `v = v_sconv(wv_dv(h))`;
+  `rel = wr_du(h)`. The short convs apply to K and V **only** — not Q.
+- `q_norm` / `k_norm` are per-head RMS norms over `head_dim`.
+- **`scale = 1 / head_dim`, not `1 / sqrt(head_dim)`** — the reference is
+  explicit that per-head RMS-normalized q/k call for `1/d`. Getting this wrong
+  scales every logit by ~11.3×.
+- Relative bias: `rel_logits = rel_states @ proj` → `[B, H, Lq, extent]`;
+  `distance = q_pos - kv_pos`; gather at `clip(distance, 0, extent-1)`; the
+  bias is **zero** (not masked) outside `0 <= distance < extent`.
+- Log scaling, **global layers only**:
+  `tau = 1 + alpha * log(max((pos+1)/n_floor, 1))`, applied to **both** `q`
+  and the position bias.
+- Additive mask = position bias + causal (`distance >= 0`, and
+  `distance < sliding_window` on local layers), then standard SDPA.
+
+**Router** (`moe.py`) — all of it in fp32; the reference warns that bf16
+rounding flips near-tied top-k choices and compounds across layers:
+
+```
+router_logits = x @ weight.T                    # [T, 258] = 256 routed + 2 shared
+scores        = sigmoid(router_logits)[:, :256]
+selection     = scores + bias                   # bias affects SELECTION ONLY
+topk_idx      = top-6(selection)
+topk_logits   = concat(routed_logits[topk_idx], shared_logits)   # [T, 8] raw logits
+weights       = softmax(logsigmoid(topk_logits)) * route_scale * global_scale
+```
+
+The final softmax spans the 6 selected **and** both shared experts — that is
+the `shared_expert_sink`. `topk_weights = weights[:, :6]`,
+`shared_gammas = weights[:, 6:]`, and
+
+```
+out = Σ_k routed_k · topk_weights_k  +  Σ_s shared_s · shared_gammas_s
+```
+
+**Dense MLP** (layers 0–1): `down(silu(gate(x)) * up(x)) * global_scale`.
+
+**Head** (`text.py`): `embed_tokens = embed_norm(embed(ids))`;
+`logits = unembed(h_final / logits_mup_width_multiplier)` truncated to
+`unpadded_vocab_size = 200058`. Skipping the truncation lets the model emit
+966 padding ids the tokenizer cannot decode.
+
+## Gap list
+
+Reusable as-is: sliding-window and full attention masks, GQA, per-head
+`q_norm`/`k_norm`, INT4 GEMV and embedding lookup, the INT4 tiled prefill
+matmul, the packed-expert streaming layout, and the expert cache.
+
+New work, roughly in dependency order:
+
+1. **Relative position bias** replacing RoPE outright (`wr_du` +
+   `rel_logits_proj`, `d_rel` 16, `rel_extent` 1024). Mference's attention path
+   assumes RoPE everywhere; this is a new kernel and a new attention variant.
+2. **Short convolutions** (kernel 4) at four sites per layer, including
+   per-sequence conv state that must live in the cache manager alongside KV and
+   be rolled back on speculative rejection.
+3. **Router variant**: sigmoid + bias + `norm_after_topk` + per-layer
+   `global_scale` + `route_scale` 8.0, over 258 logits with 2 shared-expert
+   sinks. Existing scoring functions are softmax / `sqrtsoftplus` / hash.
+4. **Mixed dense/MoE layer graph** — 2 dense layers at a different intermediate
+   width (16 384) ahead of 40 MoE layers.
+5. **Log-scaled attention** past 128 K.
+6. `embed_norm`, separate `unembed`, `logits_mup_width_multiplier` 16.0.
+7. **Tokenizer**: tiktoken-based, 201 024 vocab, new chat template and
+   `ChatDialect`, plus a tool-call parser.
+8. ~~Registration surface~~ — **done**. `ModelFamily.inklingSmall`,
+   `RelativePositionConfig`, the `inklingSmall_276B_A12B` baseline and
+   `knownArchitectures`; the tensor-name contract in `Model.swift`; manifest
+   arch round-trip (writer, decoder, `validateArch`);
+   `model_type: "inkling_mm_model"` dispatch plus production cross-check in
+   `ArchInfo.swift`; planner prefix/routed-container/slot ordering and
+   vision-audio exclusion; `SupportedModelSource` and the app descriptor
+   pinned to revision `9d6e4720`.
+
+Items 1–3 are the substantial ones and have no analogue in the existing three
+families. The overall shape is comparable to the DSV4 port (38 files).
+
+## Status
+
+**Conversion is done and verified against the real checkpoint.** The 148.4 GB
+source was converted to `inklingsmall.gturbo`, all 48 output files
+(148,421,176,017 bytes) pass `--verify-install` hashing, and the runtime
+loader's `ManifestReader.load(directoryURL:expecting:)` accepts it against the
+compiled baseline.
+
+Measured on the produced install:
+
+| | |
+|---|---|
+| `model_weights.bin` (resident) | 3,415,372,964 B — 3.42 GB, matching the 3.4 GB budget |
+| expert blobs | 40 × 3,623,878,656 B (layers 2–41) |
+| `expertStride` | 14,155,776 B = 3 × 4096 × 2048 at 4.5 bits |
+| resident tensors | 840 |
+| excluded vision/audio tensors | 18 |
+
+Five real defects were caught — three by running the conversion against the
+actual weights, two by transcribing the reference implementation:
+
+0. **`attentionScale` was wrong by 11.3×.** It was derived as
+   `1 / sqrt(head_dim)`, the near-universal convention. Inkling RMS-normalizes
+   q and k per head and therefore scales by `1 / head_dim`
+   (0.0078125, not 0.0883883). Nothing in the config file signals this; only
+   the reference does.
+1. **`unpaddedVocabSize` was missing.** Logits must be truncated to 200 058 of
+   201 024 before sampling, or the model can emit padding ids that do not
+   decode.
+
+2. `attentionScale` was additionally hardcoded as the `128^-0.5` literal
+   (0.088388347648318**45**) while the converter computes
+   `1.0 / sqrt(128)` (…**43**) — one ULP apart, and `validateArch` compares
+   exactly. The baseline now uses the same expression rather than a literal.
+   DSV4's hardcoded 512 value happens to agree bit-for-bit, which is why this
+   never bit before.
+3. `ManifestReader` required a `packed_experts/layer_NN.bin` for *every* layer;
+   the two leading dense-FFN layers legitimately have none. It now skips
+   `numDenseLayers`.
+4. `encodeLayout` published `expertsPerLayer` from `layers.first` — the dense
+   layer 0 — writing 0 into `layout.json` while the manifest said 256, so
+   `--verify-install` rejected the install. Both now select the first layer
+   that actually has experts, and the verifier skips empty layout entries.
+
+### Forward pass (2026-08-03, second session)
+
+The decode path is implemented end to end: `produceTokenInkling` in
+`RealForwardRunner`, four new Metal kernels in `Metal/Inkling/inkling.metal`
+(depthwise short-conv step with fp32 streaming state, per-head Q/K RMS norm
+with no V norm, single-token GQA attention with the relative-position bias
+computed inline plus ring/window/log-`tau` handling, and the sigmoid router
+select with shared-expert sinks), each parity-tested against a CPU reference
+on random data (`InklingKernelTests`). Routed experts reuse the existing INT4
+MoE phase kernels by padding top-6 to the contract's 8 slots with weight-0
+duplicates (cache hits, no extra I/O). Prefill v1 replays the decode path
+token by token — the DSV4-v1 pattern; conv state makes batched prefill a
+follow-up, not a correctness need. The `.inkling` chat dialect implements the
+shipped Jinja's framing (role tokens + `<|content_text|>` + `<|end_message|>`,
+effort line, `<|content_model_end_sampling|>` stop).
+
+**First light achieved 2026-08-04**: greedy completion of "The capital of
+France is" → " Paris. The capital of Germany is Berlin. …"; chat-framed
+"capital of France?" → "Paris" with a clean end-of-turn stop. The engine
+matches pipenetwork's reference implementation layer-by-layer (cos ≥ 0.999,
+first 11 layers verified against the real weights). Decode ≈ 2.4-6.5 tok/s
+unoptimized; prefill v1 ≈ 12 s/token (sequential replay — batched prefill is
+the top perf follow-up).
+
+Post-first-light bug ledger (all found by CPU/oracle parity, in order):
+FP16 residual overflow at L23 (stream is now FP32); FP16 sconv-delta
+overflow (deltas now FP32); a single shared-expert channel clipping FP16 at
+L41 (fixed by an exact ÷32/×32 prescale through the FFN output path); and
+the root cause of the garbage output — `mlp.global_scale` on the two dense
+layers is **BF16** while `mlp.gate.global_scale` is FP32, and the scalar
+reader assumed FP32, poisoning layers 0-1 with a garbage gain. The engine's
+own CPU parity harness could not catch that one (it shared the accessor);
+only the independent reference oracle could — which is why
+`Tests/.../InklingLayerParityTests.swift` keeps both modes.
+
+An earlier note in this section blamed a first garbage run on corrupt
+resumed shards — that was real, but The first real run
+produced garbage, and per-stage numeric probes (`MFERENCE_INKLING_DEBUG=1`)
+traced every NaN source to tensors whose bytes came from source shards 1–3 —
+exactly the three shards the original download had left truncated and the
+install had "repaired" with a byte-offset resume. The truncated files were
+not clean prefixes (the downloader wrote sparsely), so 128 tensors were
+corrupt on disk while all 28 shard headers still parsed and every
+size/hash check passed — install verification hashes what the converter
+*wrote*, not what it *read*. Lesson recorded: a resumed foreign download is
+untrusted input; re-fetch the whole shard or verify against upstream LFS
+digests before converting. A clean streaming reinstall from Hugging Face is
+the fix.
+
+Bring-up config note: the fused QKV GEMV and the constant-folded INT4 GEMV
+variants are bypassed for this family (plain generic GEMVs) — they were
+briefly suspected during the corruption hunt and are unproven at this
+family's shapes (`m == n == 4096`; fused (4096, 1024, 4096)). Re-enable one
+at a time against known-good output.
+
+Scope note: the text path is the target. The vision and audio towers ship in
+the checkpoint and are excluded by the planner. The MTP config block is
+present but the checkpoint carries **no** MTP tensors, so there is nothing to
+exclude there.


### PR DESCRIPTION
Adds the fourth model family: **Inkling-Small 276B-A12B** (Thinking Machines, Apache 2.0), running from [pipenetwork/Inkling-Small-MLX-4bit](https://huggingface.co/pipenetwork/Inkling-Small-MLX-4bit) with SSD-streamed experts on a 24 GB machine.

```
$ MferenceCLI --model inklingsmall.gturbo --prompt "The capital of France is" --max-new 16 --temperature 0
 Paris. The capital of Germany is Berlin. The capital of Italy is Rome.

chat: "What is the capital of France? Answer in one word." → Paris   [stop=endOfTurn]
```

## Quality vs upstream reference

Teacher-forced against the checkpoint's own `inkling_mlx` implementation (77-token text, all positions): **mean KLD 0.0089** (median 0.0015, p95 0.039), **top-1 agreement 97.4%**, teacher-forced **PPL 9.50 vs 9.33** reference (+1.8%, FP16 intermediate noise). Per-layer hidden states match the reference at cos ≥ 0.999.

## Checkpoint selection

Of ~a dozen public MLX conversions, this is the only one whose quantization matches the engine's contract (affine 4-bit g64 with BF16 scales for embedding/attention/experts; BF16 router like DSV4). The 3-bit/2-bit builds leave attention+embeddings in BF16, which the engine has no resident path for — and the 4-bit's ~3.4 GB resident set is what fits a 24 GB box. Source pinned by revision `9d6e4720` + index SHA-256. Full analysis in `docs/INKLING_SMALL.md`.

## Architecture (all new to the engine)

- **No RoPE** — a learned relative-position bias (`wr_du` → per-head 16-dim states mixing a bias-vs-distance bank), extent per layer kind (512 local / 1024 global), log-`tau` scaling on global layers past 128k
- **Depthwise short convolutions** (K=4) at four sites per layer with streaming fp32 state
- **Sigmoid router with shared-expert sinks**: 258 logits, correction bias for selection only, softmax over logsigmoid of the 6 selected + 2 shared logits — all fp32
- **2 leading dense-FFN layers** (16 384 wide); 40 MoE layers of 256 experts top-6 riding the existing INT4 MoE phase kernels (padded to the 8-slot contract with weight-0 duplicates — cache hits, zero extra I/O)
- **BF16-ranged numerics**: FP32 residual stream (hidden legitimately reaches ~5e5; FP16 overflowed at L23), FP32 sublayer deltas, and an exact ÷32/×32 prescale through the FFN output path

## Prefill: layer-major with expert-major streaming

Prefill cost is dominated by cold expert I/O, so chunks advance one layer at a time and each unique routed expert in the chunk is **read once and applied to every token routed to it** (single-expert GLU + weighted FP32 accumulation; the next expert's pread overlaps the current one's GPU work). **131-token prompt: 120.8 s → 75.4 s** (marginal 0.46 → 0.11 s/token; the gap widens with prompt length). Sequential replay retained behind `MFERENCE_INKLING_PREFILL=seq` as the correctness reference.

## Validation

- Four new Metal kernels parity-tested against CPU references; on the **real weights**: dense L0, MoE L2, global L5 attention, the head, and a 5-token deep-state composition — all cos ≥ 0.9999
- **Independent oracle**: layer-by-layer diff against upstream `inkling_mlx` on the same weights. This caught the final bug — dense layers' `mlp.global_scale` is BF16 while `gate.global_scale` is FP32; reading it as FP32 poisoned layers 0–1, invisible to the in-repo harness because engine and checker shared the accessor
- Fused QKV + constant-folded GEMV variants re-enabled after byte-identical A/B (both had been falsely suspected during a corrupt-shard incident)
- Conversion verified end to end; `--dry-run` install mode added
- **880 tests pass**

## Not in scope

- Vision/audio towers and MTP (text path only); context capped well below the advertised 1M (global-layer KV is 28.7 KB/token)

## Test plan

- [x] `swift test` — 880 tests, 143 suites green
- [x] Kernel CPU-parity suite (`InklingKernelTests`)
- [x] Real-model parity vs scalar reference (`InklingLayerParityTests`, env-gated)
- [x] Layer-by-layer + KLD + PPL vs upstream `inkling_mlx`
- [x] Greedy + sampled + chat-framed generation; chunked-vs-sequential prefill agreement

Note: All numbers are from MacBook M5 24GB
