### PR TITLE
docs: drop the stale 'forward pass is not implemented' claim from INKLING_SMALL.md

### DIFF
--- a/docs/INKLING_SMALL.md
+++ b/docs/INKLING_SMALL.md
@@ -6,9 +6,12 @@ Checkpoint selection, memory budget, and the architecture gap list for running
 document is the architecture contract for the `inklingSmall` family.
 
 Conversion has been run and verified against the real checkpoint (see
-**Status**). Throughput numbers remain *estimates* calibrated against measured
-DSV4-Flash performance on the same machine — no Inkling token has been
-generated yet, because the forward pass is not implemented.
+**Status**), and the forward pass has since shipped: measured decode is
+5.3–6.9 tok/s at an ~8.9 GiB peak footprint on an M3 Ultra
+([BENCHMARKS_M3_ULTRA.md](BENCHMARKS_M3_ULTRA.md)). Throughput figures
+elsewhere in this document that are labeled *estimates* predate those runs
+and are kept for the planning context they carried; the benchmark document
+is the measured record.
 
 ## Checkpoint selection
 


### PR DESCRIPTION
## What changed

The INKLING_SMALL.md intro still described the pre-#4 state — "no Inkling token has been generated yet, because the forward pass is not implemented". Since #4 shipped the forward pass and #7 fixed the FP16 expert-row clip, real generations are measured: 5.3–6.9 tok/s decode at an ~8.9 GiB peak on M3 Ultra (docs/BENCHMARKS_M3_ULTRA.md).

The intro now states that, and frames the remaining *estimate*-labeled figures in the document as pre-measurement planning context, with the benchmark document as the measured record. No other stale claims found (grepped for "not implemented" / "no Inkling token" across the doc).

## Verification

`ruby Scripts/check_markdown_links.rb` — 26 files, all local links and anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)