### PR TITLE
fix: Inkling FP16 expert-row clip that rendered as "!!!!"; speed up prefill

### DIFF
--- a/Sources/Mference/Kernels/Inkling/InklingKernels.swift
+++ b/Sources/Mference/Kernels/Inkling/InklingKernels.swift
@@ -18,9 +18,11 @@ final class InklingKernels {
     private let routerGemvPSO: MTLComputePipelineState
     private let routerSelectPSO: MTLComputePipelineState
     private let gammaCombinePSO: MTLComputePipelineState
+    private let gammaCombineF32InPSO: MTLComputePipelineState
     private let scalePSO: MTLComputePipelineState
     private let headEpiloguePSO: MTLComputePipelineState
     private let scaleAccumPSO: MTLComputePipelineState
+    private let scaleAccumF32InPSO: MTLComputePipelineState
     private let f32ToF16PSO: MTLComputePipelineState
     private let f16ToF32PSO: MTLComputePipelineState
     private let sconvF32OutPSO: MTLComputePipelineState
@@ -31,6 +33,9 @@ final class InklingKernels {
     let routerLogits: MTLBuffer
     /// fp32 gammas for the 2 shared experts, written by the select kernel.
     let sharedGammas: MTLBuffer
+    /// One `uint`: how many real-vocabulary logits the head epilogue found
+    /// non-finite. Reset before each head dispatch, read after it completes.
+    let nonFiniteLogitCount: MTLBuffer
 
     init(context: MetalContext,
          numRouted: Int,
@@ -41,10 +46,14 @@ final class InklingKernels {
         self.routerGemvPSO = try context.pipeline("router_gemv_bf16_r4")
         self.routerSelectPSO = try context.pipeline("inkling_router_select")
         self.gammaCombinePSO = try context.pipeline("inkling_gamma_combine")
+        self.gammaCombineF32InPSO =
+            try context.pipeline("inkling_gamma_combine_f32in")
         self.scalePSO = try context.pipeline("inkling_scale_f16")
         self.headEpiloguePSO = try context.pipeline("inkling_head_epilogue")
         self.f16ToF32PSO = try context.pipeline("inkling_f16_to_f32")
         self.scaleAccumPSO = try context.pipeline("inkling_scale_accum_f32")
+        self.scaleAccumF32InPSO =
+            try context.pipeline("inkling_scale_accum_f32_from_f32")
         self.f32ToF16PSO = try context.pipeline("inkling_f32_to_f16")
         self.sconvF32OutPSO = try context.pipeline("inkling_sconv_step_f32out")
         self.residualAddF32DPSO = try context.pipeline("inkling_residual_add_f32d")
@@ -64,6 +73,22 @@ final class InklingKernels {
         }
         gammas.label = "inkling.sharedGammas"
         self.sharedGammas = gammas
+        guard let guardBuf = context.device.makeBuffer(
+            length: MemoryLayout<UInt32>.size,
+            options: .storageModeShared) else {
+            throw MetalError.libraryCompileFailed("inkling logit guard buffer allocation failed")
+        }
+        guardBuf.label = "inkling.nonFiniteLogitCount"
+        guardBuf.contents().storeBytes(of: UInt32(0), as: UInt32.self)
+        self.nonFiniteLogitCount = guardBuf
+    }
+
+    func resetNonFiniteLogitCount() {
+        nonFiniteLogitCount.contents().storeBytes(of: UInt32(0), as: UInt32.self)
+    }
+
+    var nonFiniteLogits: Int {
+        Int(nonFiniteLogitCount.contents().load(as: UInt32.self))
     }
 
     /// One decode step of the depthwise causal conv: `out = conv(x) + x`,
@@ -232,10 +257,12 @@ final class InklingKernels {
     func encodeGammaCombine(commandBuffer cb: MTLCommandBuffer,
                             a: MTLBuffer, b: MTLBuffer,
                             y: MTLBuffer,
-                            count: UInt32) {
+                            count: UInt32,
+                            inputsAreFloat32: Bool = false) {
         guard let enc = cb.makeComputeCommandEncoder() else { return }
         var n = count
-        enc.setComputePipelineState(gammaCombinePSO)
+        enc.setComputePipelineState(
+            inputsAreFloat32 ? gammaCombineF32InPSO : gammaCombinePSO)
         enc.setBuffer(a, offset: 0, index: 0)
         enc.setBuffer(b, offset: 0, index: 1)
         enc.setBuffer(sharedGammas, offset: 0, index: 2)
@@ -246,15 +273,18 @@ final class InklingKernels {
         enc.endEncoding()
     }
 
-    /// acc(f32, at offset) += w * x(f16).
+    /// acc(f32, at offset) += w * x, with `x` FP16 or (for expert outputs whose
+    /// raw rows leave FP16 range) FP32.
     func encodeScaleAccum(commandBuffer cb: MTLCommandBuffer,
                           acc: MTLBuffer, accOffset: Int,
                           x: MTLBuffer,
-                          weight: Float, count: UInt32) {
+                          weight: Float, count: UInt32,
+                          xIsFloat32: Bool = false) {
         guard let enc = cb.makeComputeCommandEncoder() else { return }
         var w = weight
         var n = count
-        enc.setComputePipelineState(scaleAccumPSO)
+        enc.setComputePipelineState(
+            xIsFloat32 ? scaleAccumF32InPSO : scaleAccumPSO)
         enc.setBuffer(acc, offset: accOffset, index: 0)
         enc.setBuffer(x, offset: 0, index: 1)
         enc.setBytes(&w, length: 4, index: 2)
@@ -368,8 +398,11 @@ final class InklingKernels {
         enc.endEncoding()
     }
 
-    /// Logits epilogue: scale the real vocabulary by `c` and pin the padding
-    /// tail to -inf so it can never be sampled.
+    /// Logits epilogue: scale the real vocabulary by `c`, pin the padding tail
+    /// to -inf so it can never be sampled, and count any non-finite real logit
+    /// into `nonFiniteLogitCount`. Callers must reset that counter (see
+    /// `resetNonFiniteLogitCount()`) before encoding and read it after the
+    /// command buffer completes.
     func encodeHeadEpilogue(commandBuffer cb: MTLCommandBuffer,
                             logits: MTLBuffer,
                             scale c: Float,
@@ -384,6 +417,7 @@ final class InklingKernels {
         enc.setBytes(&scale, length: 4, index: 1)
         enc.setBytes(&valid, length: 4, index: 2)
         enc.setBytes(&total, length: 4, index: 3)
+        enc.setBuffer(nonFiniteLogitCount, offset: 0, index: 4)
         enc.dispatchThreads(MTLSize(width: Int(totalVocab), height: 1, depth: 1),
                             threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
         enc.endEncoding()

--- a/Sources/Mference/Kernels/Inkling/InklingPrefillExpertGLU.swift
+++ b/Sources/Mference/Kernels/Inkling/InklingPrefillExpertGLU.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Metal
+
+/// Per-expert batched GLU for Inkling prefill.
+///
+/// Replaces the v1 pattern of one 3-GEMV dispatch per (token, expert) pair with
+/// one dispatch pair per expert covering every token routed to it. Worth 1.11x
+/// on a 2 785-token prompt; the kernel comment in
+/// `Metal/Prefill/prefill.metal` records why the ceiling is low (the expert
+/// loop is ~15 % of Inkling prefill), and `docs/INKLING_SMALL.md` explains why
+/// the accumulator has to be FP32.
+///
+/// Both routed and shared experts go through this: a shared expert is just an
+/// "expert" whose pair list is every chunk token, weighted by its per-token
+/// gamma.
+final class InklingPrefillExpertGLU {
+
+    /// Mirrors `InklingPrefillExpertParamsMSL`.
+    struct Params {
+        var d: UInt32
+        var f: UInt32
+        var pairStart: UInt32
+        var pairCount: UInt32
+        var hiddenStride: UInt32
+        var gateWOff: UInt32, gateSOff: UInt32, gateBOff: UInt32
+        var upWOff: UInt32,   upSOff: UInt32,   upBOff: UInt32
+        var downWOff: UInt32, downSOff: UInt32, downBOff: UInt32
+    }
+
+    private let actPSO: MTLComputePipelineState
+    private let downPSO: MTLComputePipelineState
+
+    init(context: MetalContext) throws {
+        // Inkling's hidden activation is SiLU; the shared prefill helper
+        // defaults to GELU unless function constant 77 says otherwise.
+        self.actPSO = try context.pipeline(
+            "inkling_prefill_expert_act",
+            constants: [MetalFunctionConstant(index: 77, value: .bool(true))])
+        self.downPSO = try context.pipeline("inkling_prefill_expert_down_accum")
+    }
+
+    /// Encodes gate/up/activation then down + weighted accumulate for one
+    /// expert. `expertBuffer` may be a streamed routed blob or the resident
+    /// tensor holding a shared expert; `params` carries the byte offsets either
+    /// way. `acc` is FP32 [tokens, d] and is accumulated into, not overwritten.
+    func encode(commandBuffer cb: MTLCommandBuffer,
+                hidden: MTLBuffer,
+                hiddenOffset: Int = 0,
+                pairTokens: MTLBuffer,
+                pairWeights: MTLBuffer,
+                expertBuffer: MTLBuffer,
+                expertOffset: Int,
+                act: MTLBuffer,
+                acc: MTLBuffer,
+                params: Params) {
+        guard params.pairCount > 0 else { return }
+        var p = params
+
+        if let enc = cb.makeComputeCommandEncoder() {
+            enc.setComputePipelineState(actPSO)
+            enc.setBuffer(hidden, offset: hiddenOffset, index: 0)
+            enc.setBuffer(pairTokens, offset: 0, index: 1)
+            enc.setBuffer(expertBuffer, offset: expertOffset, index: 2)
+            enc.setBuffer(act, offset: 0, index: 3)
+            enc.setBytes(&p, length: MemoryLayout<Params>.stride, index: 4)
+            enc.dispatchThreads(
+                MTLSize(width: Int(p.f), height: Int(p.pairCount), depth: 1),
+                threadsPerThreadgroup: MTLSize(width: 8, height: 8, depth: 1))
+            enc.endEncoding()
+        }
+
+        if let enc = cb.makeComputeCommandEncoder() {
+            enc.setComputePipelineState(downPSO)
+            enc.setBuffer(act, offset: 0, index: 0)
+            enc.setBuffer(pairTokens, offset: 0, index: 1)
+            enc.setBuffer(pairWeights, offset: 0, index: 2)
+            enc.setBuffer(expertBuffer, offset: expertOffset, index: 3)
+            enc.setBuffer(acc, offset: 0, index: 4)
+            enc.setBytes(&p, length: MemoryLayout<Params>.stride, index: 5)
+            enc.dispatchThreads(
+                MTLSize(width: Int(p.d), height: Int(p.pairCount), depth: 1),
+                threadsPerThreadgroup: MTLSize(width: 8, height: 8, depth: 1))
+            enc.endEncoding()
+        }
+    }
+}

--- a/Sources/Mference/Kernels/MoE/SharedExpertInt4.swift
+++ b/Sources/Mference/Kernels/MoE/SharedExpertInt4.swift
@@ -36,7 +36,8 @@ public final class SharedExpertInt4 {
                        y: MTLBuffer, yOffset: Int = 0,
                        scratchGate: MTLBuffer, scratchGateOffset: Int = 0,
                        scratchUp: MTLBuffer, scratchUpOffset: Int = 0,
-                       scratchAct: MTLBuffer, scratchActOffset: Int = 0) throws {
+                       scratchAct: MTLBuffer, scratchActOffset: Int = 0,
+                       outputFloat32: Bool = false) throws {
         guard gate.rows == up.rows, gate.cols == up.cols,
               down.rows == gate.cols, down.cols == gate.rows else {
             throw SharedExpertError.dimensionMismatch(
@@ -50,7 +51,8 @@ public final class SharedExpertInt4 {
             throw SharedExpertError.scratchTooSmall("need \(required) bytes per intermediate buffer")
         }
         let inputBytes = Int(gate.cols) * MemoryLayout<Float16>.stride
-        let outputBytes = Int(down.rows) * MemoryLayout<Float16>.stride
+        let outputBytes = Int(down.rows) * (outputFloat32
+            ? MemoryLayout<Float>.stride : MemoryLayout<Float16>.stride)
         guard xOffset >= 0, xOffset + inputBytes <= x.length else {
             throw SharedExpertError.scratchTooSmall("input range exceeds x buffer")
         }
@@ -91,7 +93,8 @@ public final class SharedExpertInt4 {
                     biases: down.biases, biasesOffset: down.biasesOffset,
                     x: scratchAct, xOffset: scratchActOffset,
                     y: y, yOffset: yOffset,
-                    m: down.rows, n: down.cols)
+                    m: down.rows, n: down.cols,
+                    outputFloat32: outputFloat32)
     }
 }
 
@@ -124,15 +127,21 @@ public final class SharedExpertRuntime {
                        y: MTLBuffer, yOffset: Int = 0,
                        scratchGate: MTLBuffer, scratchGateOffset: Int = 0,
                        scratchUp: MTLBuffer, scratchUpOffset: Int = 0,
-                       scratchAct: MTLBuffer, scratchActOffset: Int = 0) throws {
+                       scratchAct: MTLBuffer, scratchActOffset: Int = 0,
+                       outputFloat32: Bool = false) throws {
         switch implementation {
         case .int4(let runtime):
             try runtime.encode(commandBuffer: commandBuffer, x: x, xOffset: xOffset,
                                gate: gate, up: up, down: down, y: y, yOffset: yOffset,
                                scratchGate: scratchGate, scratchGateOffset: scratchGateOffset,
                                scratchUp: scratchUp, scratchUpOffset: scratchUpOffset,
-                               scratchAct: scratchAct, scratchActOffset: scratchActOffset)
+                               scratchAct: scratchAct, scratchActOffset: scratchActOffset,
+                               outputFloat32: outputFloat32)
         case .int8(let runtime):
+            guard !outputFloat32 else {
+                throw SharedExpertError.dimensionMismatch(
+                    "FP32 output is only implemented for the INT4 shared expert")
+            }
             try runtime.encode(commandBuffer: commandBuffer, x: x, xOffset: xOffset,
                                gate: gate, up: up, down: down, y: y, yOffset: yOffset,
                                scratchAct: scratchAct, scratchActOffset: scratchActOffset)

--- a/Sources/Mference/Kernels/Quant/DequantInt4GEMV.swift
+++ b/Sources/Mference/Kernels/Quant/DequantInt4GEMV.swift
@@ -20,6 +20,9 @@ final class DequantInt4GEMV {
 
     private let pipeline: MTLComputePipelineState
     private let specializedPipelines: [Shape: MTLComputePipelineState]
+    /// FP32-output variant, unspecialized. Only the store type differs, so the
+    /// result is bit-identical to `pipeline` for rows inside FP16 range.
+    private let f32OutPipeline: MTLComputePipelineState
 
     /// `additionalShapes` compiles extra constant-folded variants for a
     /// non-Gemma model's decode shapes. Measured: an unspecialized
@@ -28,6 +31,10 @@ final class DequantInt4GEMV {
          additionalShapes: [(m: Int, n: Int)] = []) throws {
         self.pipeline = try context.pipeline(
             "dequant_int4_gemv_simd",
+            constants: [],
+            maxTotalThreadsPerThreadgroup: 512)
+        self.f32OutPipeline = try context.pipeline(
+            "dequant_int4_gemv_simd_f32out",
             constants: [],
             maxTotalThreadsPerThreadgroup: 512)
 
@@ -59,7 +66,8 @@ final class DequantInt4GEMV {
                 y: MTLBuffer,
                 yOffset: Int = 0,
                 m: UInt32,
-                n: UInt32) {
+                n: UInt32,
+                outputFloat32: Bool = false) {
         precondition(n % UInt32(Quantization.groupSize) == 0,
                      "N must be a multiple of \(Quantization.groupSize)")
         // The kernel reads packed weights through a `ushort*`; the repacker
@@ -68,7 +76,9 @@ final class DequantInt4GEMV {
                      "dequant_int4_gemv_simd needs a 2-aligned weightsOffset, got \(weightsOffset)")
         guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
         encoder.setComputePipelineState(
-            specializedPipelines[Shape(m: m, n: n)] ?? pipeline)
+            outputFloat32
+                ? f32OutPipeline
+                : (specializedPipelines[Shape(m: m, n: n)] ?? pipeline))
         encoder.setBuffer(weights, offset: weightsOffset, index: 0)
         encoder.setBuffer(scales, offset: scalesOffset, index: 1)
         encoder.setBuffer(biases, offset: biasesOffset, index: 2)

--- a/Sources/Mference/Metal/Inkling/inkling.metal
+++ b/Sources/Mference/Metal/Inkling/inkling.metal
@@ -305,6 +305,22 @@ kernel void inkling_gamma_combine(
     y[i] = half(gammas[0] * float(a[i]) + gammas[1] * float(b[i]));
 }
 
+// FP32-input gamma combine. The two shared-expert down projections write FP32
+// rows (their raw magnitudes leave FP16 range — see
+// `inkling_scale_accum_f32_from_f32`); the gammas carry the 1/32 FFN prescale,
+// so the combined output is back inside FP16 range with room to spare.
+kernel void inkling_gamma_combine_f32in(
+    device const float* a      [[buffer(0)]],
+    device const float* b      [[buffer(1)]],
+    device const float* gammas [[buffer(2)]],
+    device       half*  y      [[buffer(3)]],
+    constant     uint&  count  [[buffer(4)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    y[i] = half(gammas[0] * a[i] + gammas[1] * b[i]);
+}
+
 // ----------------------------------------------------------------------------
 // FP32 residual-stream helpers. Inkling's residual grows past 55 000 by layer
 // 22 (BF16-trained, muP-style outlier channels) and overflows an FP16 stream
@@ -414,15 +430,30 @@ void inkling_rms_f32in(
 // padding rows of the 201 024-wide unembed can never be sampled (the real
 // vocabulary is 200 058).
 // ----------------------------------------------------------------------------
+// `bad` counts non-finite real-vocabulary logits. A NaN or infinity here is
+// always an engine fault upstream, and it used to be *invisible*: the CPU
+// argmax seeds its running best at (index 0, -infinity), every `v > best`
+// comparison against NaN is false, so an all-NaN row silently returned token
+// id 0 — which decodes to "!". Counting them lets the caller fail loudly
+// instead of emitting a plausible-looking exclamation mark.
 kernel void inkling_head_epilogue(
-    device       half*  x     [[buffer(0)]],
-    constant     float& c     [[buffer(1)]],
-    constant     uint&  valid [[buffer(2)]],
-    constant     uint&  total [[buffer(3)]],
+    device       half*         x     [[buffer(0)]],
+    constant     float&        c     [[buffer(1)]],
+    constant     uint&         valid [[buffer(2)]],
+    constant     uint&         total [[buffer(3)]],
+    device       atomic_uint*  bad   [[buffer(4)]],
     uint i [[thread_position_in_grid]]
 ) {
     if (i >= total) return;
-    x[i] = (i < valid) ? half(float(x[i]) * c) : half(-INFINITY);
+    if (i < valid) {
+        const float v = float(x[i]) * c;
+        if (!isfinite(v)) {
+            atomic_fetch_add_explicit(bad, 1u, memory_order_relaxed);
+        }
+        x[i] = half(v);
+    } else {
+        x[i] = half(-INFINITY);
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -439,6 +470,22 @@ kernel void inkling_scale_accum_f32(
 ) {
     if (i >= count) return;
     acc[i] = fma(float(x[i]), w, acc[i]);
+}
+
+// As above, but the expert output is already FP32. The GLU down projection
+// writes FP32 for this family because a single Inkling channel (layer 41,
+// channel 3895 on the released checkpoint) runs at 1e4-6e4 *before* its
+// routing weight or shared gamma is applied, so an FP16 store of the raw row
+// clips to infinity on the tokens that push it over 65 504.
+kernel void inkling_scale_accum_f32_from_f32(
+    device       float* acc   [[buffer(0)]],
+    device const float* x     [[buffer(1)]],
+    constant     float& w     [[buffer(2)]],
+    constant     uint&  count [[buffer(3)]],
+    uint i [[thread_position_in_grid]]
+) {
+    if (i >= count) return;
+    acc[i] = fma(x[i], w, acc[i]);
 }
 
 // f32 -> f16 narrowing copy (per-token staging of chunk vectors into the

--- a/Sources/Mference/Metal/Prefill/prefill.metal
+++ b/Sources/Mference/Metal/Prefill/prefill.metal
@@ -605,6 +605,100 @@ kernel void prefill_moe_reduce_token_major(
     h2[t * D + d] = half(acc);
 }
 
+// ----------------------------------------------------------------------------
+// Inkling batched expert application.
+//
+// The v1 Inkling prefill applied one expert to one token per dispatch: three
+// GEMVs plus an accumulate, repeated for every (token, expert) pair. These two
+// kernels invert the loop: one dispatch pair per EXPERT covers every chunk
+// token routed to it, so an expert's weight rows are read once per expert
+// instead of once per pair and the grid's token dimension supplies the reuse
+// through the cache.
+//
+// Measured effect, 2 785-token prompt on an M3 Ultra: prefill 228.9 s -> 205.7 s
+// (1.11x). Do not read more into it than that. `MFERENCE_PREFILL_BREAKDOWN=1`
+// shows why the ceiling is low — the routed-expert loop is only ~15 % of
+// prefill (8 % streaming, 6.6 % this compute); the other ~85 % is the
+// per-token attention / norm / short-conv replay elsewhere in
+// `prefillInklingChunk`, which is where the remaining time actually is.
+//
+// The accumulate needs no atomics: within a single expert a token appears at
+// most once, so no two threads of one dispatch touch the same `acc` element.
+// `acc` is FP32 because a raw Inkling expert row reaches ~6e4 before its
+// routing weight is applied and clips an FP16 store (docs/INKLING_SMALL.md,
+// "FFN output range").
+//
+// The same pair applies a SHARED expert too: pass every chunk token with the
+// per-token shared gamma as the weight.
+// ----------------------------------------------------------------------------
+struct InklingPrefillExpertParamsMSL {
+    uint d;                 // hidden size
+    uint f;                 // expert intermediate width
+    uint pair_start;        // first pair index for this expert
+    uint pair_count;        // tokens routed to this expert
+    uint hidden_stride;     // elements between token rows of `hidden`
+    uint gate_W_off, gate_s_off, gate_b_off;
+    uint up_W_off,   up_s_off,   up_b_off;
+    uint down_W_off, down_s_off, down_b_off;
+};
+
+kernel void inkling_prefill_expert_act(
+    device const half*                          hidden      [[buffer(0)]],
+    device const uint*                          pair_tokens [[buffer(1)]],
+    device const uint8_t*                       expert      [[buffer(2)]],
+    device half*                                act         [[buffer(3)]],
+    constant InklingPrefillExpertParamsMSL&     p           [[buffer(4)]],
+    uint2                                       gid         [[thread_position_in_grid]]
+) {
+    const uint f = gid.x;
+    const uint t = gid.y;
+    if (f >= p.f || t >= p.pair_count) return;
+
+    device const half* x = hidden
+        + uint(pair_tokens[p.pair_start + t]) * p.hidden_stride;
+    const float gate = prefill_moe_int4_gemv_row_dev(
+        expert + p.gate_W_off,
+        reinterpret_cast<device const bfloat*>(expert + p.gate_s_off),
+        reinterpret_cast<device const bfloat*>(expert + p.gate_b_off),
+        x, f, p.d);
+    const float up = prefill_moe_int4_gemv_row_dev(
+        expert + p.up_W_off,
+        reinterpret_cast<device const bfloat*>(expert + p.up_s_off),
+        reinterpret_cast<device const bfloat*>(expert + p.up_b_off),
+        x, f, p.d);
+    // Round gate and up to FP16 *before* combining. The per-token path this
+    // replaces stored both GEMV results to FP16 scratch and `silu_mul_fp16`
+    // read them back, so keeping the same two roundings keeps prefill's
+    // activations consistent with the decode path rather than slightly more
+    // accurate than it.
+    const float g = float(half(gate));
+    const float u = float(half(up));
+    act[t * p.f + f] = half(prefill_hidden_activation(g) * u);
+}
+
+kernel void inkling_prefill_expert_down_accum(
+    device const half*                          act          [[buffer(0)]],
+    device const uint*                          pair_tokens  [[buffer(1)]],
+    device const float*                         pair_weights [[buffer(2)]],
+    device const uint8_t*                       expert       [[buffer(3)]],
+    device float*                               acc          [[buffer(4)]],
+    constant InklingPrefillExpertParamsMSL&     p            [[buffer(5)]],
+    uint2                                       gid          [[thread_position_in_grid]]
+) {
+    const uint d = gid.x;
+    const uint t = gid.y;
+    if (d >= p.d || t >= p.pair_count) return;
+
+    const float value = prefill_moe_int4_gemv_row_dev(
+        expert + p.down_W_off,
+        reinterpret_cast<device const bfloat*>(expert + p.down_s_off),
+        reinterpret_cast<device const bfloat*>(expert + p.down_b_off),
+        act + t * p.f, d, p.f);
+    const uint token = pair_tokens[p.pair_start + t];
+    const uint index = token * p.d + d;
+    acc[index] = fma(pair_weights[p.pair_start + t], value, acc[index]);
+}
+
 kernel void prefill_grouped_routed_moe_batched_phase1(
     device const half*                                   hidden               [[buffer(0)]],
     device const PrefillTokenExpertPairMSL*              sorted_pairs         [[buffer(1)]],

--- a/Sources/Mference/Metal/Quant/dequant_int4.metal
+++ b/Sources/Mference/Metal/Quant/dequant_int4.metal
@@ -90,12 +90,19 @@ kernel void embed_lookup_int4(
 // Each threadgroup handles eight consecutive rows, one SIMD per row. The
 // larger work unit gives the scheduler enough independent rows while sharing
 // the L1-cached input-vector reads.
-static inline void dequant_int4_gemv_simd_body(
+//
+// `OutT` is the store type only — the dot product always accumulates in FP32.
+// `half` is the default everywhere; `float` exists for rows whose magnitude
+// can leave FP16 range before a downstream scale brings them back, which is
+// the case for Inkling's shared-expert down projection (see
+// docs/INKLING_SMALL.md, "FFN output range").
+template <typename OutT>
+static inline void dequant_int4_gemv_simd_body_t(
     device const uint8_t* W,
     device const bfloat*  scales,
     device const bfloat*  biases,
     device const half*    x,
-    device half*          y,
+    device OutT*          y,
     uint                  M,
     uint                  N,
     uint                  rows_per_tg,
@@ -167,8 +174,25 @@ static inline void dequant_int4_gemv_simd_body(
     }
     acc = simd_sum(acc);
     if (lane == 0) {
-        y[row] = half(acc);
+        y[row] = OutT(acc);
     }
+}
+
+static inline void dequant_int4_gemv_simd_body(
+    device const uint8_t* W,
+    device const bfloat*  scales,
+    device const bfloat*  biases,
+    device const half*    x,
+    device half*          y,
+    uint                  M,
+    uint                  N,
+    uint                  rows_per_tg,
+    uint                  tg_idx,
+    uint                  sg_idx,
+    uint                  lane
+) {
+    dequant_int4_gemv_simd_body_t<half>(W, scales, biases, x, y, M, N,
+                                        rows_per_tg, tg_idx, sg_idx, lane);
 }
 
 kernel void dequant_int4_gemv_simd(
@@ -188,6 +212,29 @@ kernel void dequant_int4_gemv_simd(
     const uint NN = int4_fc_n(N);
     dequant_int4_gemv_simd_body(W, scales, biases, x, y, MM, NN,
                                 rows_per_tg, tg_idx, sg_idx, lane);
+}
+
+// Same GEMV, FP32 output rows. Bit-identical arithmetic to
+// `dequant_int4_gemv_simd` — only the final store widens — so a caller can
+// swap it in wherever an output row can exceed FP16's 65 504 before the
+// scale that brings it back into range is applied downstream.
+kernel void dequant_int4_gemv_simd_f32out(
+    device const uint8_t* W      [[buffer(0)]],
+    device const bfloat*  scales [[buffer(1)]],
+    device const bfloat*  biases [[buffer(2)]],
+    device const half*    x      [[buffer(3)]],
+    device float*         y      [[buffer(4)]],
+    constant uint&        M      [[buffer(5)]],
+    constant uint&        N      [[buffer(6)]],
+    uint                  tg_idx [[threadgroup_position_in_grid]],
+    uint                  sg_idx [[simdgroup_index_in_threadgroup]],
+    uint                  lane   [[thread_index_in_simdgroup]]
+) {
+    constexpr uint rows_per_tg = 8;
+    const uint MM = int4_fc_m(M);
+    const uint NN = int4_fc_n(N);
+    dequant_int4_gemv_simd_body_t<float>(W, scales, biases, x, y, MM, NN,
+                                         rows_per_tg, tg_idx, sg_idx, lane);
 }
 
 

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -1,6 +1,25 @@
 import Foundation
 import Metal
 
+/// Faults detected at the Inkling output head. Both cases mean an
+/// intermediate went non-finite somewhere in the 42-layer stack; the head is
+/// simply the first place that can see it cheaply.
+public enum InklingHeadError: Error, CustomStringConvertible, Equatable {
+    case nonFiniteLogits(position: Int, count: Int)
+    case noFiniteLogit(position: Int)
+
+    public var description: String {
+        switch self {
+        case .nonFiniteLogits(let position, let count):
+            return "Inkling head produced \(count) non-finite logits at "
+                + "position \(position); an intermediate overflowed upstream"
+        case .noFiniteLogit(let position):
+            return "Inkling head produced no finite logit at position "
+                + "\(position); greedy argmax has no candidate"
+        }
+    }
+}
+
 public enum RDAdvicePolicyMode: String, Codable, Sendable, Equatable {
     case `default`
     case off
@@ -259,6 +278,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     // shared expert (empty for the leading dense layers, which instead use
     // `inklingDenseProjections[L]`).
     let inkling: InklingKernels?
+    let inklingPrefillGLU: InklingPrefillExpertGLU?
     let inklingConvStates: [InklingLayerConvState]
     let inklingRelScratch: MTLBuffer?        // [numHeads * dRel] FP16
     /// FP32 residual stream: Inkling's hidden state overflows FP16 by layer
@@ -276,8 +296,18 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     let inklingGammaChunk: MTLBuffer?        // [chunk, 2] FP32
     let inklingAccChunk: MTLBuffer?          // [chunk, D] FP32
     let inklingChunkCapacity: Int
-    let inklingSharedY0: MTLBuffer?          // [D] FP16
-    let inklingSharedY1: MTLBuffer?          // [D] FP16
+    /// Raw shared-expert down-projection rows, FP32. These are pre-gamma, so
+    /// the 1/32 FFN prescale does not protect them and single channels run to
+    /// ~6e4 on the released checkpoint — an FP16 store clips to infinity.
+    let inklingSharedY0: MTLBuffer?          // [D] FP32
+    let inklingSharedY1: MTLBuffer?          // [D] FP32
+    /// Prefill counterpart: one expert's raw GLU output row, FP32.
+    let inklingExpertOutF32: MTLBuffer?      // [D] FP32
+    /// Batched prefill expert application: the chunk's (token, expert) pairs
+    /// grouped by expert, and one expert's activation tile.
+    let inklingPairTokens: MTLBuffer?        // [chunk * 8] UInt32
+    let inklingPairWeights: MTLBuffer?       // [chunk * 8] FP32
+    let inklingExpertActScratch: MTLBuffer?  // [chunk, F] FP16
     let inklingSharedProjections: [[LayerSharedExpertProjections]]
     let inklingDenseProjections: [LayerSharedExpertProjections?]
     /// BF16 ones over [numExperts]; neutral per_expert_scale when the router
@@ -650,6 +680,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         self.sharedExpertProjections = sharedViews
 
         if cfg.family == .inklingSmall {
+            self.inklingPrefillGLU = try InklingPrefillExpertGLU(context: context)
             self.inkling = try InklingKernels(context: context,
                                               numRouted: cfg.numExperts,
                                               numShared: cfg.numSharedExperts)
@@ -657,7 +688,16 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingRelScratch = try buf(dRelWidth)
             self.inklingHiddenF32 = try buf(D, MemoryLayout<Float>.size)
             self.inklingDeltaF32 = try buf(D, MemoryLayout<Float>.size)
-            let chunkCap = 128
+            // Sized from the configured prefill chunk, not pinned at 128.
+            // Routed-expert prefill I/O scales with the CHUNK COUNT: a chunk
+            // re-reads every expert its tokens route to, and by ~128 tokens a
+            // chunk already touches ~95% of all 256 experts per layer
+            // (256 * (1 - (1 - 6/256)^128)), so the bytes read are essentially
+            // `ceil(prompt / chunk) * 40 layers * 3.6 GB`. Doubling the chunk
+            // halves the reads; the scratch below is linear in the cap and
+            // costs ~1.3 MB per token of capacity (~168 MB at 4096).
+            let chunkCap = max(1, min(runtimeConfiguration.prefillChunkTokens,
+                                      RuntimeConfiguration.allowedPrefillChunkTokens.last!))
             self.inklingChunkCapacity = chunkCap
             self.inklingHiddenChunk = try buf(chunkCap * D, MemoryLayout<Float>.size)
             self.inklingRoutedXChunk = try buf(chunkCap * D)
@@ -665,8 +705,13 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingWChunk = try buf(chunkCap * 8)
             self.inklingGammaChunk = try buf(chunkCap * 2, MemoryLayout<Float>.size)
             self.inklingAccChunk = try buf(chunkCap * D, MemoryLayout<Float>.size)
-            self.inklingSharedY0 = try buf(D)
-            self.inklingSharedY1 = try buf(D)
+            self.inklingSharedY0 = try buf(D, MemoryLayout<Float>.size)
+            self.inklingSharedY1 = try buf(D, MemoryLayout<Float>.size)
+            self.inklingExpertOutF32 = try buf(D, MemoryLayout<Float>.size)
+            // Pair lists cover top-6 routed + 2 shared per token.
+            self.inklingPairTokens = try buf(chunkCap * 8, MemoryLayout<UInt32>.size)
+            self.inklingPairWeights = try buf(chunkCap * 8, MemoryLayout<Float>.size)
+            self.inklingExpertActScratch = try buf(chunkCap * F)
             var convStates: [InklingLayerConvState] = []
             convStates.reserveCapacity(cfg.numLayers)
             let kvDim = cfg.numKVHeads * cfg.headDim
@@ -719,6 +764,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingDenseProjections = densePerLayer
         } else {
             self.inkling = nil
+            self.inklingPrefillGLU = nil
             self.inklingConvStates = []
             self.inklingRelScratch = nil
             self.inklingHiddenF32 = nil
@@ -732,6 +778,10 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingChunkCapacity = 0
             self.inklingSharedY0 = nil
             self.inklingSharedY1 = nil
+            self.inklingExpertOutF32 = nil
+            self.inklingPairTokens = nil
+            self.inklingPairWeights = nil
+            self.inklingExpertActScratch = nil
             self.inklingSharedProjections = []
             self.inklingDenseProjections = []
         }
@@ -2935,12 +2985,58 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
               + " nonfinite=\(bad)")
     }
 
+    /// Throws if the head epilogue counted any non-finite real-vocabulary
+    /// logit. A NaN or infinity in the logit row is always an engine fault
+    /// upstream (an overflowed intermediate, a poisoned cache entry), never a
+    /// model output — and left unchecked it does not look like a fault: the
+    /// argmax and the sampler both fall through to a low token id, which in
+    /// this vocabulary is `!`. Failing here turns silent mid-word corruption
+    /// into a report that names the position.
+    private func checkFiniteLogits(_ inkling: InklingKernels,
+                                   position: Int) throws {
+        let bad = inkling.nonFiniteLogits
+        guard bad == 0 else {
+            throw InklingHeadError.nonFiniteLogits(position: position, count: bad)
+        }
+    }
+
     /// FFN output pre-scale for the Inkling MoE path: router weights and
     /// shared-expert gammas are divided by this before the FP16 expert
     /// pipeline, and the residual add multiplies it back (linear, exact).
     /// Keeps BF16-magnitude outlier channels (observed > 65k at layer 41)
     /// inside half range through h1/h2 and the phase-2 reduce.
     static let inklingFFNPrescale: Float = 32.0
+
+    /// Splits Inkling prefill's routed-expert loop into fetch / encode / drain,
+    /// the prefill counterpart to `MFERENCE_PHASES` for decode. Off by default:
+    /// when disabled the loop skips the clock reads entirely.
+    ///
+    /// Worth keeping because the shape it revealed is counter-intuitive. On a
+    /// 2 785-token prompt the whole expert path — streaming *and* compute — is
+    /// ~15 % of prefill; the other ~85 % is the per-token attention / norm /
+    /// short-conv replay outside this loop, and it grows superlinearly with
+    /// context (13.3x for 6.6x the tokens) because 7 of 42 layers are global.
+    /// Optimize against a measurement from this, not against dispatch counts.
+    static let prefillBreakdownEnabled =
+        ProcessInfo.processInfo.environment["MFERENCE_PREFILL_BREAKDOWN"] == "1"
+    nonisolated(unsafe) static var prefillFetchNanos: UInt64 = 0
+    nonisolated(unsafe) static var prefillEncodeNanos: UInt64 = 0
+    nonisolated(unsafe) static var prefillDrainNanos: UInt64 = 0
+    nonisolated(unsafe) static var prefillExpertCount: UInt64 = 0
+    public static func dumpPrefillBreakdown() {
+        let f = Double(prefillFetchNanos) / 1e9
+        let e = Double(prefillEncodeNanos) / 1e9
+        let d = Double(prefillDrainNanos) / 1e9
+        FileHandle.standardError.write(Data(
+            ("[prefill] experts=\(prefillExpertCount) fetch=\(String(format: "%.1f", f))s " +
+             "encode=\(String(format: "%.1f", e))s drain=\(String(format: "%.1f", d))s " +
+             "perExpert: fetch=\(String(format: "%.2f", f*1000/Double(max(1,prefillExpertCount))))ms " +
+             "drain=\(String(format: "%.2f", d*1000/Double(max(1,prefillExpertCount))))ms\n").utf8))
+    }
+
+    /// Non-finite real logits counted by the last head dispatch. Zero on every
+    /// healthy step; a regression test asserts that directly.
+    var inklingNonFiniteLogitCount: Int { inkling?.nonFiniteLogits ?? 0 }
 
     /// Parity-test helper: advance the KV cursor after a stop-layer run so a
     /// following produce() at the next position lands in the right slot.
@@ -3261,7 +3357,8 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                y: sharedY0,
                                scratchGate: denseScratchGate,
                                scratchUp: denseScratchUp,
-                               scratchAct: denseScratchAct)
+                               scratchAct: denseScratchAct,
+                               outputFloat32: true)
             try! shared.encode(commandBuffer: cb,
                                x: routedX,
                                gate: sharedProjs[1].gate,
@@ -3270,10 +3367,13 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                y: sharedY1,
                                scratchGate: denseScratchGate,
                                scratchUp: denseScratchUp,
-                               scratchAct: denseScratchAct)
+                               scratchAct: denseScratchAct,
+                               outputFloat32: true)
+            // Gammas carry the 1/32 prescale, so h1Buf is back in FP16 range.
             inkling.encodeGammaCombine(commandBuffer: cb,
                                        a: sharedY0, b: sharedY1,
-                                       y: h1Buf, count: D)
+                                       y: h1Buf, count: D,
+                                       inputsAreFloat32: true)
             cb.commit()
             waitForRouterSignal(routerSignal, fallback: cb)
             if let p = pending { finishPending(p, waitIfNeeded: false); pending = nil }
@@ -3392,6 +3492,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                 // only the vocab truncation matters. The final norm runs from
                 // the FP32 stream first; the fused chain then consumes the
                 // pre-normed row via unit gains (fNorm already applied).
+                inkling.resetNonFiniteLogitCount()
                 runSync { cb in
                     inkling.encodeRMSF32(commandBuffer: cb, x: hiddenF32,
                                          weight: fNorm.buffer,
@@ -3409,17 +3510,27 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                                validVocab: validVocab,
                                                totalVocab: UInt32(self.cfg.vocabSize))
                 }
+                try checkFiniteLogits(inkling, position: position)
                 // Argmax on CPU over the truncated logits (bring-up path;
                 // the fused-head chain is FP16-hidden and not yet FP32-aware).
+                //
+                // `best` starts at index -1, not 0: a NaN fails every `>`
+                // comparison, so seeding at index 0 made an all-NaN row return
+                // token 0 ("!") as if it had won. The guard above already
+                // throws on that row; this keeps the invariant local.
                 let lp = logits.contents()
                     .bindMemory(to: Float16.self, capacity: Int(validVocab))
-                var best: (Int, Float) = (0, -.infinity)
+                var best: (Int, Float) = (-1, -.infinity)
                 for i in 0..<Int(validVocab) {
                     let v = Float(lp[i])
                     if v > best.1 { best = (i, v) }
                 }
+                guard best.0 >= 0 else {
+                    throw InklingHeadError.noFiniteLogit(position: position)
+                }
                 lastGreedyToken = UInt32(best.0)
             } else {
+                inkling.resetNonFiniteLogitCount()
                 runSync { cb in
                     inkling.encodeRMSF32(commandBuffer: cb, x: hiddenF32,
                                          weight: fNorm.buffer,
@@ -3437,6 +3548,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                                validVocab: validVocab,
                                                totalVocab: UInt32(self.cfg.vocabSize))
                 }
+                try checkFiniteLogits(inkling, position: position)
                 if Self.inklingDebugEnabled {
                     inklingDebugStats("head normed", normed, count: cfg.hiddenSize)
                     let lp = logits.contents()
@@ -3478,9 +3590,15 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
               let wChunk = inklingWChunk,
               let gammaChunk = inklingGammaChunk,
               let accChunk = inklingAccChunk,
+              let expertOutF32 = inklingExpertOutF32,
+              let pairTokens = inklingPairTokens,
+              let pairWeights = inklingPairWeights,
+              let actScratch = inklingExpertActScratch,
+              let prefillGLU = inklingPrefillGLU,
               let kv else {
             preconditionFailure("Inkling prefill state missing")
         }
+        _ = expertOutF32
         let N = tokens.count
         precondition(N <= inklingChunkCapacity,
                      "chunk \(N) exceeds capacity \(inklingChunkCapacity)")
@@ -3721,74 +3839,134 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             }
             let routedOffsets = model.routedExpertOffsets(layer: L)
             let F = UInt32(cfg.moeIntermediateSize)
-            func blobProjection(_ blob: TensorView, w: UInt32, sOff: UInt32,
-                                b: UInt32, rows: UInt32, cols: UInt32)
-                -> SharedExpertProjection {
-                SharedExpertProjection(weights: blob.buffer,
-                                       scales: blob.buffer,
-                                       biases: blob.buffer,
-                                       weightsOffset: Int(blob.offset) + Int(w),
-                                       scalesOffset: Int(blob.offset) + Int(sOff),
-                                       biasesOffset: Int(blob.offset) + Int(b),
-                                       rows: rows, cols: cols)
-            }
-            var pendingExpertCB: MTLCommandBuffer?
-            func encodeGLUGroup(gate: SharedExpertProjection,
-                                up: SharedExpertProjection,
-                                down: SharedExpertProjection,
-                                pairs: [(Int, Float)]) {
-                let cb = ctx.queue.makeCommandBuffer()!
-                for (i, w) in pairs {
-                    try! shared.encode(commandBuffer: cb,
-                                       x: routedXChunk, xOffset: xOff(i),
-                                       gate: gate, up: up, down: down,
-                                       y: h2Buf,
-                                       scratchGate: denseScratchGate,
-                                       scratchUp: denseScratchUp,
-                                       scratchAct: denseScratchAct)
-                    inkling.encodeScaleAccum(commandBuffer: cb,
-                                             acc: accChunk, accOffset: hOff(i),
-                                             x: h2Buf, weight: w, count: D)
-                }
-                cb.commit()
-                if let p = pendingExpertCB, let err = p.error {
-                    print("CB error: \(err)")
-                }
-                pendingExpertCB = cb
-            }
-            // Shared experts first (resident; gammas as weights).
+            // Flatten every (token, expert) pair into one expert-grouped list,
+            // uploaded once per chunk-layer. Each expert then costs two
+            // dispatches over its whole token set instead of three GEMVs per
+            // token: the v1 per-pair encoding spent ~250 us of dispatch
+            // overhead against ~17 us of bandwidth, and it dominated prefill.
+            //
+            // Shared experts come first, then routed experts in ascending id —
+            // the same accumulation order the per-pair path used, so the FP32
+            // sum per token is unchanged.
+            let tokPtr = pairTokens.contents().bindMemory(to: UInt32.self,
+                                                          capacity: N * 8)
+            let wgtPtr = pairWeights.contents().bindMemory(to: Float.self,
+                                                           capacity: N * 8)
+            struct ExpertPairRange { let expert: Int; let start: Int; let count: Int }
+            var sharedRanges: [ExpertPairRange] = []
+            var routedRanges: [ExpertPairRange] = []
+            var cursor = 0
             for s2 in 0..<cfg.numSharedExperts {
-                let projs = inklingSharedProjections[L][s2]
-                let pairs = (0..<N).map { ($0, gPtr[$0 * 2 + s2]) }
-                encodeGLUGroup(gate: projs.gate, up: projs.up, down: projs.down,
-                               pairs: pairs)
+                let start = cursor
+                for i in 0..<N {
+                    tokPtr[cursor] = UInt32(i)
+                    wgtPtr[cursor] = gPtr[i * 2 + s2]
+                    cursor += 1
+                }
+                sharedRanges.append(ExpertPairRange(expert: s2, start: start,
+                                                    count: N))
             }
-            // Routed experts, each streamed once for the whole chunk. The
-            // fetch of expert e+1 overlaps the GPU work of expert e.
-            let tIoStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
             for (e, pairs) in expertTokens.sorted(by: { $0.key < $1.key }) {
+                let start = cursor
+                for (i, w) in pairs {
+                    tokPtr[cursor] = UInt32(i)
+                    wgtPtr[cursor] = w
+                    cursor += 1
+                }
+                routedRanges.append(ExpertPairRange(expert: e, start: start,
+                                                    count: pairs.count))
+            }
+
+            func expertParams(_ range: ExpertPairRange,
+                              base: Int) -> InklingPrefillExpertGLU.Params {
+                InklingPrefillExpertGLU.Params(
+                    d: D, f: F,
+                    pairStart: UInt32(range.start),
+                    pairCount: UInt32(range.count),
+                    hiddenStride: D,
+                    gateWOff: UInt32(base) + routedOffsets.gateWOff,
+                    gateSOff: UInt32(base) + routedOffsets.gateSOff,
+                    gateBOff: UInt32(base) + routedOffsets.gateBOff,
+                    upWOff: UInt32(base) + routedOffsets.upWOff,
+                    upSOff: UInt32(base) + routedOffsets.upSOff,
+                    upBOff: UInt32(base) + routedOffsets.upBOff,
+                    downWOff: UInt32(base) + routedOffsets.downWOff,
+                    downSOff: UInt32(base) + routedOffsets.downSOff,
+                    downBOff: UInt32(base) + routedOffsets.downBOff)
+            }
+
+            // Shared experts (resident; per-token gammas as the pair weights).
+            // Their projections are separate tensors rather than one packed
+            // blob, so the byte offsets come from the views directly.
+            let sharedCB = ctx.queue.makeCommandBuffer()!
+            for range in sharedRanges {
+                let projs = inklingSharedProjections[L][range.expert]
+                var p = InklingPrefillExpertGLU.Params(
+                    d: D, f: F,
+                    pairStart: UInt32(range.start),
+                    pairCount: UInt32(range.count),
+                    hiddenStride: D,
+                    gateWOff: UInt32(projs.gate.weightsOffset),
+                    gateSOff: UInt32(projs.gate.scalesOffset),
+                    gateBOff: UInt32(projs.gate.biasesOffset),
+                    upWOff: UInt32(projs.up.weightsOffset),
+                    upSOff: UInt32(projs.up.scalesOffset),
+                    upBOff: UInt32(projs.up.biasesOffset),
+                    downWOff: UInt32(projs.down.weightsOffset),
+                    downSOff: UInt32(projs.down.scalesOffset),
+                    downBOff: UInt32(projs.down.biasesOffset))
+                p.pairStart = UInt32(range.start)
+                prefillGLU.encode(commandBuffer: sharedCB,
+                                  hidden: routedXChunk,
+                                  pairTokens: pairTokens,
+                                  pairWeights: pairWeights,
+                                  expertBuffer: projs.gate.weights,
+                                  expertOffset: 0,
+                                  act: actScratch,
+                                  acc: accChunk,
+                                  params: p)
+            }
+            sharedCB.commit()
+            waitForCompletion(sharedCB)
+
+            // Routed experts, each streamed once for the whole chunk.
+            let tIoStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+            let breakdown = Self.prefillBreakdownEnabled
+            func now() -> UInt64 {
+                breakdown ? clock_gettime_nsec_np(CLOCK_UPTIME_RAW) : 0
+            }
+            for range in routedRanges {
+                let t0 = now()
                 let blob = try await model.fetchRoutedExperts(layer: L,
-                                                              experts: [e])[0]
-                encodeGLUGroup(
-                    gate: blobProjection(blob, w: routedOffsets.gateWOff,
-                                         sOff: routedOffsets.gateSOff,
-                                         b: routedOffsets.gateBOff,
-                                         rows: F, cols: D),
-                    up: blobProjection(blob, w: routedOffsets.upWOff,
-                                       sOff: routedOffsets.upSOff,
-                                       b: routedOffsets.upBOff,
-                                       rows: F, cols: D),
-                    down: blobProjection(blob, w: routedOffsets.downWOff,
-                                         sOff: routedOffsets.downSOff,
-                                         b: routedOffsets.downBOff,
-                                         rows: D, cols: F),
-                    pairs: pairs)
-                // The next fetch may evict this expert's slot; drain first.
-                if let p = pendingExpertCB { waitForCompletion(p) }
-                pendingExpertCB = nil
+                                                              experts: [range.expert])[0]
+                let t1 = now()
+                let cb = ctx.queue.makeCommandBuffer()!
+                prefillGLU.encode(commandBuffer: cb,
+                                  hidden: routedXChunk,
+                                  pairTokens: pairTokens,
+                                  pairWeights: pairWeights,
+                                  expertBuffer: blob.buffer,
+                                  expertOffset: 0,
+                                  act: actScratch,
+                                  acc: accChunk,
+                                  params: expertParams(range, base: Int(blob.offset)))
+                cb.commit()
+                let t2 = now()
+                // The next fetch may evict this expert's slot, and the shared
+                // `act` tile is reused, so drain before moving on. This
+                // serialization is why fetch does not overlap GPU work; see
+                // PrefillRoutedTileScheduler for the pipelined alternative the
+                // other families use.
+                waitForCompletion(cb)
+                if breakdown {
+                    let t3 = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+                    Self.prefillFetchNanos &+= t1 - t0
+                    Self.prefillEncodeNanos &+= t2 - t1
+                    Self.prefillDrainNanos &+= t3 - t2
+                    Self.prefillExpertCount &+= 1
+                }
             }
             totalIoNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tIoStart
-            if let p = pendingExpertCB { waitForCompletion(p); pendingExpertCB = nil }
 
             // Tail: per token IN ORDER (mlp conv state), acc -> sconv -> add.
             let cbC = ctx.queue.makeCommandBuffer()!
@@ -3819,6 +3997,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             let validVocab = UInt32(cfg.unpaddedVocabSize > 0
                 ? cfg.unpaddedVocabSize : cfg.vocabSize)
             let muP = Float(1.0 / cfg.logitsWidthMultiplier)
+            inkling.resetNonFiniteLogitCount()
             runSync { cb in
                 inkling.encodeRMSF32(commandBuffer: cb,
                                      x: hiddenChunk, xOffset: hOff(N - 1),
@@ -3837,13 +4016,18 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                            validVocab: validVocab,
                                            totalVocab: UInt32(self.cfg.vocabSize))
             }
+            try checkFiniteLogits(inkling, position: startPosition + N - 1)
             if useFusedGreedyHead && outputMode == .greedyIfAvailable {
                 let lp = logits.contents()
                     .bindMemory(to: Float16.self, capacity: Int(validVocab))
-                var best: (Int, Float) = (0, -.infinity)
+                var best: (Int, Float) = (-1, -.infinity)
                 for i in 0..<Int(validVocab) {
                     let vl = Float(lp[i])
                     if vl > best.1 { best = (i, vl) }
+                }
+                guard best.0 >= 0 else {
+                    throw InklingHeadError.noFiniteLogit(
+                        position: startPosition + N - 1)
                 }
                 lastGreedyToken = UInt32(best.0)
             }

--- a/Sources/MferenceCLI/Args.swift
+++ b/Sources/MferenceCLI/Args.swift
@@ -27,6 +27,12 @@ public struct Args: Equatable, Sendable {
     public var expertCacheSlots: Int
     public var rdadvise: String
     public var prefillChunk: PrefillChunkChoice
+    /// Model-integrity policy. `.fullSha256` re-hashes every routed-expert
+    /// file on first touch — 145 GB for Inkling-Small, ~59 s inside the first
+    /// prefill. `.sizeCheckTrustedReceipt` checks sizes against the receipt
+    /// written at install time instead. Mirrors the Mac app's existing
+    /// verification control.
+    public var verification: ModelIntegrityPolicy
 
     public init(model: String,
                 prompt: String? = nil,
@@ -44,7 +50,8 @@ public struct Args: Equatable, Sendable {
                 quiet: Bool = false,
                 expertCacheSlots: Int = 16,
                 rdadvise: String = "off",
-                prefillChunk: PrefillChunkChoice = .fixed(128)) {
+                prefillChunk: PrefillChunkChoice = .fixed(128),
+                verification: ModelIntegrityPolicy = .fullSha256) {
         self.model = model
         self.prompt = prompt
         self.messagesFile = messagesFile
@@ -59,6 +66,7 @@ public struct Args: Equatable, Sendable {
         self.expertCacheSlots = expertCacheSlots
         self.rdadvise = rdadvise
         self.prefillChunk = prefillChunk
+        self.verification = verification
         self.seed = seed
         self.stops = stops
         self.quiet = quiet
@@ -121,6 +129,12 @@ extension Args {
                                 prompt processing; auto sizes the chunk to
                                 the prompt (--chat uses the default). Allowed:
                                 32, 64, 128, 256, 512, 1024, 2048, 4096.
+      --verify <mode>           Model integrity: full-sha256 (default)
+                                re-hashes every routed-expert file on first
+                                touch, which for a 145 GB expert pool costs
+                                ~59 s inside the first prefill;
+                                trusted-receipt checks file sizes against the
+                                receipt written at install time instead.
       --quiet                   Suppress the timing footer.
       --help                    Show this message.
     """
@@ -143,6 +157,7 @@ extension Args {
         var expertCacheSlots = 16
         var rdadvise = "off"
         var prefillChunk = PrefillChunkChoice.fixed(128)
+        var verification = ModelIntegrityPolicy.fullSha256
 
         var index = 0
         while index < argv.count {
@@ -225,6 +240,13 @@ extension Args {
                 } else {
                     throw ArgsError.invalidValue(flag: flag, value: value)
                 }
+            case "--verify":
+                let value = try takeValue(argv, &index, flag: flag)
+                switch value {
+                case "full-sha256": verification = .fullSha256
+                case "trusted-receipt": verification = .sizeCheckTrustedReceipt
+                default: throw ArgsError.invalidValue(flag: flag, value: value)
+                }
             case "--rdadvise":
                 let value = try takeValue(argv, &index, flag: flag)
                 guard ["off", "default", "bounded", "adaptive"].contains(value) else {
@@ -273,7 +295,8 @@ extension Args {
                     quiet: quiet,
                     expertCacheSlots: expertCacheSlots,
                     rdadvise: rdadvise,
-                    prefillChunk: prefillChunk)
+                    prefillChunk: prefillChunk,
+                    verification: verification)
     }
 
     private static func takeValue(_ argv: [String],

--- a/Sources/MferenceCLI/Run.swift
+++ b/Sources/MferenceCLI/Run.swift
@@ -83,7 +83,7 @@ public func run(args: Args,
             device: context.device,
             streamingMode: .pread(slotCount: runtime.expertCacheSlots),
             expertCachePolicy: runtime.modelExpertCachePolicy,
-            integrityPolicy: .fullSha256)
+            integrityPolicy: args.verification)
         let runner = try RealForwardRunner(
             model: model,
             context: context,
@@ -110,6 +110,9 @@ public func run(args: Args,
                 }
             }
 
+        if ProcessInfo.processInfo.environment["MFERENCE_PREFILL_BREAKDOWN"] == "1" {
+            RealForwardRunner.dumpPrefillBreakdown()
+        }
         if ProcessInfo.processInfo.environment["MFERENCE_PHASES"] == "1" {
             let ms = { (n: UInt64) in String(format: "%.1f", Double(n) / 1e6) }
             let total = stats.decodeSeconds * 1000
@@ -201,7 +204,7 @@ private func runChat(args: Args,
             device: context.device,
             streamingMode: .pread(slotCount: runtime.expertCacheSlots),
             expertCachePolicy: runtime.modelExpertCachePolicy,
-            integrityPolicy: .fullSha256)
+            integrityPolicy: args.verification)
         let runner = try RealForwardRunner(
             model: model,
             context: context,

--- a/Tests/Mference/Core/CLI/CLIArgumentsTests.swift
+++ b/Tests/Mference/Core/CLI/CLIArgumentsTests.swift
@@ -186,14 +186,19 @@ import Mference
         #expect(arguments.verification == .fullSha256)
     }
 
-    @Test(arguments: [("full-sha256", ModelIntegrityPolicy.fullSha256),
-                      ("trusted-receipt", ModelIntegrityPolicy.sizeCheckTrustedReceipt)])
-    func verifyAcceptsBothPolicies(value: String,
-                                   expected: ModelIntegrityPolicy) throws {
+    @Test func verifyAcceptsFullSha256() throws {
         let arguments = try Args.parse([
-            "--model", "m.gturbo", "--prompt", "hi", "--verify", value,
+            "--model", "m.gturbo", "--prompt", "hi", "--verify", "full-sha256",
         ])
-        #expect(arguments.verification == expected)
+        #expect(arguments.verification == .fullSha256)
+    }
+
+    @Test func verifyAcceptsTrustedReceipt() throws {
+        let arguments = try Args.parse([
+            "--model", "m.gturbo", "--prompt", "hi",
+            "--verify", "trusted-receipt",
+        ])
+        #expect(arguments.verification == .sizeCheckTrustedReceipt)
     }
 
     @Test(arguments: ["", "none", "sha", "trusted", "full"])

--- a/Tests/Mference/Core/CLI/CLIArgumentsTests.swift
+++ b/Tests/Mference/Core/CLI/CLIArgumentsTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Mference
 @testable import MferenceCLICore
 
 @Suite struct CLIArgumentsTests {
@@ -66,7 +67,7 @@ import Testing
             "--max-new", "--max-context",
             "--temperature", "--top-k", "--top-p", "--repetition-penalty",
             "--seed", "--stop", "--prefill-chunk", "--quiet", "--help",
-            "--rdadvise", "--expert-cache-slots",
+            "--rdadvise", "--expert-cache-slots", "--verify",
         ]
         let words = Args.usage.split { $0.isWhitespace || $0 == "(" || $0 == ")" }
         let options = Set(words.map(String.init).filter { $0.hasPrefix("--") })
@@ -174,6 +175,32 @@ import Testing
             _ = try Args.parse([
                 "--model", "m.gturbo", "--prompt", "hi",
                 "--prefill-chunk", value,
+            ])
+        }
+    }
+
+    /// Verification defaults to the strict policy: skipping the per-expert
+    /// hashes is a deliberate opt-in, not something a caller inherits.
+    @Test func verificationDefaultsToFullSha256() throws {
+        let arguments = try Args.parse(["--model", "m.gturbo", "--prompt", "hi"])
+        #expect(arguments.verification == .fullSha256)
+    }
+
+    @Test(arguments: [("full-sha256", ModelIntegrityPolicy.fullSha256),
+                      ("trusted-receipt", ModelIntegrityPolicy.sizeCheckTrustedReceipt)])
+    func verifyAcceptsBothPolicies(value: String,
+                                   expected: ModelIntegrityPolicy) throws {
+        let arguments = try Args.parse([
+            "--model", "m.gturbo", "--prompt", "hi", "--verify", value,
+        ])
+        #expect(arguments.verification == expected)
+    }
+
+    @Test(arguments: ["", "none", "sha", "trusted", "full"])
+    func verifyRejectsUnknownPolicies(value: String) {
+        #expect(throws: ArgsError.invalidValue(flag: "--verify", value: value)) {
+            _ = try Args.parse([
+                "--model", "m.gturbo", "--prompt", "hi", "--verify", value,
             ])
         }
     }

--- a/Tests/Mference/Core/Kernels/Quant/DequantInt4GEMVF32OutTests.swift
+++ b/Tests/Mference/Core/Kernels/Quant/DequantInt4GEMVF32OutTests.swift
@@ -106,9 +106,11 @@ import MferenceValidationSupport
         let f = try Self.makeFixture(m: 256, n: 2816, key: "in-range")
         let (half, float) = try Self.runBoth(f)
         for i in 0..<f.m {
+            // One interpolated literal, not a `+` concatenation: `#expect`'s
+            // comment argument is a `Comment`, which is expressible by string
+            // literal and interpolation but not by a `String` expression.
             #expect(Float(Float16(float[i])) == half[i],
-                    "row \(i): f32=\(float[i]) narrows to \(Float16(float[i])) "
-                        + "but the f16 kernel wrote \(half[i])")
+                    "row \(i): f32=\(float[i]) narrows to \(Float16(float[i])) but the f16 kernel wrote \(half[i])")
         }
         let ref = DequantInt4GemvRef.apply(weightRows: f.rows, x: f.xRef, n: f.n)
         let rel = RelError.compute(actual: float, reference: ref)
@@ -124,11 +126,9 @@ import MferenceValidationSupport
                                      weightRange: (4, 8), xRange: (20, 40))
         let (half, float) = try Self.runBoth(f)
         #expect(half.allSatisfy { !$0.isFinite },
-                "fixture must overflow FP16 to be a regression test; f16 rows "
-                    + "were \(half.prefix(4)), f32 rows \(float.prefix(4))")
+                "fixture must overflow FP16 to be a regression test; f16 rows were \(half.prefix(4)), f32 rows \(float.prefix(4))")
         #expect(float.allSatisfy { $0.isFinite },
-                "FP32 output must not produce non-finite rows: "
-                    + "\(float.prefix(4))")
+                "FP32 output must not produce non-finite rows: \(float.prefix(4))")
         #expect(float.allSatisfy { $0 > 65_504 },
                 "rows should land above the FP16 ceiling: \(float.prefix(4))")
         let ref = DequantInt4GemvRef.apply(weightRows: f.rows, x: f.xRef, n: f.n)

--- a/Tests/Mference/Core/Kernels/Quant/DequantInt4GEMVF32OutTests.swift
+++ b/Tests/Mference/Core/Kernels/Quant/DequantInt4GEMVF32OutTests.swift
@@ -1,0 +1,138 @@
+import Testing
+import Foundation
+import Metal
+@testable import Mference
+import MferenceValidationSupport
+
+/// `dequant_int4_gemv_simd_f32out` exists because Inkling's shared-expert down
+/// projection produces rows that leave FP16 range *before* the routing weight
+/// or shared gamma that brings them back. On the released 4-bit checkpoint,
+/// layer 41 channel 3895 sits at 1.5e4-6e4 on every token, and the token that
+/// pushed it to 69 307 clipped to `inf`, poisoned the FP32 residual, and made
+/// the whole logit row NaN — which the greedy argmax reported as token 0, `!`.
+///
+/// Two properties are locked here: the FP32 store is faithful to the FP16 one
+/// wherever FP16 can represent the row, and it does *not* clip where FP16
+/// would.
+@Suite struct DequantInt4GEMVF32OutTests {
+
+    private struct Fixture {
+        var rows: [Quantization.Int4AffineRow]
+        var weights: MTLBuffer
+        var scales: MTLBuffer
+        var biases: MTLBuffer
+        var x: MTLBuffer
+        var xRef: [Float]
+        var m: Int
+        var n: Int
+    }
+
+    /// `weightRange`/`xRange` are drawn uniformly. Signed ranges cancel and
+    /// keep rows small; all-positive ranges make every row a large sum, which
+    /// is how the overflow case is built.
+    private static func makeFixture(m: Int, n: Int, key: String,
+                                    weightRange: (Float, Float) = (-0.5, 0.5),
+                                    xRange: (Float, Float) = (-1, 1)) throws
+        -> Fixture
+    {
+        precondition(n % Quantization.groupSize == 0)
+        var rng = SeedTree(0x1AB_4F32).key(key)
+        var rows: [Quantization.Int4AffineRow] = []
+        rows.reserveCapacity(m)
+        for _ in 0..<m {
+            let raw = (0..<n).map { _ in
+                rng.uniform(weightRange.0, weightRange.1)
+            }
+            rows.append(Quantization.quantizeInt4Affine(raw))
+        }
+        let n2 = rows[0].packed.count
+        let s = rows[0].scales.count
+        var packed = [UInt8](repeating: 0, count: m * n2)
+        var scales = [UInt16](repeating: 0, count: m * s)
+        var biases = [UInt16](repeating: 0, count: m * s)
+        for row in 0..<m {
+            for i in 0..<n2 { packed[row * n2 + i] = rows[row].packed[i] }
+            for i in 0..<s {
+                scales[row * s + i] = rows[row].scales[i]
+                biases[row * s + i] = rows[row].biases[i]
+            }
+        }
+        let ctx = try MetalContext()
+        let xFp16 = (0..<n).map { _ in Float16(rng.uniform(xRange.0, xRange.1)) }
+        return Fixture(
+            rows: rows,
+            weights: ctx.device.makeBuffer(bytes: packed, length: packed.count,
+                                           options: .storageModeShared)!,
+            scales: ctx.device.makeBuffer(
+                bytes: scales, length: scales.count * MemoryLayout<UInt16>.size,
+                options: .storageModeShared)!,
+            biases: ctx.device.makeBuffer(
+                bytes: biases, length: biases.count * MemoryLayout<UInt16>.size,
+                options: .storageModeShared)!,
+            x: Fp16Buffer.make(ctx.device, halves: xFp16)!,
+            xRef: xFp16.map { Float($0) },
+            m: m, n: n)
+    }
+
+    private static func runBoth(_ f: Fixture)
+        throws -> (half: [Float], float: [Float])
+    {
+        let ctx = try MetalContext()
+        let kernel = try DequantInt4GEMV(context: ctx)
+        let yHalf = Fp16Buffer.make(ctx.device, count: f.m)!
+        let yFloat = ctx.device.makeBuffer(
+            length: f.m * MemoryLayout<Float>.size,
+            options: .storageModeShared)!
+        let cb = ctx.queue.makeCommandBuffer()!
+        kernel.encode(commandBuffer: cb,
+                      weights: f.weights, scales: f.scales, biases: f.biases,
+                      x: f.x, y: yHalf,
+                      m: UInt32(f.m), n: UInt32(f.n))
+        kernel.encode(commandBuffer: cb,
+                      weights: f.weights, scales: f.scales, biases: f.biases,
+                      x: f.x, y: yFloat,
+                      m: UInt32(f.m), n: UInt32(f.n),
+                      outputFloat32: true)
+        cb.commit()
+        cb.waitUntilCompleted()
+        let fp = yFloat.contents().bindMemory(to: Float.self, capacity: f.m)
+        return (Fp16Buffer.read(yHalf, count: f.m), (0..<f.m).map { fp[$0] })
+    }
+
+    /// In-range rows: narrowing the FP32 store reproduces the FP16 store
+    /// exactly, i.e. only the store width differs — the accumulation is
+    /// untouched.
+    @Test func f32OutRoundsToTheF16KernelInRange() throws {
+        let f = try Self.makeFixture(m: 256, n: 2816, key: "in-range")
+        let (half, float) = try Self.runBoth(f)
+        for i in 0..<f.m {
+            #expect(Float(Float16(float[i])) == half[i],
+                    "row \(i): f32=\(float[i]) narrows to \(Float16(float[i])) "
+                        + "but the f16 kernel wrote \(half[i])")
+        }
+        let ref = DequantInt4GemvRef.apply(weightRows: f.rows, x: f.xRef, n: f.n)
+        let rel = RelError.compute(actual: float, reference: ref)
+        #expect(rel < Tolerance.fp16Reduction, "rel=\(rel)")
+    }
+
+    /// The regression proper: all-positive weights and inputs make every row a
+    /// sum well past FP16's 65 504. The FP16 kernel saturates to infinity —
+    /// the Inkling layer-41 failure in miniature — and the FP32 kernel must
+    /// stay finite and track the reference.
+    @Test func f32OutDoesNotClipWhereF16Saturates() throws {
+        let f = try Self.makeFixture(m: 128, n: 2816, key: "overflow",
+                                     weightRange: (4, 8), xRange: (20, 40))
+        let (half, float) = try Self.runBoth(f)
+        #expect(half.allSatisfy { !$0.isFinite },
+                "fixture must overflow FP16 to be a regression test; f16 rows "
+                    + "were \(half.prefix(4)), f32 rows \(float.prefix(4))")
+        #expect(float.allSatisfy { $0.isFinite },
+                "FP32 output must not produce non-finite rows: "
+                    + "\(float.prefix(4))")
+        #expect(float.allSatisfy { $0 > 65_504 },
+                "rows should land above the FP16 ceiling: \(float.prefix(4))")
+        let ref = DequantInt4GemvRef.apply(weightRows: f.rows, x: f.xRef, n: f.n)
+        let rel = RelError.compute(actual: float, reference: ref)
+        #expect(rel < Tolerance.fp16Reduction, "rel=\(rel)")
+    }
+}

--- a/Tests/Mference/Core/Runtime/InklingGenerationRegressionTests.swift
+++ b/Tests/Mference/Core/Runtime/InklingGenerationRegressionTests.swift
@@ -1,0 +1,121 @@
+import Testing
+import Foundation
+import Metal
+@testable import Mference
+
+/// End-to-end generation regression for the Inkling family, run against the
+/// real install. Env-gated on `MFERENCE_INKLING_GTURBO`; skipped otherwise.
+///
+/// The bug this guards: layer 41's shared-expert down projection has a channel
+/// (3895 on the released 4-bit checkpoint) that runs at 1.5e4-6e4 on every
+/// token. It was stored as FP16, whose ceiling is 65 504, and the ÷32 FFN
+/// prescale is applied *after* that store, so it gave the raw row no headroom.
+/// A token that pushed the channel to 69 307 clipped to `-inf`; the FP32
+/// residual inherited it; the head's RMS norm turned `inf * 0` into NaN across
+/// the whole row; and the greedy argmax — seeded at `(index 0, -infinity)`,
+/// where every `>` comparison against NaN is false — returned token 0, which
+/// this vocabulary decodes as `!`. Because layer 41's `mlp_sconv` state holds
+/// the last K-1 = 3 inputs, one clipped token produced a four-token burst:
+///
+///     "Coastal wetlands—salt marshes, mang!!!! Wait, I need to be careful…"
+///
+/// Deterministic, and invisible to every install and manifest check.
+@Suite struct InklingGenerationRegressionTests {
+
+    /// docs/benchmark-prompts/real-generation-v1/<name>.json, located from this
+    /// file rather than an env var so the fixture cannot silently drift.
+    private static func benchmarkMessages(_ name: String) throws
+        -> [MFTokenizer.Message]
+    {
+        var root = URL(fileURLWithPath: #filePath)
+        for _ in 0..<5 { root.deleteLastPathComponent() }
+        let url = root
+            .appendingPathComponent("docs/benchmark-prompts/real-generation-v1")
+            .appendingPathComponent("\(name).json")
+        struct Turn: Decodable { let role: String; let content: String }
+        let turns = try JSONDecoder().decode(
+            [Turn].self, from: try Data(contentsOf: url))
+        return turns.map {
+            MFTokenizer.Message(role: $0.role == "system" ? .system : .user,
+                                content: $0.content)
+        }
+    }
+
+    /// The reported reproduction: greedy decode of the `short-explanation`
+    /// benchmark prompt must not contain a run of exclamation marks.
+    ///
+    /// `!!` is the assertion rather than `!` because a single exclamation mark
+    /// is ordinary prose; a run of two or more is the signature of consecutive
+    /// argmax fallbacks. `MFERENCE_INKLING_GTURBO` must point at the install
+    /// (~148 GB); this prefills 59 tokens and decodes 120, so expect a couple
+    /// of minutes.
+    @Test func shortExplanationHasNoExclamationBurst() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"] else { return }
+        let ctx = try MetalContext()
+        let modelURL = URL(fileURLWithPath: path)
+        let tokenizer = try await MFTokenizer.load(forModelDirectory: modelURL)
+        let config = GenerationConfig(maxNewTokens: 120, temperature: 0)
+        let runtime = RuntimeConfiguration(prefillChunkTokens: 128,
+                                           forceLogitsHead: !config.isPureGreedy)
+        let model = try Model.load(
+            directoryURL: modelURL,
+            device: ctx.device,
+            streamingMode: .pread(slotCount: runtime.expertCacheSlots),
+            expertCachePolicy: runtime.modelExpertCachePolicy)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                          maxContext: 4096,
+                                          runtimeConfiguration: runtime)
+        let scratch = try RawCompletionScratch(
+            context: ctx, vocab: model.config.vocabSize,
+            logitSoftcap: Float(model.config.finalLogitSoftcap))
+        let prompt = try tokenizer.applyChatTemplate(
+            try Self.benchmarkMessages("short-explanation"))
+        var text = ""
+        // A throw here is itself the regression firing: the head guard reports
+        // `InklingHeadError.nonFiniteLogits` for exactly the row that used to
+        // be silently reported as token 0.
+        _ = try await runRawCompletion(
+            producer: runner,
+            tokenizer: tokenizer,
+            promptIds: tokenizer.encode(prompt, addBOS: false),
+            config: config,
+            context: ctx,
+            scratch: scratch,
+            prefillConfig: runtime.prefillConfig) { progress in
+                switch progress {
+                case .prefill: break
+                case .token(_, _, let delta): text += delta
+                case .tail(let tail): text += tail
+                }
+            }
+        #expect(!text.contains("!!"),
+                "exclamation-mark burst in Inkling output — a logit row went "
+                    + "non-finite and the argmax fell back to token 0:\n\(text)")
+        // A burst replaced real text mid-word, so the completion also has to
+        // look like prose: the failing run reached 15 words before the burst,
+        // and every healthy run runs well past that.
+        #expect(text.split(separator: " ").count > 40,
+                "completion is implausibly short:\n\(text)")
+    }
+
+    /// The head guard itself: with a finite residual stream the epilogue must
+    /// report zero non-finite logits, so `produce()` cannot throw
+    /// `InklingHeadError`. Cheap — one token, no generation loop.
+    @Test func headReportsNoNonFiniteLogitsOnAHealthyStep() async throws {
+        guard let path = ProcessInfo.processInfo
+            .environment["MFERENCE_INKLING_GTURBO"] else { return }
+        let ctx = try MetalContext()
+        let cfg = try #require(ArchConfig.knownArchitectures[.inklingSmall])
+        let model = try Model.load(directoryURL: URL(fileURLWithPath: path),
+                                   device: ctx.device,
+                                   expecting: cfg)
+        let runner = try RealForwardRunner(model: model, context: ctx,
+                                          maxContext: 64)
+        let logits = ctx.device.makeBuffer(
+            length: cfg.vocabSize * MemoryLayout<Float16>.stride,
+            options: .storageModeShared)!
+        try await runner.produce(token: 200_028, position: 0, into: logits)
+        #expect(runner.inklingNonFiniteLogitCount == 0)
+    }
+}

--- a/Tests/Mference/Core/Runtime/InklingGenerationRegressionTests.swift
+++ b/Tests/Mference/Core/Runtime/InklingGenerationRegressionTests.swift
@@ -90,8 +90,7 @@ import Metal
                 }
             }
         #expect(!text.contains("!!"),
-                "exclamation-mark burst in Inkling output — a logit row went "
-                    + "non-finite and the argmax fell back to token 0:\n\(text)")
+                "exclamation-mark burst in Inkling output — a logit row went non-finite and the argmax fell back to token 0:\n\(text)")
         // A burst replaced real text mid-word, so the completion also has to
         // look like prose: the failing run reached 15 words before the burst,
         // and every healthy run runs well past that.

--- a/docs/INKLING_SMALL.md
+++ b/docs/INKLING_SMALL.md
@@ -336,7 +336,8 @@ the top perf follow-up).
 Post-first-light bug ledger (all found by CPU/oracle parity, in order):
 FP16 residual overflow at L23 (stream is now FP32); FP16 sconv-delta
 overflow (deltas now FP32); a single shared-expert channel clipping FP16 at
-L41 (fixed by an exact ÷32/×32 prescale through the FFN output path); and
+L41 (fixed by an exact ÷32/×32 prescale through the FFN output path — only
+partly, see **FFN output range** below); and
 the root cause of the garbage output — `mlp.global_scale` on the two dense
 layers is **BF16** while `mlp.gate.global_scale` is FP32, and the scalar
 reader assumed FP32, poisoning layers 0-1 with a garbage gain. The engine's
@@ -357,6 +358,116 @@ size/hash check passed — install verification hashes what the converter
 untrusted input; re-fetch the whole shard or verify against upstream LFS
 digests before converting. A clean streaming reinstall from Hugging Face is
 the fix.
+
+### FFN output range (2026-08-04)
+
+The ÷32/×32 prescale above was an incomplete fix, and the gap produced the
+first *plausible-looking* corruption this family has shipped: occasional long
+or rare words truncated mid-word and replaced by a burst of exclamation marks
+("salt marshes, mang**!!!!**" for "mangroves"; "cancellation / ded**!!!!**"
+for "deduplication"). Deterministic, reproducible under greedy decode, and
+absent from all three other families under the same harness.
+
+The prescale divides the router weights and the shared gammas, so it protects
+`h1`/`h2` — the *post*-gamma FFN output. It does nothing for the **raw
+shared-expert down-projection rows**, which are written before any gamma is
+applied. On the released checkpoint, layer 41 channel 3895 of that raw row
+runs at **1.5e4 – 6e4 on every token** — permanently within a factor of two
+of FP16's 65 504 ceiling. The token that pushed it to **69 307** clipped to
+`-inf`.
+
+The failure then laundered itself through four stages, which is why nothing
+caught it earlier:
+
+1. `-inf` reached the FP32 residual via the ×32 residual add. Layer 41 is the
+   last layer, so no KV entry was poisoned — only the layer's `mlp_sconv`
+   state, which holds the last `K-1 = 3` inputs. That is exactly the observed
+   **four-token** burst, self-clearing on the fifth.
+2. The head's RMS norm squared the `inf` into an `inf` sum-of-squares, so
+   `1/sqrt(ss)` was `0` and `-inf * 0` produced **NaN**, which the INT4 GEMV
+   then smeared across all 200 058 logits.
+3. The CPU greedy argmax seeds its running best at `(index 0, -infinity)`.
+   Every `v > best` comparison against NaN is false, so it returned **token
+   id 0** — and id 0 in this vocabulary is `!`. Both output-head paths emit the
+   same `!`, because the NaN row is produced upstream of the split: the greedy
+   fallback above is traced, and the sampled path's own degeneration on an
+   all-NaN distribution was not traced further once the shared cause was
+   established.
+4. Nothing in the manifest, install verification, or per-layer parity harness
+   inspects a mid-generation logit row, and a stray `!` reads as a model tic
+   rather than an engine fault.
+
+Fix: the shared-expert (and, in prefill, every streamed expert's) down
+projection writes **FP32** rows —
+`dequant_int4_gemv_simd_f32out`, consumed by `inkling_gamma_combine_f32in` in
+decode and `inkling_scale_accum_f32_from_f32` in prefill. Arithmetic is
+unchanged; only the store widens. Post-fix the same token's channel reads
+-69 307.5 and `h1` lands at -7 064, a 9× margin inside FP16, and the
+completion is "salt marshes, mangroves, and seagrass beds".
+
+Second fix, independent of the first: `inkling_head_epilogue` now counts
+non-finite real logits and the runner throws `InklingHeadError` on a non-zero
+count, with the argmax seed moved to index `-1`. Any future numeric blowup
+fails loudly at the position where it happens instead of rendering as `!`.
+
+Lesson recorded: a *scale applied after a narrowing store* protects nothing.
+When an outlier channel forces a prescale, the prescale has to sit upstream of
+every FP16 store on that path, or the store has to widen.
+
+Audit of the remaining FP16 stores on the FFN output path, for whoever hits
+the next one:
+
+| Store | Prescaled before it? | Measured headroom |
+|---|---|---|
+| routed down projection (decode, `moe_phase2_down_reduce_k8`) | yes — `routing_w` carries ÷32 and the reduce is FP32 | `h2` peaked at 4 764 of 65 504 |
+| shared down projection (decode + prefill) | **no** — gamma applies after | **overflowed**; now FP32 |
+| `h1` / `h2` after the gamma combine | yes | 7 064 of 65 504 at the worst observed token |
+| dense MLP down projection, layers 0-1 | **no** — `mlp.global_scale` applies after, same pattern | not overflowing: the L0/L1 residual peaks near 1e2, so ~500× margin. Left FP16 deliberately; widen it if those layers ever grow. |
+
+### Prefill cost profile (2026-08-04)
+
+Measured on an M3 Ultra / 256 GB with `MFERENCE_PREFILL_BREAKDOWN=1`, greedy,
+`--verify trusted-receipt --prefill-chunk auto`. Three changes landed together:
+receipt-based verification instead of re-hashing every expert file on first
+touch, a prefill chunk capacity that follows `--prefill-chunk` instead of a
+hardcoded 128, and per-expert batched GLUs replacing per-(token, expert)
+dispatches.
+
+| Prompt | Before | After | Gain |
+|---|---:|---:|---:|
+| short-explanation, 59 tok | 65.8 s | 9.6 s | 6.8x |
+| medium-review, 421 tok | 107.0 s | 28.2 s | 3.8x |
+| long-synthesis, 2 785 tok | 483.2 s | 205.7 s | 2.3x |
+
+Where the remaining 205.7 s of the long case goes:
+
+| Component | Time | Share |
+|---|---:|---:|
+| Routed-expert streaming (serialized, 1.89 ms x 8 651) | 16.4 s | 8.0 % |
+| Routed-expert compute (batched GLUs) | 13.5 s | 6.6 % |
+| Per-token attention / norm / short-conv / tail | 175.8 s | **85.5 %** |
+
+The last row is the one that matters, and it was not obvious: the whole expert
+path — streaming *and* compute — is ~15 % of prefill. It also grows
+superlinearly, 13.3x for 6.6x the tokens, because 7 of 42 layers are global
+while the other 35 are capped at window 512.
+
+Two consequences for whoever picks this up:
+
+1. **Batched prefill attention is the remaining work.** `PrefillAttention` /
+   `attention_prefill_causal_tiled` already exist and serve the other three
+   families; Inkling is the only one still replaying attention per token, and
+   that is why Gemma 4 prefills at 134 tok/s on this host and Inkling at 13.5.
+2. **Expert streaming is serialized.** `prefillInklingChunk` awaits a fetch,
+   encodes, then drains, so the fetch never overlaps GPU work.
+   `PrefillRoutedTileScheduler` implements the pipelined alternative.
+
+Method note, recorded because it cost real time: the first three attempts at
+this ranked the levers from dispatch counts and a per-pair cost fitted across
+prompt sizes. That fit was total prefill time divided by pair count, so it
+silently contained attention, the tail, and streaming — it looked constant
+because it measured everything, and every extrapolation from it was wrong by
+5-20x. Profile with `MFERENCE_PREFILL_BREAKDOWN=1` before optimizing.
 
 Bring-up config note: the fused QKV GEMV and the constant-folded INT4 GEMV
 variants are bypassed for this family (plain generic GEMVs) — they were

--- a/docs/RUNTIME_CONTROLS.md
+++ b/docs/RUNTIME_CONTROLS.md
@@ -71,16 +71,18 @@ benchmark protocol.
 | Prompt prefill | On, off | — | On | On processes known prompt tokens through the chunked prefill path. Off disables that path. |
 | RDADVISE | Off, Default, Bounded, Adaptive | `--rdadvise` | Off | Applies experimental read advice. Its effect depends on the workload; it may help a short decode and slow a long one. |
 | Prefill chunk tokens | 32, 64, 128, 256, 512, 1024, 2048, 4096, or auto | `--prefill-chunk` | 128 | Tokens processed per prefill chunk. Larger chunks re-read the routed experts fewer times, which lowers prefill I/O and time. `auto` picks the smallest allowed size that covers the whole prompt (interactive `--chat` keeps the default). Larger chunks use more prefill scratch memory, and on sliding-window models more KV ring memory. DeepSeek-V4 models prefill through the decode path and ignore the chunk size. |
+| Model verification | Full SHA-256, trusted receipt | `--verify` | Full SHA-256 | `full-sha256` re-hashes each routed-expert file on first touch, which for a 145 GB expert pool costs about 59 s inside the first prefill. `trusted-receipt` instead checks each file's size against the receipt written at install time; the receipt itself is still validated against the manifest hash, and `model_weights.bin` and `layout.json` are still hashed. It trades detection of size-preserving corruption for that time. The Mac app exposes the same choice. |
 
 The prefill chunk size is a CLI control; the Mac app uses the default.
 The CLI applies these settings when it loads the model, so each run uses the
 values passed on its command line. Setting `MFERENCE_PHASES=1` makes the
 CLI print the decode phase split (`cb1`, expert I/O await, `cb2`, and GPU
-waits) after the timing footer; it is a diagnostic and does not change
-behavior.
+waits) after the timing footer; `MFERENCE_PREFILL_BREAKDOWN=1` prints the
+Inkling prefill routed-expert split (fetch, encode, drain). Both are
+diagnostics and do not change behavior.
 
-Changing context length, expert-cache slots, RDADVISE, or the prefill chunk
-size requires a reload.
+Changing context length, expert-cache slots, RDADVISE, model verification, or
+the prefill chunk size requires a reload.
 Some sampling changes also require a reload because greedy and sampled
 generation use different output-head paths. Prompt-prefill settings apply to
 each request and do not require a reload.


### PR DESCRIPTION
## Summary

Two related pieces of work on the `inklingSmall` family.

**A deterministic token corruption, root-caused and fixed.** Occasional long or
rare words were truncated mid-word and replaced by a burst of exclamation marks
— `"salt marshes, mang!!!!"` for "mangroves", `"cancellation / ded!!!!"` for
"deduplication" — reproducibly, under both greedy and sampled decoding, and
only on this family.

Layer 41's shared-expert down projection stored its **raw** output rows as FP16.
The ÷32 FFN prescale added earlier for this very outlier channel divides the
router weights and shared gammas, and those apply *after* that store, so the raw
row got no headroom at all: channel 3895 runs at 1.5e4–6e4 on **every** token
against FP16's 65504 ceiling. The token that pushed it to −69307.5 clipped to
`-inf`.

Four stages then hid it, which is why install verification, manifest checks and
the layer-parity harness all passed:

1. The `-inf` entered the FP32 residual. Layer 41 is the last layer, so no KV
   entry was poisoned — only its `mlp_sconv` state, which holds the last
   K−1 = 3 inputs. That is the four-token burst, self-clearing on the fifth.
2. The head's RMS norm squared the `inf`, so `1/sqrt(ss)` was 0 and
   `-inf * 0` = **NaN** across all 200 058 logits.
3. The CPU argmax seeds at `(index 0, -infinity)`; every `>` against NaN is
   false, so it returned **token id 0** — which this vocabulary decodes as `!`.
4. Nothing inspects a mid-generation logit row, and a stray `!` reads as a model
   tic rather than an engine fault.

The leading hypothesis in the report (logit truncation to 200 058) was **not**
the cause: truncation is correctly applied on both head paths and the padding
tail is properly pinned to −inf.

**Prefill time.** Three measured changes, described under Memory and
performance.

## Validation

```bash
swift build -c release            # all 5 products, exit 0
ruby Scripts/check_markdown_links.rb   # 25 files, all links resolve
```

`Scripts/test.sh` **cannot run on this host** and this is pre-existing on
`main`: `xcode-select -p` is `/Library/Developer/CommandLineTools` with no
Xcode.app, and the CLT ships `_Testing_Foundation.framework` as a binary with no
module interface, so every `import Testing` fails with
`no such module '_Testing_Foundation'`. The new tests were validated instead by
type-checking against the real modules and running macro-free mirrors of their
bodies through a temporary SwiftPM target (since removed):

```
in-range: mismatches=0 rel=1.2101975e-07 tol=0.005
overflow: f16[0]=inf f32[0]=502325.75 rel=1.2280498e-07
words=77 contains(!!)=false   nonFiniteLogitCount=0
ALL PASS
```

Real-model runs, `scratch/inklingsmall.gturbo`, Mac Studio `Mac15,14` M3 Ultra
32-core / 256 GB, macOS 26.3, Swift 6.2.4, `--max-context 4096`:

| Run | Before | After |
|---|---|---|
| short-explanation, greedy | `salt marshes, mang!!!!` | `salt marshes, mangroves, and seagrass beds` |
| short-explanation, T=0.2 topK=64 topP=0.95 seed=20260721 | 1 burst, md5 `cc719d66…`, 463 tok | **0 bursts**, md5 `f8e19d11…`, 498 tok, endOfTurn |
| medium-review | `cancellation / ded!!!!:**` | 0 bursts |
| long-synthesis | 0 bursts | 0 bursts |
| `sharedY0[3895]` @ pos 68 | `-inf` | `-69307.5` |
| `h1[3895]` @ pos 68 | `-inf` | `-7064` (9× FP16 margin) |
| Gemma 4 smoke (shared GEMV was refactored) | — | clean, 26.4 tok/s |

The batched prefill path matches the `MFERENCE_INKLING_PREFILL=seq` decode-replay
reference token-for-token. It is **not** byte-identical to the old prefill: the
old chain rounded gate and up to FP16 separately before multiplying, so the new
kernel reproduces both roundings deliberately, to keep prefill's activations
consistent with decode rather than silently more accurate. Exact bit-identity
isn't reachable anyway — the two GEMVs use different accumulation orders (~1e-7
relative, far below the FP16 activation store).

## Memory and performance

Bounded memory is preserved: no complete checkpoint, shard, or large tensor
enters Swift heap memory. The FP32 widening adds three `[D]` FP32 buffers
(48 KB) and the batched prefill adds pair lists plus one activation tile, all
linear in the prefill chunk (~1.3 MB per token of capacity, ~168 MB at 4096).
Raising the Inkling chunk capacity to follow `--prefill-chunk` is what costs
that scratch; it stays at 128 unless asked.

Prefill seconds, greedy, `--verify trusted-receipt --prefill-chunk auto`:

| Prompt | Before | After | Gain |
|---|---:|---:|---:|
| 59 tok | 65.8 | 9.6 | **6.8×** |
| 421 tok | 107.0 | 28.2 | **3.8×** |
| 2 785 tok | 483.2 | 205.7 | **2.3×** |

Attribution, because the three changes are very unequal:

- `--verify trusted-receipt` is most of it: −56 s on every process start. The
  fixed cost was lazy SHA-256 of the 145 GB expert pool on first touch, not mmap.
- Chunk capacity is worth 2.1× on the long prompt (424 → 229 s).
- Batched expert GLUs are worth **1.11×** (229 → 206 s).

`MFERENCE_PREFILL_BREAKDOWN=1` explains that last figure and is the most useful
thing here. On the 2 785-token prompt: expert streaming 16.4 s (8.0 %), expert
compute 13.5 s (6.6 %), and **per-token attention / norm / short-conv replay
175.8 s (85.5 %)** — which also grows superlinearly, 13.3× for 6.6× the tokens,
since 7 of 42 layers are global. The entire expert path is ~15 % of prefill, so
no further expert work can exceed ~1.17×.

Decode is unchanged throughout (5.1–8.3 tok/s, varying with prompt length, not
with any of these changes).

## Remaining limitations

- **Batched prefill attention is the real remaining lever** (85 % above).
  `PrefillAttention` / `attention_prefill_causal_tiled` already serve the other
  three families; Inkling is the only one still replaying attention per token,
  and that is why Gemma 4 prefills at 134 tok/s on this host and Inkling at 13.5.
- **Expert streaming is serialized**: `prefillInklingChunk` awaits a fetch,
  encodes, then drains, so fetch never overlaps GPU work (8 % of prefill).
  `PrefillRoutedTileScheduler` implements the pipelined alternative.
- The dense-MLP down projection at layers 0–1 has the same
  scale-after-a-narrowing-store shape as the bug fixed here, but its residual
  peaks near 1e2 (~500× margin). Left FP16 deliberately and recorded in the
  FP16-store audit table in `docs/INKLING_SMALL.md`.
- `--verify trusted-receipt` drops detection of size-preserving content
  corruption in expert files. The receipt is still validated against the
  manifest hash and all sizes are checked, and it is opt-in with the strict
  policy as the default.
- `benchmark-results/inklingsmall/` still holds the pre-fix artifacts;
  regenerating the suite is ~35 min of model runs and was left out of scope.
- Test-suite execution is blocked host-side as described under Validation.

- [x] The change does not load a complete checkpoint, shard, or large model
      tensor into Swift heap memory.
- [x] Logs and artifacts contain no credentials, private paths, or model
      weights.
