### PR TITLE
Accelerate Inkling prefill with batched Metal kernels

### DIFF
--- a/Sources/Mference/Kernels/Inkling/InklingKernels.swift
+++ b/Sources/Mference/Kernels/Inkling/InklingKernels.swift
@@ -13,10 +13,17 @@ import Metal
 /// semantics (see docs/INKLING_SMALL.md "Forward-pass contract").
 final class InklingKernels {
     private let sconvPSO: MTLComputePipelineState
+    private let sconvPrefillF16PSO: MTLComputePipelineState
+    private let sconvPrefillResidualPSO: MTLComputePipelineState
     private let qkNormPSO: MTLComputePipelineState
+    private let qkNormPrefillPSO: MTLComputePipelineState
     private let attentionPSO: MTLComputePipelineState
+    private let attentionPrefillPSO: MTLComputePipelineState
+    private let attentionPrefillTensorOpsPSO: MTLComputePipelineState?
     private let routerGemvPSO: MTLComputePipelineState
     private let routerSelectPSO: MTLComputePipelineState
+    private let routerGemvPrefillPSO: MTLComputePipelineState
+    private let routerSelectPrefillPSO: MTLComputePipelineState
     private let gammaCombinePSO: MTLComputePipelineState
     private let gammaCombineF32InPSO: MTLComputePipelineState
     private let scalePSO: MTLComputePipelineState
@@ -29,6 +36,7 @@ final class InklingKernels {
     private let residualAddF32DPSO: MTLComputePipelineState
     private let residualAddF32PSO: MTLComputePipelineState
     private let rmsF32PSO: MTLComputePipelineState
+    private let rmsF32PrefillPSO: MTLComputePipelineState
     /// fp32 logits for the 256 routed + 2 shared sink scores.
     let routerLogits: MTLBuffer
     /// fp32 gammas for the 2 shared experts, written by the select kernel.
@@ -38,13 +46,30 @@ final class InklingKernels {
     let nonFiniteLogitCount: MTLBuffer
 
     init(context: MetalContext,
-         numRouted: Int,
+        numRouted: Int,
          numShared: Int) throws {
         self.sconvPSO = try context.pipeline("inkling_sconv_step")
+        self.sconvPrefillF16PSO = try context.pipeline("inkling_sconv_prefill_f16out")
+        self.sconvPrefillResidualPSO =
+            try context.pipeline("inkling_sconv_prefill_residual_f32")
         self.qkNormPSO = try context.pipeline("inkling_qk_norm")
+        self.qkNormPrefillPSO = try context.pipeline("inkling_qk_norm_prefill")
         self.attentionPSO = try context.pipeline("inkling_attention_decode")
+        self.attentionPrefillPSO = try context.pipeline("inkling_attention_prefill")
+        if context.device.supportsApple10TensorOps,
+           let library = try? MetalContext.moduleLibrary(
+               device: context.device, module: "tensorops"),
+           let function = library.makeFunction(
+               name: "inkling_attention_prefill_tensorops") {
+            self.attentionPrefillTensorOpsPSO =
+                try? context.device.makeComputePipelineState(function: function)
+        } else {
+            self.attentionPrefillTensorOpsPSO = nil
+        }
         self.routerGemvPSO = try context.pipeline("router_gemv_bf16_r4")
         self.routerSelectPSO = try context.pipeline("inkling_router_select")
+        self.routerGemvPrefillPSO = try context.pipeline("inkling_router_gemv_prefill")
+        self.routerSelectPrefillPSO = try context.pipeline("inkling_router_select_prefill")
         self.gammaCombinePSO = try context.pipeline("inkling_gamma_combine")
         self.gammaCombineF32InPSO =
             try context.pipeline("inkling_gamma_combine_f32in")
@@ -59,6 +84,7 @@ final class InklingKernels {
         self.residualAddF32DPSO = try context.pipeline("inkling_residual_add_f32d")
         self.residualAddF32PSO = try context.pipeline("inkling_residual_add_f32")
         self.rmsF32PSO = try context.pipeline("inkling_rms_f32in")
+        self.rmsF32PrefillPSO = try context.pipeline("inkling_rms_f32in_prefill")
         guard let logits = context.device.makeBuffer(
             length: (numRouted + numShared) * MemoryLayout<Float>.size,
             options: .storageModeShared) else {
@@ -91,6 +117,10 @@ final class InklingKernels {
         Int(nonFiniteLogitCount.contents().load(as: UInt32.self))
     }
 
+    var tensorOpsPrefillAttentionAvailable: Bool {
+        attentionPrefillTensorOpsPSO != nil
+    }
+
     /// One decode step of the depthwise causal conv: `out = conv(x) + x`,
     /// fp32 state (last K-1 inputs per channel) updated in place.
     func encodeSconvStep(commandBuffer cb: MTLCommandBuffer,
@@ -110,6 +140,57 @@ final class InklingKernels {
         enc.setBuffer(out, offset: outOffset, index: 3)
         enc.setBytes(&c, length: 4, index: 4)
         enc.setBytes(&k, length: 4, index: 5)
+        enc.dispatchThreads(MTLSize(width: Int(channels), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// Chunked K/V short convolution. Inkling fixes K=4, so one GPU thread
+    /// keeps a channel's three-value history in registers while walking rows.
+    func encodeSconvPrefill(commandBuffer cb: MTLCommandBuffer,
+                            x: MTLBuffer,
+                            state: MTLBuffer,
+                            weight: MTLBuffer, weightOffset: Int,
+                            out: MTLBuffer,
+                            channels: UInt32,
+                            rows: UInt32) {
+        guard rows > 0, let enc = cb.makeComputeCommandEncoder() else { return }
+        var c = channels
+        var t = rows
+        enc.setComputePipelineState(sconvPrefillF16PSO)
+        enc.setBuffer(x, offset: 0, index: 0)
+        enc.setBuffer(state, offset: 0, index: 1)
+        enc.setBuffer(weight, offset: weightOffset, index: 2)
+        enc.setBuffer(out, offset: 0, index: 3)
+        enc.setBytes(&c, length: 4, index: 4)
+        enc.setBytes(&t, length: 4, index: 5)
+        enc.dispatchThreads(MTLSize(width: Int(channels), height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// Chunked attention/MLP short convolution fused with the FP32 residual
+    /// update. `scale` is one for attention and the FFN un-prescale for MLP.
+    func encodeSconvPrefillResidual(commandBuffer cb: MTLCommandBuffer,
+                                    x: MTLBuffer,
+                                    state: MTLBuffer,
+                                    weight: MTLBuffer, weightOffset: Int,
+                                    hidden: MTLBuffer,
+                                    channels: UInt32,
+                                    rows: UInt32,
+                                    scale: Float = 1.0) {
+        guard rows > 0, let enc = cb.makeComputeCommandEncoder() else { return }
+        var c = channels
+        var t = rows
+        var s = scale
+        enc.setComputePipelineState(sconvPrefillResidualPSO)
+        enc.setBuffer(x, offset: 0, index: 0)
+        enc.setBuffer(state, offset: 0, index: 1)
+        enc.setBuffer(weight, offset: weightOffset, index: 2)
+        enc.setBuffer(hidden, offset: 0, index: 3)
+        enc.setBytes(&c, length: 4, index: 4)
+        enc.setBytes(&t, length: 4, index: 5)
+        enc.setBytes(&s, length: 4, index: 6)
         enc.dispatchThreads(MTLSize(width: Int(channels), height: 1, depth: 1),
                             threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
         enc.endEncoding()
@@ -136,6 +217,39 @@ final class InklingKernels {
         enc.setBytes(&e, length: 4, index: 7)
         enc.dispatchThreadgroups(
             MTLSize(width: Int(numQHeads + numKVHeads), height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// Batched in-place Q/K RMS norm over `[rows, heads, headDim]`.
+    func encodeQKNormPrefill(commandBuffer cb: MTLCommandBuffer,
+                             q: MTLBuffer,
+                             k: MTLBuffer,
+                             qWeight: MTLBuffer, qWeightOffset: Int,
+                             kWeight: MTLBuffer, kWeightOffset: Int,
+                             headDim: UInt32,
+                             numQHeads: UInt32,
+                             numKVHeads: UInt32,
+                             rows: UInt32,
+                             eps: Float) {
+        guard rows > 0, let enc = cb.makeComputeCommandEncoder() else { return }
+        var hd = headDim
+        var nq = numQHeads
+        var nkv = numKVHeads
+        var t = rows
+        var e = eps
+        enc.setComputePipelineState(qkNormPrefillPSO)
+        enc.setBuffer(q, offset: 0, index: 0)
+        enc.setBuffer(k, offset: 0, index: 1)
+        enc.setBuffer(qWeight, offset: qWeightOffset, index: 2)
+        enc.setBuffer(kWeight, offset: kWeightOffset, index: 3)
+        enc.setBytes(&hd, length: 4, index: 4)
+        enc.setBytes(&nq, length: 4, index: 5)
+        enc.setBytes(&nkv, length: 4, index: 6)
+        enc.setBytes(&t, length: 4, index: 7)
+        enc.setBytes(&e, length: 4, index: 8)
+        enc.dispatchThreadgroups(
+            MTLSize(width: Int(numQHeads + numKVHeads), height: Int(rows), depth: 1),
             threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
         enc.endEncoding()
     }
@@ -183,6 +297,81 @@ final class InklingKernels {
         enc.endEncoding()
     }
 
+    /// Chunked causal attention with relative-position bias. All query rows
+    /// are dispatched together after their K/V rows have been copied to cache.
+    func encodeAttentionPrefill(commandBuffer cb: MTLCommandBuffer,
+                                q: MTLBuffer,
+                                k: MTLBuffer,
+                                v: MTLBuffer,
+                                rel: MTLBuffer,
+                                proj: MTLBuffer, projOffset: Int,
+                                out: MTLBuffer,
+                                headDim: UInt32,
+                                numQHeads: UInt32,
+                                numKVHeads: UInt32,
+                                startPosition: UInt32,
+                                rows: UInt32,
+                                slidingWindow: UInt32,
+                                relExtent: UInt32,
+                                dRel: UInt32,
+                                ringCapacity: UInt32,
+                                logScalingFloor: UInt32,
+                                scale: Float,
+                                logScalingAlpha: Float,
+                                preferTensorOps: Bool = true) {
+        guard rows > 0, let enc = cb.makeComputeCommandEncoder() else { return }
+        var hd = headDim
+        var nq = numQHeads
+        var nkv = numKVHeads
+        var start = startPosition
+        var t = rows
+        var window = slidingWindow
+        var extent = relExtent
+        var dr = dRel
+        var ring = ringCapacity
+        var floor = logScalingFloor
+        var s = scale
+        var alpha = logScalingAlpha
+        // Below one sliding-window length, cooperative-tile setup loses to the
+        // portable batch kernel on the measured M5. At and beyond 512 tokens,
+        // QK/PV reuse wins for both global and wrapped-ring attention.
+        let tensorOpsShape = preferTensorOps
+            && startPosition >= 512
+            && rows >= 8
+            && headDim == 128
+            && numQHeads == 32
+            && numKVHeads == 8
+            && dRel == 16
+        let tensorOpsPSO = tensorOpsShape ? attentionPrefillTensorOpsPSO : nil
+        enc.setComputePipelineState(tensorOpsPSO ?? attentionPrefillPSO)
+        enc.setBuffer(q, offset: 0, index: 0)
+        enc.setBuffer(k, offset: 0, index: 1)
+        enc.setBuffer(v, offset: 0, index: 2)
+        enc.setBuffer(rel, offset: 0, index: 3)
+        enc.setBuffer(proj, offset: projOffset, index: 4)
+        enc.setBuffer(out, offset: 0, index: 5)
+        enc.setBytes(&hd, length: 4, index: 6)
+        enc.setBytes(&nq, length: 4, index: 7)
+        enc.setBytes(&nkv, length: 4, index: 8)
+        enc.setBytes(&start, length: 4, index: 9)
+        enc.setBytes(&t, length: 4, index: 10)
+        enc.setBytes(&window, length: 4, index: 11)
+        enc.setBytes(&extent, length: 4, index: 12)
+        enc.setBytes(&dr, length: 4, index: 13)
+        enc.setBytes(&ring, length: 4, index: 14)
+        enc.setBytes(&floor, length: 4, index: 15)
+        enc.setBytes(&s, length: 4, index: 16)
+        enc.setBytes(&alpha, length: 4, index: 17)
+        let groups = tensorOpsPSO != nil
+            ? MTLSize(width: (Int(rows) + 7) / 8,
+                      height: Int(numQHeads), depth: 1)
+            : MTLSize(width: Int(numQHeads), height: Int(rows), depth: 1)
+        enc.dispatchThreadgroups(groups,
+                                 threadsPerThreadgroup: MTLSize(
+                                    width: 128, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
     /// BF16 router GEMV over `numRouted + numShared` rows into `routerLogits`,
     /// then selection + weighting. `onesScale` is a bf16 all-ones [d] buffer.
     func encodeRouter(commandBuffer cb: MTLCommandBuffer,
@@ -223,6 +412,65 @@ final class InklingKernels {
                                gammasOut: gammasOut, gammasOffset: gammasOffset,
                                numRouted: numRouted, numShared: numShared,
                                topK: topK, routeScale: routeScale)
+    }
+
+    /// Batched BF16 router GEMV and Inkling sigmoid/shared-sink selection.
+    /// `logits` is FP32 `[rows, numRouted + numShared]` scratch owned by the
+    /// runner; route outputs use fixed strides 8 and `numShared` respectively.
+    func encodeRouterPrefill(commandBuffer cb: MTLCommandBuffer,
+                             weights: MTLBuffer, weightsOffset: Int,
+                             hidden: MTLBuffer,
+                             effectiveScale: MTLBuffer,
+                             logits: MTLBuffer,
+                             gateBias: MTLBuffer, gateBiasOffset: Int,
+                             globalScale: MTLBuffer, globalScaleOffset: Int,
+                             outIndices: MTLBuffer,
+                             outWeights: MTLBuffer,
+                             gammasOut: MTLBuffer,
+                             numRouted: UInt32,
+                             numShared: UInt32,
+                             topK: UInt32,
+                             routeScale: Float,
+                             d: UInt32,
+                             rows: UInt32) {
+        guard rows > 0 else { return }
+        var total = numRouted + numShared
+        var dim = d
+        var t = rows
+        if let enc = cb.makeComputeCommandEncoder() {
+            enc.setComputePipelineState(routerGemvPrefillPSO)
+            enc.setBuffer(weights, offset: weightsOffset, index: 0)
+            enc.setBuffer(hidden, offset: 0, index: 1)
+            enc.setBuffer(effectiveScale, offset: 0, index: 2)
+            enc.setBuffer(logits, offset: 0, index: 3)
+            enc.setBytes(&total, length: 4, index: 4)
+            enc.setBytes(&dim, length: 4, index: 5)
+            enc.setBytes(&t, length: 4, index: 6)
+            enc.dispatchThreadgroups(
+                MTLSize(width: (Int(total) + 3) / 4, height: Int(rows), depth: 1),
+                threadsPerThreadgroup: MTLSize(width: 128, height: 1, depth: 1))
+            enc.endEncoding()
+        }
+        guard let enc = cb.makeComputeCommandEncoder() else { return }
+        var nr = numRouted
+        var ns = numShared
+        var tk = topK
+        var rs = routeScale
+        enc.setComputePipelineState(routerSelectPrefillPSO)
+        enc.setBuffer(logits, offset: 0, index: 0)
+        enc.setBuffer(gateBias, offset: gateBiasOffset, index: 1)
+        enc.setBuffer(globalScale, offset: globalScaleOffset, index: 2)
+        enc.setBuffer(outIndices, offset: 0, index: 3)
+        enc.setBuffer(outWeights, offset: 0, index: 4)
+        enc.setBuffer(gammasOut, offset: 0, index: 5)
+        enc.setBytes(&nr, length: 4, index: 6)
+        enc.setBytes(&ns, length: 4, index: 7)
+        enc.setBytes(&tk, length: 4, index: 8)
+        enc.setBytes(&rs, length: 4, index: 9)
+        enc.setBytes(&t, length: 4, index: 10)
+        enc.dispatchThreadgroups(MTLSize(width: Int(rows), height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+        enc.endEncoding()
     }
 
     /// Selection + weighting over an already-populated `routerLogits`.
@@ -394,6 +642,30 @@ final class InklingKernels {
         enc.setBytes(&dd, length: 4, index: 3)
         enc.setBytes(&e, length: 4, index: 4)
         enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding()
+    }
+
+    /// Batched FP32-residual RMSNorm into contiguous FP16 projection rows.
+    func encodeRMSF32Prefill(commandBuffer cb: MTLCommandBuffer,
+                             x: MTLBuffer,
+                             weight: MTLBuffer, weightOffset: Int,
+                             out: MTLBuffer,
+                             d: UInt32,
+                             rows: UInt32,
+                             eps: Float) {
+        guard rows > 0, let enc = cb.makeComputeCommandEncoder() else { return }
+        var dim = d
+        var t = rows
+        var e = eps
+        enc.setComputePipelineState(rmsF32PrefillPSO)
+        enc.setBuffer(x, offset: 0, index: 0)
+        enc.setBuffer(weight, offset: weightOffset, index: 1)
+        enc.setBuffer(out, offset: 0, index: 2)
+        enc.setBytes(&dim, length: 4, index: 3)
+        enc.setBytes(&t, length: 4, index: 4)
+        enc.setBytes(&e, length: 4, index: 5)
+        enc.dispatchThreadgroups(MTLSize(width: Int(rows), height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
         enc.endEncoding()
     }

--- a/Sources/Mference/Metal/Inkling/inkling.metal
+++ b/Sources/Mference/Metal/Inkling/inkling.metal
@@ -65,6 +65,86 @@ kernel void inkling_sconv_step(
     row[km1 - 1u] = xv;
 }
 
+// Chunked prefill counterpart, specialized to Inkling's fixed K=4 contract.
+// One thread owns a channel and walks the token axis in causal order, keeping
+// the three history values in registers. This replaces T separate dispatches
+// without changing the recurrence or the FP16 store boundary.
+kernel void inkling_sconv_prefill_f16out(
+    device const half*   x      [[buffer(0)]],  // [T, C]
+    device       float*  state  [[buffer(1)]],  // [C, 3]
+    device const bfloat* w      [[buffer(2)]],  // [C, 4]
+    device       half*   out    [[buffer(3)]],  // [T, C]
+    constant     uint&   C      [[buffer(4)]],
+    constant     uint&   T      [[buffer(5)]],
+    uint c [[thread_position_in_grid]]
+) {
+    if (c >= C) return;
+    device float* hist = state + c * 3u;
+    device const bfloat* taps = w + c * 4u;
+    float x0 = hist[0];
+    float x1 = hist[1];
+    float x2 = hist[2];
+    const float w0 = float(taps[0]);
+    const float w1 = float(taps[1]);
+    const float w2 = float(taps[2]);
+    const float w3 = float(taps[3]);
+    for (uint t = 0; t < T; ++t) {
+        const uint index = t * C + c;
+        const float xv = float(x[index]);
+        float acc = xv * w3;
+        acc = fma(x0, w0, acc);
+        acc = fma(x1, w1, acc);
+        acc = fma(x2, w2, acc);
+        out[index] = half(acc + xv);
+        x0 = x1;
+        x1 = x2;
+        x2 = xv;
+    }
+    hist[0] = x0;
+    hist[1] = x1;
+    hist[2] = x2;
+}
+
+// The attention/MLP short-convolution sites feed the FP32 residual stream.
+// Fuse their FP32 output and residual add while walking the causal token axis;
+// `scale` is 1 for attention and the FFN un-prescale for the MLP tail.
+kernel void inkling_sconv_prefill_residual_f32(
+    device const half*   x       [[buffer(0)]],  // [T, C]
+    device       float*  state   [[buffer(1)]],  // [C, 3]
+    device const bfloat* w       [[buffer(2)]],  // [C, 4]
+    device       float*  hidden  [[buffer(3)]],  // [T, C]
+    constant     uint&   C       [[buffer(4)]],
+    constant     uint&   T       [[buffer(5)]],
+    constant     float&  scale   [[buffer(6)]],
+    uint c [[thread_position_in_grid]]
+) {
+    if (c >= C) return;
+    device float* hist = state + c * 3u;
+    device const bfloat* taps = w + c * 4u;
+    float x0 = hist[0];
+    float x1 = hist[1];
+    float x2 = hist[2];
+    const float w0 = float(taps[0]);
+    const float w1 = float(taps[1]);
+    const float w2 = float(taps[2]);
+    const float w3 = float(taps[3]);
+    for (uint t = 0; t < T; ++t) {
+        const uint index = t * C + c;
+        const float xv = float(x[index]);
+        float acc = xv * w3;
+        acc = fma(x0, w0, acc);
+        acc = fma(x1, w1, acc);
+        acc = fma(x2, w2, acc);
+        hidden[index] = fma(acc + xv, scale, hidden[index]);
+        x0 = x1;
+        x1 = x2;
+        x2 = xv;
+    }
+    hist[0] = x0;
+    hist[1] = x1;
+    hist[2] = x2;
+}
+
 // ----------------------------------------------------------------------------
 // Per-head weighted RMS norm over Q [NQ, HD] and K [NKV, HD], fp32 math.
 // Threadgroup per head; heads [0, NQ) are Q, [NQ, NQ+NKV) are K.
@@ -111,6 +191,61 @@ void inkling_qk_norm(
     const float inv = rsqrt(bcast / float(HD) + eps);
     for (uint i = lid; i < HD; i += lsize) {
         row[i] = half(float(row[i]) * inv * float(w[i]));
+    }
+}
+
+// Batched Q/K norm: grid = [NQ + NKV, T]. The arithmetic inside each
+// threadgroup is deliberately identical to `inkling_qk_norm` so batching
+// changes scheduling, not the model's reduction order.
+[[kernel, max_total_threads_per_threadgroup(kInklingAttnThreads)]]
+void inkling_qk_norm_prefill(
+    device       half*   q        [[buffer(0)]],
+    device       half*   k        [[buffer(1)]],
+    device const bfloat* q_weight [[buffer(2)]],
+    device const bfloat* k_weight [[buffer(3)]],
+    constant     uint&   head_dim [[buffer(4)]],
+    constant     uint&   nq       [[buffer(5)]],
+    constant     uint&   nkv      [[buffer(6)]],
+    constant     uint&   rows     [[buffer(7)]],
+    constant     float&  eps      [[buffer(8)]],
+    uint2 tg [[threadgroup_position_in_grid]],
+    uint2 lid_xy  [[thread_position_in_threadgroup]],
+    uint2 lsize_xy [[threads_per_threadgroup]],
+    uint simd_lane_id  [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroups    [[simdgroups_per_threadgroup]]
+) {
+    threadgroup float scratch[kInklingAttnMaxSimdGroups];
+    threadgroup float bcast;
+    const uint lid = lid_xy.x;
+    const uint lsize = lsize_xy.x;
+    const uint head = tg.x;
+    const uint token = tg.y;
+    if (token >= rows || head >= nq + nkv) return;
+    const bool is_q = head < nq;
+    const uint HD = head_dim;
+    device half* row = is_q
+        ? (q + (token * nq + head) * HD)
+        : (k + (token * nkv + head - nq) * HD);
+    device const bfloat* gain = is_q ? q_weight : k_weight;
+
+    float acc = 0.0f;
+    for (uint i = lid; i < HD; i += lsize) {
+        const float v = float(row[i]);
+        acc = fma(v, v, acc);
+    }
+    float s = simd_sum(acc);
+    if (simd_lane_id == 0) { scratch[simd_group_id] = s; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simd_group_id == 0) {
+        float value = (simd_lane_id < simdgroups) ? scratch[simd_lane_id] : 0.0f;
+        value = simd_sum(value);
+        if (simd_lane_id == 0) { bcast = value; }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const float inv = rsqrt(bcast / float(HD) + eps);
+    for (uint i = lid; i < HD; i += lsize) {
+        row[i] = half(float(row[i]) * inv * float(gain[i]));
     }
 }
 
@@ -221,6 +356,139 @@ void inkling_attention_decode(
     }
 }
 
+// Chunked causal GQA attention with Inkling's learned relative-position bias.
+// Grid = [NQ, T], so all token/head threadgroups from a layer are visible to
+// the GPU scheduler at once instead of being serialized behind T dispatches.
+// K/V for the complete chunk must be present before this kernel is encoded.
+[[kernel, max_total_threads_per_threadgroup(kInklingAttnThreads)]]
+void inkling_attention_prefill(
+    device const half*   Q              [[buffer(0)]],  // [T, NQ, HD]
+    device const half*   K              [[buffer(1)]],  // cache
+    device const half*   V              [[buffer(2)]],  // cache
+    device const half*   rel            [[buffer(3)]],  // [T, NQ, D_REL]
+    device const bfloat* proj           [[buffer(4)]],
+    device       half*   out            [[buffer(5)]],  // [T, NQ, HD]
+    constant     uint&   head_dim       [[buffer(6)]],
+    constant     uint&   nq             [[buffer(7)]],
+    constant     uint&   nkv            [[buffer(8)]],
+    constant     uint&   start_position [[buffer(9)]],
+    constant     uint&   query_count    [[buffer(10)]],
+    constant     uint&   sliding_window [[buffer(11)]], // 0 = global
+    constant     uint&   rel_extent     [[buffer(12)]],
+    constant     uint&   d_rel          [[buffer(13)]],
+    constant     uint&   ring_cap       [[buffer(14)]],
+    constant     uint&   log_floor      [[buffer(15)]],
+    constant     float&  scale          [[buffer(16)]],
+    constant     float&  log_alpha      [[buffer(17)]],
+    uint2 tg [[threadgroup_position_in_grid]],
+    uint2 lid_xy  [[thread_position_in_threadgroup]],
+    uint2 lsize_xy [[threads_per_threadgroup]],
+    uint simd_lane_id  [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroups    [[simdgroups_per_threadgroup]]
+) {
+    threadgroup float q_smem[kInklingMaxHeadDim];
+    threadgroup float rel_smem[kInklingMaxDRel];
+    threadgroup float scratch[kInklingAttnMaxSimdGroups];
+    threadgroup float bcast;
+    const uint lid = lid_xy.x;
+    const uint lsize = lsize_xy.x;
+
+    const uint q_head = tg.x;
+    const uint token = tg.y;
+    if (q_head >= nq || token >= query_count) return;
+    const uint HD = head_dim;
+    const uint kv_head = q_head / (nq / nkv);
+    const uint q_pos = start_position + token;
+    const uint seq_len = q_pos + 1u;
+    const uint kv_start = sliding_window == 0u || seq_len <= sliding_window
+        ? 0u : seq_len - sliding_window;
+    float tau = 1.0f;
+    if (sliding_window == 0u && log_floor > 0u && seq_len > log_floor) {
+        tau += log_alpha * log(float(seq_len) / float(log_floor));
+    }
+
+    device const half* Q_row = Q + (token * nq + q_head) * HD;
+    for (uint i = lid; i < HD; i += lsize) { q_smem[i] = float(Q_row[i]); }
+    device const half* rel_row = rel + (token * nq + q_head) * d_rel;
+    if (lid < d_rel) { rel_smem[lid] = float(rel_row[lid]); }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float o_local = 0.0f;
+    const uint my_i = lid;
+    float m_run = -INFINITY;
+    float d_run = 0.0f;
+    for (uint p = kv_start; p < seq_len; ++p) {
+        const uint phys = ring_cap != 0u ? p % ring_cap : p;
+        device const half* K_row = K + (phys * nkv + kv_head) * HD;
+        device const half* V_row = V + (phys * nkv + kv_head) * HD;
+        float partial = 0.0f;
+        for (uint i = lid; i < HD; i += lsize) {
+            partial = fma(q_smem[i], float(K_row[i]), partial);
+        }
+        float sum = simd_sum(partial);
+        if (simd_lane_id == 0) { scratch[simd_group_id] = sum; }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (simd_group_id == 0) {
+            float value = (simd_lane_id < simdgroups) ? scratch[simd_lane_id] : 0.0f;
+            value = simd_sum(value);
+            if (simd_lane_id == 0) { bcast = value; }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        const uint dist = q_pos - p;
+        float bias = 0.0f;
+        if (dist < rel_extent) {
+            for (uint i = 0; i < d_rel; ++i) {
+                bias = fma(rel_smem[i], float(proj[i * rel_extent + dist]), bias);
+            }
+        }
+        const float logit = tau * fma(bcast, scale, bias);
+        const float m_new = max(m_run, logit);
+        const float alpha = fast::exp(m_run - m_new);
+        const float p_exp = fast::exp(logit - m_new);
+        d_run = d_run * alpha + p_exp;
+        if (my_i < HD) {
+            o_local = o_local * alpha + p_exp * float(V_row[my_i]);
+        }
+        m_run = m_new;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    device half* out_row = out + (token * nq + q_head) * HD;
+    if (my_i < HD) {
+        out_row[my_i] = half(d_run > 0.0f ? o_local / d_run : 0.0f);
+    }
+}
+
+// Batched BF16 router GEMV. This is the 2-D form of router_gemv_bf16_r4:
+// four expert rows per threadgroup on X and one prompt row on Y.
+[[kernel, max_total_threads_per_threadgroup(128)]]
+void inkling_router_gemv_prefill(
+    device const bfloat* W               [[buffer(0)]],
+    device const half*   hidden          [[buffer(1)]],
+    device const bfloat* effective_scale [[buffer(2)]],
+    device       float*  out_logits      [[buffer(3)]],
+    constant     uint&   num_outputs     [[buffer(4)]],
+    constant     uint&   D               [[buffer(5)]],
+    constant     uint&   rows            [[buffer(6)]],
+    uint2 tg_idx [[threadgroup_position_in_grid]],
+    uint sg_idx [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    const uint token = tg_idx.y;
+    const uint e = tg_idx.x * 4u + sg_idx;
+    if (token >= rows || e >= num_outputs) return;
+    device const bfloat* W_row = W + e * D;
+    device const half* x_row = hidden + token * D;
+    float acc = 0.0f;
+    for (uint i = lane; i < D; i += 32u) {
+        acc = fma(float(W_row[i]),
+                  float(x_row[i]) * float(effective_scale[i]), acc);
+    }
+    acc = simd_sum(acc);
+    if (lane == 0) { out_logits[token * num_outputs + e] = acc; }
+}
+
 // ----------------------------------------------------------------------------
 // Sigmoid router selection over 258 logits (256 routed + 2 shared sinks).
 // Single threadgroup; the scan is 256 elements so one thread does selection.
@@ -287,6 +555,73 @@ kernel void inkling_router_select(
     }
     for (uint s = 0; s < n_shared; ++s) {
         out_gammas[s] = fast::exp(lp[KK + s] - mx) * s_all;
+    }
+}
+
+// Batched selector for logits produced by `inkling_router_gemv_prefill`.
+// One threadgroup owns one token row. The lane-0 serial scan intentionally
+// mirrors `inkling_router_select` exactly; the expensive GEMV is parallelized
+// across all prompt rows while selection keeps its established tie behavior.
+kernel void inkling_router_select_prefill(
+    device const float* logits       [[buffer(0)]], // [T, routed + shared]
+    device const float* bias         [[buffer(1)]],
+    device const float* global_scale [[buffer(2)]],
+    device       uint*  out_indices  [[buffer(3)]], // [T, 8]
+    device       half*  out_weights  [[buffer(4)]], // [T, 8]
+    device       float* out_gammas   [[buffer(5)]], // [T, shared]
+    constant     uint&  n_routed     [[buffer(6)]],
+    constant     uint&  n_shared     [[buffer(7)]],
+    constant     uint&  top_k        [[buffer(8)]],
+    constant     float& route_scale  [[buffer(9)]],
+    constant     uint&  rows         [[buffer(10)]],
+    uint token [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]]
+) {
+    if (tid != 0 || token >= rows) return;
+    const uint num_outputs = n_routed + n_shared;
+    device const float* row_logits = logits + token * num_outputs;
+    device uint* row_indices = out_indices + token * 8u;
+    device half* row_weights = out_weights + token * 8u;
+    device float* row_gammas = out_gammas + token * n_shared;
+
+    uint top_idx[8];
+    float top_score[8];
+    const uint KK = min(top_k, 8u);
+    for (uint i = 0; i < KK; ++i) {
+        top_idx[i] = 0u;
+        top_score[i] = -INFINITY;
+    }
+    for (uint e = 0; e < n_routed; ++e) {
+        const float s = 1.0f / (1.0f + fast::exp(-row_logits[e])) + bias[e];
+        if (s <= top_score[KK - 1u]) continue;
+        uint pos = KK;
+        while (pos > 0u && top_score[pos - 1u] < s) { --pos; }
+        for (uint j = KK - 1u; j > pos; --j) {
+            top_score[j] = top_score[j - 1u];
+            top_idx[j] = top_idx[j - 1u];
+        }
+        top_score[pos] = s;
+        top_idx[pos] = e;
+    }
+
+    float lp[10];
+    const uint total = KK + n_shared;
+    for (uint i = 0; i < total; ++i) {
+        const float value = i < KK
+            ? row_logits[top_idx[i]] : row_logits[n_routed + i - KK];
+        lp[i] = min(value, 0.0f) - log(1.0f + fast::exp(-fabs(value)));
+    }
+    float mx = -INFINITY;
+    for (uint i = 0; i < total; ++i) { mx = max(mx, lp[i]); }
+    float denom = 0.0f;
+    for (uint i = 0; i < total; ++i) { denom += fast::exp(lp[i] - mx); }
+    const float all_scale = route_scale * global_scale[0] / denom;
+    for (uint i = 0; i < KK; ++i) {
+        row_indices[i] = top_idx[i];
+        row_weights[i] = half(fast::exp(lp[i] - mx) * all_scale);
+    }
+    for (uint s = 0; s < n_shared; ++s) {
+        row_gammas[s] = fast::exp(lp[KK + s] - mx) * all_scale;
     }
 }
 
@@ -422,6 +757,49 @@ void inkling_rms_f32in(
     const float inv = rsqrt(bcast / float(d) + eps);
     for (uint i = lid; i < d; i += lsize) {
         out[i] = half(x[i] * inv * float(weight[i]));
+    }
+}
+
+// Batched FP32-residual RMSNorm. Grid X is the token row; each threadgroup
+// uses the same 256-thread reduction as `inkling_rms_f32in` and writes one
+// contiguous FP16 row for the following matrix projections.
+[[kernel, max_total_threads_per_threadgroup(256)]]
+void inkling_rms_f32in_prefill(
+    device const float*  x      [[buffer(0)]], // [T, D]
+    device const bfloat* weight [[buffer(1)]],
+    device       half*   out    [[buffer(2)]], // [T, D]
+    constant     uint&   d      [[buffer(3)]],
+    constant     uint&   rows   [[buffer(4)]],
+    constant     float&  eps    [[buffer(5)]],
+    uint token [[threadgroup_position_in_grid]],
+    uint lid   [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id  [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroups    [[simdgroups_per_threadgroup]]
+) {
+    threadgroup float scratch[8];
+    threadgroup float bcast;
+    if (token >= rows) return;
+    device const float* x_row = x + token * d;
+    device half* out_row = out + token * d;
+    float acc = 0.0f;
+    for (uint i = lid; i < d; i += lsize) {
+        const float value = x_row[i];
+        acc = fma(value, value, acc);
+    }
+    float sum = simd_sum(acc);
+    if (simd_lane_id == 0) { scratch[simd_group_id] = sum; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simd_group_id == 0) {
+        float value = simd_lane_id < simdgroups ? scratch[simd_lane_id] : 0.0f;
+        value = simd_sum(value);
+        if (simd_lane_id == 0) { bcast = value; }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const float inv = rsqrt(bcast / float(d) + eps);
+    for (uint i = lid; i < d; i += lsize) {
+        out_row[i] = half(x_row[i] * inv * float(weight[i]));
     }
 }
 

--- a/Sources/Mference/Metal/TensorCore/tensorops.metal
+++ b/Sources/Mference/Metal/TensorCore/tensorops.metal
@@ -104,4 +104,296 @@ kernel void mpp_prefill_affine_threadgroup_f16(
     }
 }
 
+// Inkling's production attention shape is GQA 32/8 with a 128-wide head and
+// a learned 16-wide relative-position projection. Eight consecutive query
+// tokens share each QK/PV tile. This is deliberately separate from the generic
+// 512-wide prefill attention kernel: it keeps Inkling's relative bias and
+// per-query log scaling inside the online softmax while using TensorOps for the
+// two matrix products that dominate long-context attention.
+constant constexpr int kInklingAttentionQueries = 8;
+constant constexpr int kInklingAttentionKeys = 64;
+constant constexpr int kInklingAttentionHeadDim = 128;
+constant constexpr int kInklingAttentionDRel = 16;
+
+kernel void inkling_attention_prefill_tensorops(
+    device const half*   Q              [[buffer(0)]],
+    device const half*   K              [[buffer(1)]],
+    device const half*   V              [[buffer(2)]],
+    device const half*   rel            [[buffer(3)]],
+    device const bfloat* proj           [[buffer(4)]],
+    device       half*   output         [[buffer(5)]],
+    constant     uint&   headDim        [[buffer(6)]],
+    constant     uint&   numQHeads      [[buffer(7)]],
+    constant     uint&   numKVHeads     [[buffer(8)]],
+    constant     uint&   startPosition  [[buffer(9)]],
+    constant     uint&   queryCount     [[buffer(10)]],
+    constant     uint&   slidingWindow  [[buffer(11)]],
+    constant     uint&   relExtent      [[buffer(12)]],
+    constant     uint&   dRel           [[buffer(13)]],
+    constant     uint&   ringCapacity   [[buffer(14)]],
+    constant     uint&   logFloor       [[buffer(15)]],
+    constant     float&  scale          [[buffer(16)]],
+    constant     float&  logAlpha       [[buffer(17)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint threads [[threads_per_threadgroup]]) {
+    constexpr auto qkDescriptor = matmul2d_descriptor(
+        kInklingAttentionQueries,
+        kInklingAttentionKeys,
+        kInklingAttentionHeadDim,
+        false, true, false);
+    constexpr auto pvDescriptor = matmul2d_descriptor(
+        kInklingAttentionQueries,
+        kInklingAttentionHeadDim,
+        kInklingAttentionKeys,
+        false, false, false);
+    matmul2d<qkDescriptor, execution_simdgroups<4>> qkOperation;
+    matmul2d<pvDescriptor, execution_simdgroups<4>> pvOperation;
+
+    using deviceHalfTensor =
+        tensor<device half, dextents<int32_t, 2>, tensor_inline>;
+    using threadgroupHalfTensor =
+        tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>;
+    using threadgroupFloatTensor =
+        tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>;
+
+    // The Swift dispatcher only selects this kernel for the fixed Inkling
+    // shape. Keep the checks here as a hard safety net because the cooperative
+    // tensor descriptors are compile-time.
+    if (headDim != uint(kInklingAttentionHeadDim)
+        || numQHeads != 32u
+        || numKVHeads != 8u
+        || dRel != uint(kInklingAttentionDRel)) {
+        return;
+    }
+
+    threadgroup half queryTile[
+        kInklingAttentionQueries * kInklingAttentionHeadDim];
+    threadgroup half relativeTile[
+        kInklingAttentionQueries * kInklingAttentionDRel];
+    threadgroup float scoreTile[
+        kInklingAttentionQueries * kInklingAttentionKeys];
+    threadgroup float weightTile[
+        kInklingAttentionQueries * kInklingAttentionKeys];
+    threadgroup float rowMax[kInklingAttentionQueries];
+    threadgroup float rowSum[kInklingAttentionQueries];
+    threadgroup float rowOldScale[kInklingAttentionQueries];
+
+    const uint queryStart = tgid.x * uint(kInklingAttentionQueries);
+    const uint queryHead = tgid.y;
+    if (queryStart >= queryCount || queryHead >= numQHeads) return;
+    const uint validRows = min(
+        uint(kInklingAttentionQueries), queryCount - queryStart);
+    const uint kvHead = queryHead / (numQHeads / numKVHeads);
+    const uint kvStride = numKVHeads * headDim;
+    const uint qStride = numQHeads * headDim;
+
+    for (uint linear = lid;
+         linear < uint(kInklingAttentionQueries * kInklingAttentionHeadDim);
+         linear += threads) {
+        const uint row = linear / uint(kInklingAttentionHeadDim);
+        const uint d = linear % uint(kInklingAttentionHeadDim);
+        queryTile[linear] = row < validRows
+            ? Q[(queryStart + row) * qStride + queryHead * headDim + d]
+            : half(0.0f);
+    }
+    for (uint linear = lid;
+         linear < uint(kInklingAttentionQueries * kInklingAttentionDRel);
+         linear += threads) {
+        const uint row = linear / uint(kInklingAttentionDRel);
+        const uint d = linear % uint(kInklingAttentionDRel);
+        relativeTile[linear] = row < validRows
+            ? rel[((queryStart + row) * numQHeads + queryHead) * dRel + d]
+            : half(0.0f);
+    }
+    if (lid < uint(kInklingAttentionQueries)) {
+        rowMax[lid] = -INFINITY;
+        rowSum[lid] = 0.0f;
+        rowOldScale[lid] = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    threadgroupHalfTensor queryTensor(
+        queryTile,
+        dextents<int32_t, 2>(
+            kInklingAttentionHeadDim, kInklingAttentionQueries),
+        array<int32_t, 2>({1, kInklingAttentionHeadDim}));
+    threadgroupFloatTensor weightTensor(
+        weightTile,
+        dextents<int32_t, 2>(
+            kInklingAttentionKeys, kInklingAttentionQueries),
+        array<int32_t, 2>({1, kInklingAttentionKeys}));
+    const uint cacheCount = ringCapacity != 0u
+        ? ringCapacity : startPosition + queryCount;
+    deviceHalfTensor keyTensor(
+        K + kvHead * headDim,
+        dextents<int32_t, 2>(
+            int32_t(headDim), int32_t(cacheCount)),
+        array<int32_t, 2>({1, int32_t(kvStride)}));
+    deviceHalfTensor valueTensor(
+        V + kvHead * headDim,
+        dextents<int32_t, 2>(
+            int32_t(headDim), int32_t(cacheCount)),
+        array<int32_t, 2>({1, int32_t(kvStride)}));
+
+    auto querySlice = queryTensor.slice(0, 0);
+    auto firstValueSlice = valueTensor.slice(0, 0);
+    auto outputAccumulator =
+        pvOperation.get_destination_cooperative_tensor<
+            decltype(weightTensor), decltype(firstValueSlice), float>();
+    for (int element = 0;
+         element < outputAccumulator.get_capacity(); ++element) {
+        if (outputAccumulator.is_valid_element(element)) {
+            outputAccumulator[element] = 0.0f;
+        }
+    }
+
+    const uint firstQueryPosition = startPosition + queryStart;
+    const uint firstKey = slidingWindow != 0u
+        && firstQueryPosition + 1u > slidingWindow
+        ? firstQueryPosition + 1u - slidingWindow
+        : 0u;
+    const uint lastKey = startPosition + queryStart + validRows;
+    // A logical sliding-window range occupies at most two physical spans in
+    // the KV ring. Never let a cooperative tile cross the ring boundary:
+    // invalid columns are masked to zero, then the next iteration resumes at
+    // physical slot zero without staging or copying K/V.
+    for (uint keyStart = firstKey; keyStart < lastKey;) {
+        const uint physicalStart = ringCapacity != 0u
+            ? keyStart % ringCapacity : keyStart;
+        uint tileCount = min(
+            uint(kInklingAttentionKeys), lastKey - keyStart);
+        if (ringCapacity != 0u) {
+            tileCount = min(tileCount, ringCapacity - physicalStart);
+        }
+        auto keySlice = keyTensor.slice(0, int32_t(physicalStart));
+        auto scoreProduct =
+            qkOperation.get_destination_cooperative_tensor<
+                decltype(querySlice), decltype(keySlice), float>();
+        for (int element = 0;
+             element < scoreProduct.get_capacity(); ++element) {
+            if (scoreProduct.is_valid_element(element)) {
+                scoreProduct[element] = 0.0f;
+            }
+        }
+        qkOperation.run(querySlice, keySlice, scoreProduct);
+        for (int element = 0;
+             element < scoreProduct.get_capacity(); ++element) {
+            if (!scoreProduct.is_valid_element(element)) continue;
+            const auto position =
+                scoreProduct.get_multidimensional_index(element);
+            const uint keyColumn = uint(position[0]);
+            const uint row = uint(position[1]);
+            scoreTile[row * uint(kInklingAttentionKeys) + keyColumn] =
+                scoreProduct[element];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (lid < uint(kInklingAttentionQueries)) {
+            const uint row = lid;
+            const bool validRow = row < validRows;
+            const uint queryPosition = startPosition + queryStart + row;
+            const uint rowFirst = validRow && slidingWindow != 0u
+                && queryPosition + 1u > slidingWindow
+                ? queryPosition + 1u - slidingWindow
+                : 0u;
+            const uint rowLast = validRow ? queryPosition + 1u : 0u;
+            float tau = 1.0f;
+            if (validRow && slidingWindow == 0u && logFloor > 0u
+                && rowLast > logFloor) {
+                tau += logAlpha * log(float(rowLast) / float(logFloor));
+            }
+
+            float tileMax = -INFINITY;
+            for (uint keyColumn = 0u;
+                 keyColumn < uint(kInklingAttentionKeys); ++keyColumn) {
+                if (keyColumn >= tileCount) continue;
+                const uint key = keyStart + keyColumn;
+                if (key < rowFirst || key >= rowLast) continue;
+                const uint distance = queryPosition - key;
+                float bias = 0.0f;
+                if (distance < relExtent) {
+                    for (uint d = 0u; d < uint(kInklingAttentionDRel); ++d) {
+                        bias = fma(
+                            float(relativeTile[
+                                row * uint(kInklingAttentionDRel) + d]),
+                            float(proj[d * relExtent + distance]),
+                            bias);
+                    }
+                }
+                const uint index =
+                    row * uint(kInklingAttentionKeys) + keyColumn;
+                const float logit = tau * fma(scoreTile[index], scale, bias);
+                scoreTile[index] = logit;
+                tileMax = max(tileMax, logit);
+            }
+            const float nextMax = max(rowMax[row], tileMax);
+            const float oldScale = rowSum[row] > 0.0f
+                ? fast::exp(rowMax[row] - nextMax)
+                : 0.0f;
+            float tileSum = 0.0f;
+            for (uint keyColumn = 0u;
+                 keyColumn < uint(kInklingAttentionKeys); ++keyColumn) {
+                const uint key = keyStart + keyColumn;
+                const bool visible = validRow
+                    && keyColumn < tileCount
+                    && key >= rowFirst && key < rowLast;
+                const float weight = visible
+                    ? fast::exp(scoreTile[
+                        row * uint(kInklingAttentionKeys) + keyColumn] - nextMax)
+                    : 0.0f;
+                weightTile[
+                    row * uint(kInklingAttentionKeys) + keyColumn] = weight;
+                tileSum += weight;
+            }
+            rowOldScale[row] = oldScale;
+            rowSum[row] = rowSum[row] * oldScale + tileSum;
+            rowMax[row] = nextMax;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        auto valueSlice = valueTensor.slice(0, int32_t(physicalStart));
+        auto outputProduct =
+            pvOperation.get_destination_cooperative_tensor<
+                decltype(weightTensor), decltype(valueSlice), float>();
+        for (int element = 0;
+             element < outputProduct.get_capacity(); ++element) {
+            if (outputProduct.is_valid_element(element)) {
+                outputProduct[element] = 0.0f;
+            }
+        }
+        pvOperation.run(weightTensor, valueSlice, outputProduct);
+        for (int element = 0;
+             element < outputAccumulator.get_capacity(); ++element) {
+            if (!outputAccumulator.is_valid_element(element)
+                || !outputProduct.is_valid_element(element)) continue;
+            const auto position =
+                outputAccumulator.get_multidimensional_index(element);
+            const uint row = uint(position[1]);
+            outputAccumulator[element] = fma(
+                1.0f,
+                outputProduct[element],
+                outputAccumulator[element] * rowOldScale[row]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        keyStart += tileCount;
+    }
+
+    for (int element = 0;
+         element < outputAccumulator.get_capacity(); ++element) {
+        if (!outputAccumulator.is_valid_element(element)) continue;
+        const auto position =
+            outputAccumulator.get_multidimensional_index(element);
+        const uint d = uint(position[0]);
+        const uint row = uint(position[1]);
+        if (row < validRows) {
+            const float denominator = rowSum[row];
+            output[((queryStart + row) * numQHeads + queryHead) * headDim + d] =
+                denominator > 0.0f
+                ? half(outputAccumulator[element] / denominator)
+                : half(0.0f);
+        }
+    }
+}
+
 #endif

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -291,6 +291,12 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     // accumulator. Sized to maxPrefillChunkTokens.
     let inklingHiddenChunk: MTLBuffer?       // [chunk, D] FP32
     let inklingRoutedXChunk: MTLBuffer?      // [chunk, D] FP16
+    let inklingQChunk: MTLBuffer?            // [chunk, numHeads * headDim] FP16
+    let inklingKChunk: MTLBuffer?            // [chunk, numKVHeads * headDim] FP16
+    let inklingVChunk: MTLBuffer?            // [chunk, numKVHeads * headDim] FP16
+    let inklingRelChunk: MTLBuffer?          // [chunk, numHeads * dRel] FP16
+    let inklingAttentionChunk: MTLBuffer?    // [chunk, numHeads * headDim] FP16
+    let inklingRouterLogitsChunk: MTLBuffer? // [chunk, routed + shared] FP32
     let inklingIdxChunk: MTLBuffer?          // [chunk, 8] u32
     let inklingWChunk: MTLBuffer?            // [chunk, 8] FP16
     let inklingGammaChunk: MTLBuffer?        // [chunk, 2] FP32
@@ -301,8 +307,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     /// ~6e4 on the released checkpoint — an FP16 store clips to infinity.
     let inklingSharedY0: MTLBuffer?          // [D] FP32
     let inklingSharedY1: MTLBuffer?          // [D] FP32
-    /// Prefill counterpart: one expert's raw GLU output row, FP32.
-    let inklingExpertOutF32: MTLBuffer?      // [D] FP32
     /// Batched prefill expert application: the chunk's (token, expert) pairs
     /// grouped by expert, and one expert's activation tile.
     let inklingPairTokens: MTLBuffer?        // [chunk * 8] UInt32
@@ -701,13 +705,20 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingChunkCapacity = chunkCap
             self.inklingHiddenChunk = try buf(chunkCap * D, MemoryLayout<Float>.size)
             self.inklingRoutedXChunk = try buf(chunkCap * D)
+            self.inklingQChunk = try buf(chunkCap * cfg.numHeads * cfg.headDim)
+            self.inklingKChunk = try buf(chunkCap * cfg.numKVHeads * cfg.headDim)
+            self.inklingVChunk = try buf(chunkCap * cfg.numKVHeads * cfg.headDim)
+            self.inklingRelChunk = try buf(chunkCap * dRelWidth)
+            self.inklingAttentionChunk = try buf(chunkCap * cfg.numHeads * cfg.headDim)
+            self.inklingRouterLogitsChunk = try buf(
+                chunkCap * (cfg.numExperts + cfg.numSharedExperts),
+                MemoryLayout<Float>.size)
             self.inklingIdxChunk = try buf(chunkCap * 8, MemoryLayout<UInt32>.size)
             self.inklingWChunk = try buf(chunkCap * 8)
             self.inklingGammaChunk = try buf(chunkCap * 2, MemoryLayout<Float>.size)
             self.inklingAccChunk = try buf(chunkCap * D, MemoryLayout<Float>.size)
             self.inklingSharedY0 = try buf(D, MemoryLayout<Float>.size)
             self.inklingSharedY1 = try buf(D, MemoryLayout<Float>.size)
-            self.inklingExpertOutF32 = try buf(D, MemoryLayout<Float>.size)
             // Pair lists cover top-6 routed + 2 shared per token.
             self.inklingPairTokens = try buf(chunkCap * 8, MemoryLayout<UInt32>.size)
             self.inklingPairWeights = try buf(chunkCap * 8, MemoryLayout<Float>.size)
@@ -771,6 +782,12 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingDeltaF32 = nil
             self.inklingHiddenChunk = nil
             self.inklingRoutedXChunk = nil
+            self.inklingQChunk = nil
+            self.inklingKChunk = nil
+            self.inklingVChunk = nil
+            self.inklingRelChunk = nil
+            self.inklingAttentionChunk = nil
+            self.inklingRouterLogitsChunk = nil
             self.inklingIdxChunk = nil
             self.inklingWChunk = nil
             self.inklingGammaChunk = nil
@@ -778,7 +795,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             self.inklingChunkCapacity = 0
             self.inklingSharedY0 = nil
             self.inklingSharedY1 = nil
-            self.inklingExpertOutF32 = nil
             self.inklingPairTokens = nil
             self.inklingPairWeights = nil
             self.inklingExpertActScratch = nil
@@ -3575,22 +3591,28 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
     /// processed EXPERT-major — each unique expert in the chunk's routing is
     /// streamed once and applied to every token routed to it — so cold-cache
     /// expert I/O amortizes over the chunk instead of being paid per token
-    /// (~3.4 GB/token when sequential). Attention/sconv/norm reuse the decode
-    /// kernels per token inside one command buffer per layer, which preserves
-    /// conv-state and KV write ordering by construction.
+    /// (~3.4 GB/token when sequential). Attention, projections, norms, routing,
+    /// and fixed-width short convolutions operate on whole chunks; Apple10
+    /// attention switches to cooperative QK/PV tiles after the 512-token
+    /// crossover while preserving both linear and wrapped-ring KV layouts.
     private func prefillInklingChunk(tokens: ArraySlice<Int32>,
                                      startPosition: Int,
                                      emitHead: Bool,
                                      outputMode: PrefillOutputMode,
                                      into logits: MTLBuffer) async throws {
-        guard let inkling, let relScratch = inklingRelScratch,
+        guard let inkling,
               let hiddenChunk = inklingHiddenChunk,
               let routedXChunk = inklingRoutedXChunk,
+              let qChunk = inklingQChunk,
+              let kChunk = inklingKChunk,
+              let vChunk = inklingVChunk,
+              let relChunk = inklingRelChunk,
+              let attentionChunk = inklingAttentionChunk,
+              let routerLogitsChunk = inklingRouterLogitsChunk,
               let idxChunk = inklingIdxChunk,
               let wChunk = inklingWChunk,
               let gammaChunk = inklingGammaChunk,
               let accChunk = inklingAccChunk,
-              let expertOutF32 = inklingExpertOutF32,
               let pairTokens = inklingPairTokens,
               let pairWeights = inklingPairWeights,
               let actScratch = inklingExpertActScratch,
@@ -3598,7 +3620,6 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
               let kv else {
             preconditionFailure("Inkling prefill state missing")
         }
-        _ = expertOutF32
         let N = tokens.count
         precondition(N <= inklingChunkCapacity,
                      "chunk \(N) exceeds capacity \(inklingChunkCapacity)")
@@ -3613,6 +3634,72 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
 
         func hOff(_ i: Int) -> Int { i * Dh * 4 }
         func xOff(_ i: Int) -> Int { i * Dh * 2 }
+
+        // Inkling's prefill projections are contiguous `[token, output]`
+        // matrices. Their shapes favor the packed block QMM in the measured
+        // Inkling path. This replaces N decode GEMV dispatches with one matrix
+        // dispatch.
+        func encodeProjection(_ cb: MTLCommandBuffer,
+                              _ view: TensorView,
+                              x: MTLBuffer,
+                              y: MTLBuffer,
+                              rows: Int,
+                              columns: Int) {
+            prefillQMM.encode(commandBuffer: cb,
+                              weights: view.buffer,
+                              weightsOffset: Int(view.offset),
+                              scales: view.buffer,
+                              scalesOffset: Int(view.scaleOffset),
+                              biases: view.buffer,
+                              biasesOffset: Int(view.biasOffset),
+                              x: x,
+                              y: y,
+                              t: N,
+                              n: rows,
+                              k: columns)
+        }
+
+        func encodeKVWrite(_ cb: MTLCommandBuffer,
+                           layer: Int,
+                           key: MTLBuffer,
+                           value: MTLBuffer) {
+            let capacity = kv.capacity(layer: layer)
+            let physicalStart = startPosition % capacity
+            let firstCount = min(N, capacity - physicalStart)
+            let bytesPerRow = Int(kvDim) * MemoryLayout<Float16>.stride
+            guard let blit = cb.makeBlitCommandEncoder() else {
+                preconditionFailure("Inkling prefill KV blit encoder unavailable")
+            }
+            let keyFirst = kv.kRange(layer: layer,
+                                     start: startPosition,
+                                     count: firstCount)
+            let valueFirst = kv.vRange(layer: layer,
+                                       start: startPosition,
+                                       count: firstCount)
+            blit.copy(from: key, sourceOffset: 0,
+                      to: keyFirst.buffer, destinationOffset: keyFirst.offset,
+                      size: firstCount * bytesPerRow)
+            blit.copy(from: value, sourceOffset: 0,
+                      to: valueFirst.buffer, destinationOffset: valueFirst.offset,
+                      size: firstCount * bytesPerRow)
+            if firstCount < N {
+                let secondCount = N - firstCount
+                let secondStart = startPosition + firstCount
+                let keySecond = kv.kRange(layer: layer,
+                                          start: secondStart,
+                                          count: secondCount)
+                let valueSecond = kv.vRange(layer: layer,
+                                            start: secondStart,
+                                            count: secondCount)
+                blit.copy(from: key, sourceOffset: firstCount * bytesPerRow,
+                          to: keySecond.buffer, destinationOffset: keySecond.offset,
+                          size: secondCount * bytesPerRow)
+                blit.copy(from: value, sourceOffset: firstCount * bytesPerRow,
+                          to: valueSecond.buffer, destinationOffset: valueSecond.offset,
+                          size: secondCount * bytesPerRow)
+            }
+            blit.endEncoding()
+        }
 
         // Seed the chunk's FP32 hidden rows: embed + embed_norm per token.
         let emb = model.embedding
@@ -3660,114 +3747,89 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                 blit.fill(buffer: accChunk, range: 0..<(N * Dh * 4), value: 0)
                 blit.endEncoding()
             }
-            for i in 0..<N {
-                let position = startPosition + i
-                let seqLen = UInt32(position + 1)
-                let kSlot = kv.kSlot(layer: L, position: position)
-                let vSlot = kv.vSlot(layer: L, position: position)
-                inkling.encodeRMSF32(commandBuffer: cbA,
-                                     x: hiddenChunk, xOffset: hOff(i),
-                                     weight: inNorm.buffer,
-                                     weightOffset: Int(inNorm.offset),
-                                     out: normed, d: D, eps: eps)
-                int4.encode(commandBuffer: cbA,
-                            weights: q.buffer, weightsOffset: Int(q.offset),
-                            scales:  q.buffer, scalesOffset:  Int(q.scaleOffset),
-                            biases:  q.buffer, biasesOffset:  Int(q.biasOffset),
-                            x: normed, y: qScratch, m: qDim, n: D)
-                int4.encode(commandBuffer: cbA,
-                            weights: k.buffer, weightsOffset: Int(k.offset),
-                            scales:  k.buffer, scalesOffset:  Int(k.scaleOffset),
-                            biases:  k.buffer, biasesOffset:  Int(k.biasOffset),
-                            x: normed, y: kStage, m: kvDim, n: D)
-                int4.encode(commandBuffer: cbA,
-                            weights: v.buffer, weightsOffset: Int(v.offset),
-                            scales:  v.buffer, scalesOffset:  Int(v.scaleOffset),
-                            biases:  v.buffer, biasesOffset:  Int(v.biasOffset),
-                            x: normed, y: vStage, m: kvDim, n: D)
-                int4.encode(commandBuffer: cbA,
-                            weights: wr.buffer, weightsOffset: Int(wr.offset),
-                            scales:  wr.buffer, scalesOffset:  Int(wr.scaleOffset),
-                            biases:  wr.buffer, biasesOffset:  Int(wr.biasOffset),
-                            x: normed, y: relScratch,
-                            m: UInt32(rel.projDim), n: D)
-                inkling.encodeSconvStep(commandBuffer: cbA,
-                                        x: kStage, state: conv.k,
-                                        weight: kSconvW.buffer,
-                                        weightOffset: Int(kSconvW.offset),
-                                        out: kSlot.buffer, outOffset: kSlot.offset,
-                                        channels: kvDim, kernelSize: sconvK)
-                inkling.encodeSconvStep(commandBuffer: cbA,
-                                        x: vStage, state: conv.v,
-                                        weight: vSconvW.buffer,
-                                        weightOffset: Int(vSconvW.offset),
-                                        out: vSlot.buffer, outOffset: vSlot.offset,
-                                        channels: kvDim, kernelSize: sconvK)
-                inkling.encodeQKNorm(commandBuffer: cbA,
-                                     q: qScratch,
-                                     k: kSlot.buffer, kOffset: kSlot.offset,
-                                     qWeight: qNorm.buffer, qWeightOffset: Int(qNorm.offset),
-                                     kWeight: kNorm.buffer, kWeightOffset: Int(kNorm.offset),
-                                     headDim: UInt32(cfg.headDim),
-                                     numQHeads: UInt32(cfg.numHeads),
-                                     numKVHeads: UInt32(cfg.numKVHeads),
-                                     eps: eps)
-                let window = UInt32(cfg.slidingWindow)
-                let kvStart: UInt32 = isFull ? 0 : (seqLen > window ? seqLen - window : 0)
-                let ringCapacity = kv.ringCapacity(layer: L)
-                let activeRing: UInt32 = (!isFull && ringCapacity > 0 && Int(seqLen) > ringCapacity)
-                    ? UInt32(ringCapacity) : 0
-                var tau: Float = 1.0
-                if isFull && rel.logScalingFloor > 0 {
-                    let n = Float(position + 1)
-                    let floorN = Float(rel.logScalingFloor)
-                    if n > floorN {
-                        tau = 1.0 + Float(rel.logScalingAlpha) * log(n / floorN)
-                    }
-                }
-                inkling.encodeAttentionDecode(commandBuffer: cbA,
-                                              q: qScratch,
-                                              k: kSlot.buffer, v: vSlot.buffer,
-                                              rel: relScratch,
-                                              proj: relProj.buffer,
-                                              projOffset: Int(relProj.offset),
-                                              out: attnOut,
-                                              headDim: UInt32(cfg.headDim),
-                                              numQHeads: UInt32(cfg.numHeads),
-                                              numKVHeads: UInt32(cfg.numKVHeads),
-                                              seqLen: seqLen, kvStart: kvStart,
-                                              relExtent: UInt32(isFull ? rel.extent : cfg.slidingWindow),
-                                              dRel: UInt32(rel.dRel),
-                                              ringCapacity: activeRing,
-                                              scale: Float(cfg.attentionScale),
-                                              tau: tau)
-                int4.encode(commandBuffer: cbA,
-                            weights: o.buffer, weightsOffset: Int(o.offset),
-                            scales:  o.buffer, scalesOffset:  Int(o.scaleOffset),
-                            biases:  o.buffer, biasesOffset:  Int(o.biasOffset),
-                            x: attnOut, y: oOut, m: D, n: qDim)
-                inkling.encodeSconvStepF32Out(commandBuffer: cbA,
-                                              x: oOut, state: conv.attn,
-                                              weight: attnSconvW.buffer,
-                                              weightOffset: Int(attnSconvW.offset),
-                                              out: inklingDeltaF32!,
-                                              channels: D, kernelSize: sconvK)
-                inkling.encodeResidualAddF32Delta(commandBuffer: cbA,
-                                                  hidden: hiddenChunk,
-                                                  hiddenOffset: hOff(i),
-                                                  delta: inklingDeltaF32!,
-                                                  count: D)
-                inkling.encodeRMSF32(commandBuffer: cbA,
-                                     x: hiddenChunk, xOffset: hOff(i),
-                                     weight: mlpNorm.buffer,
-                                     weightOffset: Int(mlpNorm.offset),
-                                     out: routedX, d: D, eps: eps)
-                if isDense {
+            inkling.encodeRMSF32Prefill(commandBuffer: cbA,
+                                        x: hiddenChunk,
+                                        weight: inNorm.buffer,
+                                        weightOffset: Int(inNorm.offset),
+                                        out: routedXChunk,
+                                        d: D, rows: UInt32(N), eps: eps)
+            encodeProjection(cbA, q, x: routedXChunk, y: qChunk,
+                             rows: Int(qDim), columns: Dh)
+            encodeProjection(cbA, k, x: routedXChunk, y: kChunk,
+                             rows: Int(kvDim), columns: Dh)
+            encodeProjection(cbA, v, x: routedXChunk, y: vChunk,
+                             rows: Int(kvDim), columns: Dh)
+            encodeProjection(cbA, wr, x: routedXChunk, y: relChunk,
+                             rows: rel.projDim, columns: Dh)
+            inkling.encodeSconvPrefill(commandBuffer: cbA,
+                                       x: kChunk, state: conv.k,
+                                       weight: kSconvW.buffer,
+                                       weightOffset: Int(kSconvW.offset),
+                                       out: kChunk,
+                                       channels: kvDim, rows: UInt32(N))
+            inkling.encodeSconvPrefill(commandBuffer: cbA,
+                                       x: vChunk, state: conv.v,
+                                       weight: vSconvW.buffer,
+                                       weightOffset: Int(vSconvW.offset),
+                                       out: vChunk,
+                                       channels: kvDim, rows: UInt32(N))
+            inkling.encodeQKNormPrefill(
+                commandBuffer: cbA,
+                q: qChunk, k: kChunk,
+                qWeight: qNorm.buffer, qWeightOffset: Int(qNorm.offset),
+                kWeight: kNorm.buffer, kWeightOffset: Int(kNorm.offset),
+                headDim: UInt32(cfg.headDim),
+                numQHeads: UInt32(cfg.numHeads),
+                numKVHeads: UInt32(cfg.numKVHeads),
+                rows: UInt32(N), eps: eps)
+            encodeKVWrite(cbA, layer: L, key: kChunk, value: vChunk)
+            let ringCapacity = kv.ringCapacity(layer: L)
+            let validCount = startPosition + N
+            let activeRing = !isFull && ringCapacity > 0 && validCount > ringCapacity
+                ? UInt32(ringCapacity) : 0
+            inkling.encodeAttentionPrefill(
+                commandBuffer: cbA,
+                q: qChunk,
+                k: kv.keyBuffer(layer: L, validTokenCount: validCount),
+                v: kv.valueBuffer(layer: L, validTokenCount: validCount),
+                rel: relChunk,
+                proj: relProj.buffer, projOffset: Int(relProj.offset),
+                out: attentionChunk,
+                headDim: UInt32(cfg.headDim),
+                numQHeads: UInt32(cfg.numHeads),
+                numKVHeads: UInt32(cfg.numKVHeads),
+                startPosition: UInt32(startPosition),
+                rows: UInt32(N),
+                slidingWindow: isFull ? 0 : UInt32(cfg.slidingWindow),
+                relExtent: UInt32(isFull ? rel.extent : cfg.slidingWindow),
+                dRel: UInt32(rel.dRel),
+                ringCapacity: activeRing,
+                logScalingFloor: UInt32(rel.logScalingFloor),
+                scale: Float(cfg.attentionScale),
+                logScalingAlpha: Float(rel.logScalingAlpha))
+            // Q is dead after attention, so reuse its chunk allocation for O.
+            encodeProjection(cbA, o, x: attentionChunk, y: qChunk,
+                             rows: Dh, columns: Int(qDim))
+            inkling.encodeSconvPrefillResidual(
+                commandBuffer: cbA,
+                x: qChunk, state: conv.attn,
+                weight: attnSconvW.buffer,
+                weightOffset: Int(attnSconvW.offset),
+                hidden: hiddenChunk,
+                channels: D, rows: UInt32(N))
+            inkling.encodeRMSF32Prefill(commandBuffer: cbA,
+                                        x: hiddenChunk,
+                                        weight: mlpNorm.buffer,
+                                        weightOffset: Int(mlpNorm.offset),
+                                        out: routedXChunk,
+                                        d: D, rows: UInt32(N), eps: eps)
+            if isDense {
+                for i in 0..<N {
                     let proj = inklingDenseProjections[L]!
                     let gain = model.inklingScalar(
                         try model.inklingDenseGlobalScale(layer: L))
                     try! shared.encode(commandBuffer: cbA,
-                                       x: routedX,
+                                       x: routedXChunk, xOffset: xOff(i),
                                        gate: proj.gate, up: proj.up, down: proj.down,
                                        y: h2Buf,
                                        scratchGate: denseScratchGate,
@@ -3786,38 +3848,32 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                                       hiddenOffset: hOff(i),
                                                       delta: inklingDeltaF32!,
                                                       count: D)
-                } else {
-                    if let blit = cbA.makeBlitCommandEncoder() {
-                        blit.copy(from: routedX, sourceOffset: 0,
-                                  to: routedXChunk, destinationOffset: xOff(i),
-                                  size: Dh * 2)
-                        blit.endEncoding()
-                    }
-                    let routerW = try model.router(layer: L)
-                    let gateBias = try model.inklingGateBias(layer: L)
-                    let gateScale = try model.inklingGateGlobalScale(layer: L)
-                    inkling.encodeRouter(commandBuffer: cbA,
-                                         weights: routerW.buffer,
-                                         weightsOffset: Int(routerW.offset),
-                                         hidden: routedX,
-                                         onesScale: effectiveScaleBuffers[L],
-                                         gateBias: gateBias.buffer,
-                                         gateBiasOffset: Int(gateBias.offset),
-                                         globalScale: gateScale.buffer,
-                                         globalScaleOffset: Int(gateScale.offset),
-                                         outIndices: idxChunk,
-                                         outIndicesOffset: i * 8 * 4,
-                                         outWeights: wChunk,
-                                         outWeightsOffset: i * 8 * 2,
-                                         gammasOut: gammaChunk,
-                                         gammasOffset: i * 2 * 4,
-                                         numRouted: UInt32(cfg.numExperts),
-                                         numShared: UInt32(cfg.numSharedExperts),
-                                         topK: UInt32(cfg.topKExperts),
-                                         routeScale: Float(cfg.routedScalingFactor)
-                                             / Self.inklingFFNPrescale,
-                                         d: D)
                 }
+            } else {
+                let routerW = try model.router(layer: L)
+                let gateBias = try model.inklingGateBias(layer: L)
+                let gateScale = try model.inklingGateGlobalScale(layer: L)
+                inkling.encodeRouterPrefill(
+                    commandBuffer: cbA,
+                    weights: routerW.buffer,
+                    weightsOffset: Int(routerW.offset),
+                    hidden: routedXChunk,
+                    effectiveScale: effectiveScaleBuffers[L],
+                    logits: routerLogitsChunk,
+                    gateBias: gateBias.buffer,
+                    gateBiasOffset: Int(gateBias.offset),
+                    globalScale: gateScale.buffer,
+                    globalScaleOffset: Int(gateScale.offset),
+                    outIndices: idxChunk,
+                    outWeights: wChunk,
+                    gammasOut: gammaChunk,
+                    numRouted: UInt32(cfg.numExperts),
+                    numShared: UInt32(cfg.numSharedExperts),
+                    topK: UInt32(cfg.topKExperts),
+                    routeScale: Float(cfg.routedScalingFactor)
+                        / Self.inklingFFNPrescale,
+                    d: D,
+                    rows: UInt32(N))
             }
             cbA.commit()
             waitForCompletion(cbA)
@@ -3968,25 +4024,20 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             }
             totalIoNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tIoStart
 
-            // Tail: per token IN ORDER (mlp conv state), acc -> sconv -> add.
+            // Tail: one causal channel-wise dispatch replaces N narrowing,
+            // short-conv, and residual-add dispatch triplets.
             let cbC = ctx.queue.makeCommandBuffer()!
-            for i in 0..<N {
-                inkling.encodeF32ToF16(commandBuffer: cbC,
-                                       src: accChunk, srcOffset: hOff(i),
-                                       dst: h2Buf, count: D)
-                inkling.encodeSconvStepF32Out(commandBuffer: cbC,
-                                              x: h2Buf, state: conv.mlp,
-                                              weight: mlpSconvW.buffer,
-                                              weightOffset: Int(mlpSconvW.offset),
-                                              out: inklingDeltaF32!,
-                                              channels: D, kernelSize: sconvK)
-                inkling.encodeResidualAddF32Delta(commandBuffer: cbC,
-                                                  hidden: hiddenChunk,
-                                                  hiddenOffset: hOff(i),
-                                                  delta: inklingDeltaF32!,
-                                                  count: D,
-                                                  scale: Self.inklingFFNPrescale)
-            }
+            inkling.encodeF32ToF16(commandBuffer: cbC,
+                                   src: accChunk, srcOffset: 0,
+                                   dst: qChunk, count: UInt32(N * Dh))
+            inkling.encodeSconvPrefillResidual(
+                commandBuffer: cbC,
+                x: qChunk, state: conv.mlp,
+                weight: mlpSconvW.buffer,
+                weightOffset: Int(mlpSconvW.offset),
+                hidden: hiddenChunk,
+                channels: D, rows: UInt32(N),
+                scale: Self.inklingFFNPrescale)
             cbC.commit()
             waitForCompletion(cbC)
         }

--- a/Tests/Mference/Core/Kernels/Inkling/InklingKernelTests.swift
+++ b/Tests/Mference/Core/Kernels/Inkling/InklingKernelTests.swift
@@ -90,6 +90,103 @@ import MferenceValidationSupport
         }
     }
 
+    @Test func sconvPrefillMatchesDecodeStepsAndFusedResidual() throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        var rng = SplitMix64(seed: 0x11C_BA7C)
+        let C = 96, T = 7, K = 4
+        let x = Self.randomHalf(T * C, &rng, scale: 2)
+        let w: [UInt16] = (0..<C * K).map { _ in
+            Self.bf16(rng.uniform(0, 1) - 0.5)
+        }
+        let xBuf = Self.buffer(context.device, x)
+        let wBuf = Self.buffer(context.device, w)
+        func state() -> MTLBuffer {
+            let result = context.device.makeBuffer(
+                length: C * (K - 1) * MemoryLayout<Float>.size,
+                options: .storageModeShared)!
+            memset(result.contents(), 0, result.length)
+            return result
+        }
+
+        let scalarState = state()
+        let scalarOut = context.device.makeBuffer(
+            length: T * C * MemoryLayout<Float16>.size,
+            options: .storageModeShared)!
+        Self.run(context) { cb in
+            for t in 0..<T {
+                kernels.encodeSconvStep(
+                    commandBuffer: cb,
+                    x: xBuf, xOffset: t * C * 2,
+                    state: scalarState,
+                    weight: wBuf, weightOffset: 0,
+                    out: scalarOut, outOffset: t * C * 2,
+                    channels: UInt32(C), kernelSize: UInt32(K))
+            }
+        }
+
+        let batchState = state()
+        let batchOut = context.device.makeBuffer(
+            length: scalarOut.length, options: .storageModeShared)!
+        Self.run(context) { cb in
+            kernels.encodeSconvPrefill(
+                commandBuffer: cb,
+                x: xBuf, state: batchState,
+                weight: wBuf, weightOffset: 0,
+                out: batchOut,
+                channels: UInt32(C), rows: UInt32(T))
+        }
+        let scalar = scalarOut.contents().bindMemory(
+            to: Float16.self, capacity: T * C)
+        let batch = batchOut.contents().bindMemory(
+            to: Float16.self, capacity: T * C)
+        for i in 0..<T * C { #expect(batch[i] == scalar[i], "f16 output \(i)") }
+        #expect(memcmp(batchState.contents(), scalarState.contents(), batchState.length) == 0)
+
+        let initialHidden: [Float] = (0..<T * C).map { _ in
+            rng.uniform(0, 1) * 10 - 5
+        }
+        let scalarHidden = Self.buffer(context.device, initialHidden)
+        let batchHidden = Self.buffer(context.device, initialHidden)
+        let scalarResidualState = state()
+        let batchResidualState = state()
+        let delta = context.device.makeBuffer(
+            length: C * MemoryLayout<Float>.size,
+            options: .storageModeShared)!
+        let rowBuffers = (0..<T).map { t in
+            Self.buffer(context.device, Array(x[(t * C)..<((t + 1) * C)]))
+        }
+        Self.run(context) { cb in
+            for t in 0..<T {
+                kernels.encodeSconvStepF32Out(
+                    commandBuffer: cb,
+                    x: rowBuffers[t], state: scalarResidualState,
+                    weight: wBuf, weightOffset: 0,
+                    out: delta,
+                    channels: UInt32(C), kernelSize: UInt32(K))
+                kernels.encodeResidualAddF32Delta(
+                    commandBuffer: cb,
+                    hidden: scalarHidden,
+                    hiddenOffset: t * C * MemoryLayout<Float>.size,
+                    delta: delta,
+                    count: UInt32(C), scale: 32)
+            }
+        }
+        Self.run(context) { cb in
+            kernels.encodeSconvPrefillResidual(
+                commandBuffer: cb,
+                x: xBuf, state: batchResidualState,
+                weight: wBuf, weightOffset: 0,
+                hidden: batchHidden,
+                channels: UInt32(C), rows: UInt32(T), scale: 32)
+        }
+        let scalarF32 = scalarHidden.contents().bindMemory(to: Float.self, capacity: T * C)
+        let batchF32 = batchHidden.contents().bindMemory(to: Float.self, capacity: T * C)
+        for i in 0..<T * C { #expect(batchF32[i] == scalarF32[i], "f32 residual \(i)") }
+        #expect(memcmp(batchResidualState.contents(), scalarResidualState.contents(),
+                       batchResidualState.length) == 0)
+    }
+
     // MARK: - Q/K per-head RMS norm
 
     @Test func qkNormMatchesReference() throws {
@@ -133,6 +230,61 @@ import MferenceValidationSupport
         }
         check(qBuf, q, qw, heads: NQ, label: "q")
         check(kBuf, k, kw, heads: NKV, label: "k")
+    }
+
+    @Test func qkNormPrefillMatchesDecodeRows() throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        var rng = SplitMix64(seed: 0xBEEF_BA7C)
+        let T = 5, HD = 128, NQ = 4, NKV = 2
+        let q = Self.randomHalf(T * NQ * HD, &rng, scale: 2)
+        let k = Self.randomHalf(T * NKV * HD, &rng, scale: 2)
+        let qw = Self.buffer(context.device, (0..<HD).map { _ in
+            Self.bf16(rng.uniform(0, 1) + 0.5)
+        })
+        let kw = Self.buffer(context.device, (0..<HD).map { _ in
+            Self.bf16(rng.uniform(0, 1) + 0.5)
+        })
+        let batchQ = Self.buffer(context.device, q)
+        let batchK = Self.buffer(context.device, k)
+        let scalarQ = (0..<T).map { t in
+            Self.buffer(context.device,
+                        Array(q[(t * NQ * HD)..<((t + 1) * NQ * HD)]))
+        }
+        let scalarK = (0..<T).map { t in
+            Self.buffer(context.device,
+                        Array(k[(t * NKV * HD)..<((t + 1) * NKV * HD)]))
+        }
+        Self.run(context) { cb in
+            for t in 0..<T {
+                kernels.encodeQKNorm(
+                    commandBuffer: cb,
+                    q: scalarQ[t], k: scalarK[t], kOffset: 0,
+                    qWeight: qw, qWeightOffset: 0,
+                    kWeight: kw, kWeightOffset: 0,
+                    headDim: UInt32(HD), numQHeads: UInt32(NQ),
+                    numKVHeads: UInt32(NKV), eps: 1e-6)
+            }
+        }
+        Self.run(context) { cb in
+            kernels.encodeQKNormPrefill(
+                commandBuffer: cb,
+                q: batchQ, k: batchK,
+                qWeight: qw, qWeightOffset: 0,
+                kWeight: kw, kWeightOffset: 0,
+                headDim: UInt32(HD), numQHeads: UInt32(NQ),
+                numKVHeads: UInt32(NKV), rows: UInt32(T), eps: 1e-6)
+        }
+        let gotQ = batchQ.contents().bindMemory(to: Float16.self, capacity: q.count)
+        let gotK = batchK.contents().bindMemory(to: Float16.self, capacity: k.count)
+        for t in 0..<T {
+            let wantQ = scalarQ[t].contents().bindMemory(to: Float16.self,
+                                                        capacity: NQ * HD)
+            let wantK = scalarK[t].contents().bindMemory(to: Float16.self,
+                                                        capacity: NKV * HD)
+            for i in 0..<NQ * HD { #expect(gotQ[t * NQ * HD + i] == wantQ[i]) }
+            for i in 0..<NKV * HD { #expect(gotK[t * NKV * HD + i] == wantK[i]) }
+        }
     }
 
     // MARK: - Attention with relative-position bias
@@ -233,6 +385,219 @@ import MferenceValidationSupport
         }
     }
 
+    @Test(arguments: [
+        (3, 5, 0, 0, 5, Float(0.1)),
+        (7, 5, 6, 11, 0, Float(0)),
+    ] as [(Int, Int, Int, Int, Int, Float)])
+    func attentionPrefillMatchesDecodeRows(
+        _ arg: (start: Int, rows: Int, window: Int, ring: Int,
+                logFloor: Int, logAlpha: Float)
+    ) throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        var rng = SplitMix64(seed: 0xA77E_BA7C &+ UInt64(arg.start))
+        let HD = 64, NQ = 4, NKV = 2, dRel = 16
+        let end = arg.start + arg.rows
+        let slots = arg.ring > 0 ? arg.ring : end
+        let extent = arg.window > 0 ? arg.window : 16
+        let q = Self.randomHalf(arg.rows * NQ * HD, &rng)
+        let rel = Self.randomHalf(arg.rows * NQ * dRel, &rng)
+        let logicalK = Self.randomHalf(end * NKV * HD, &rng)
+        let logicalV = Self.randomHalf(end * NKV * HD, &rng)
+        var physicalK = [Float16](repeating: 0, count: slots * NKV * HD)
+        var physicalV = [Float16](repeating: 0, count: slots * NKV * HD)
+        let rowWidth = NKV * HD
+        for p in 0..<end {
+            let slot = arg.ring > 0 ? p % arg.ring : p
+            physicalK.replaceSubrange((slot * rowWidth)..<((slot + 1) * rowWidth),
+                                      with: logicalK[(p * rowWidth)..<((p + 1) * rowWidth)])
+            physicalV.replaceSubrange((slot * rowWidth)..<((slot + 1) * rowWidth),
+                                      with: logicalV[(p * rowWidth)..<((p + 1) * rowWidth)])
+        }
+        let qBuf = Self.buffer(context.device, q)
+        let kBuf = Self.buffer(context.device, physicalK)
+        let vBuf = Self.buffer(context.device, physicalV)
+        let relBuf = Self.buffer(context.device, rel)
+        let proj = Self.buffer(context.device, (0..<dRel * extent).map { _ in
+            Self.bf16(rng.uniform(0, 1) - 0.5)
+        })
+        let batchOut = context.device.makeBuffer(
+            length: arg.rows * NQ * HD * MemoryLayout<Float16>.size,
+            options: .storageModeShared)!
+        Self.run(context) { cb in
+            kernels.encodeAttentionPrefill(
+                commandBuffer: cb,
+                q: qBuf, k: kBuf, v: vBuf, rel: relBuf,
+                proj: proj, projOffset: 0, out: batchOut,
+                headDim: UInt32(HD), numQHeads: UInt32(NQ),
+                numKVHeads: UInt32(NKV),
+                startPosition: UInt32(arg.start), rows: UInt32(arg.rows),
+                slidingWindow: UInt32(arg.window), relExtent: UInt32(extent),
+                dRel: UInt32(dRel), ringCapacity: UInt32(arg.ring),
+                logScalingFloor: UInt32(arg.logFloor),
+                scale: 1 / Float(HD), logScalingAlpha: arg.logAlpha,
+                preferTensorOps: false)
+        }
+
+        let got = batchOut.contents().bindMemory(
+            to: Float16.self, capacity: arg.rows * NQ * HD)
+        for t in 0..<arg.rows {
+            let qRow = Self.buffer(context.device,
+                Array(q[(t * NQ * HD)..<((t + 1) * NQ * HD)]))
+            let relRow = Self.buffer(context.device,
+                Array(rel[(t * NQ * dRel)..<((t + 1) * NQ * dRel)]))
+            let scalarOut = context.device.makeBuffer(
+                length: NQ * HD * MemoryLayout<Float16>.size,
+                options: .storageModeShared)!
+            let seqLen = arg.start + t + 1
+            let kvStart = arg.window > 0 ? max(0, seqLen - arg.window) : 0
+            let activeRing = arg.ring > 0 && seqLen > arg.ring ? arg.ring : 0
+            let tau: Float = arg.logFloor > 0 && seqLen > arg.logFloor
+                ? 1 + arg.logAlpha * log(Float(seqLen) / Float(arg.logFloor)) : 1
+            Self.run(context) { cb in
+                kernels.encodeAttentionDecode(
+                    commandBuffer: cb,
+                    q: qRow, k: kBuf, v: vBuf, rel: relRow,
+                    proj: proj, projOffset: 0, out: scalarOut,
+                    headDim: UInt32(HD), numQHeads: UInt32(NQ),
+                    numKVHeads: UInt32(NKV), seqLen: UInt32(seqLen),
+                    kvStart: UInt32(kvStart), relExtent: UInt32(extent),
+                    dRel: UInt32(dRel), ringCapacity: UInt32(activeRing),
+                    scale: 1 / Float(HD), tau: tau)
+            }
+            let want = scalarOut.contents().bindMemory(to: Float16.self,
+                                                       capacity: NQ * HD)
+            for i in 0..<NQ * HD {
+                #expect(got[t * NQ * HD + i] == want[i], "token \(t) elem \(i)")
+            }
+        }
+    }
+
+    @Test func attentionTensorOpsMatchesPortableInklingShape() throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        guard kernels.tensorOpsPrefillAttentionAvailable else { return }
+        var rng = SplitMix64(seed: 0xA77E_7E05)
+        let HD = 128, NQ = 32, NKV = 8, dRel = 16
+        let start = 513, rows = 13, end = start + rows, extent = 64
+        let q = Self.buffer(context.device,
+                            Self.randomHalf(rows * NQ * HD, &rng))
+        let k = Self.buffer(context.device,
+                            Self.randomHalf(end * NKV * HD, &rng))
+        let v = Self.buffer(context.device,
+                            Self.randomHalf(end * NKV * HD, &rng))
+        let rel = Self.buffer(context.device,
+                              Self.randomHalf(rows * NQ * dRel, &rng))
+        let proj = Self.buffer(context.device, (0..<dRel * extent).map { _ in
+            Self.bf16(rng.uniform(0, 1) - 0.5)
+        })
+        let byteCount = rows * NQ * HD * MemoryLayout<Float16>.size
+        let portable = context.device.makeBuffer(
+            length: byteCount, options: .storageModeShared)!
+        let tensorOps = context.device.makeBuffer(
+            length: byteCount, options: .storageModeShared)!
+
+        func encode(_ output: MTLBuffer, preferTensorOps: Bool) {
+            Self.run(context) { cb in
+                kernels.encodeAttentionPrefill(
+                    commandBuffer: cb,
+                    q: q, k: k, v: v, rel: rel,
+                    proj: proj, projOffset: 0, out: output,
+                    headDim: UInt32(HD), numQHeads: UInt32(NQ),
+                    numKVHeads: UInt32(NKV),
+                    startPosition: UInt32(start), rows: UInt32(rows),
+                    slidingWindow: 0, relExtent: UInt32(extent),
+                    dRel: UInt32(dRel), ringCapacity: 0,
+                    logScalingFloor: 8,
+                    scale: 1 / Float(HD), logScalingAlpha: 0.1,
+                    preferTensorOps: preferTensorOps)
+            }
+        }
+        encode(portable, preferTensorOps: false)
+        encode(tensorOps, preferTensorOps: true)
+
+        let expected = portable.contents().bindMemory(
+            to: Float16.self, capacity: rows * NQ * HD)
+        let actual = tensorOps.contents().bindMemory(
+            to: Float16.self, capacity: rows * NQ * HD)
+        var maxDifference: Float = 0
+        for i in 0..<rows * NQ * HD {
+            maxDifference = max(
+                maxDifference, abs(Float(actual[i]) - Float(expected[i])))
+        }
+        #expect(maxDifference <= 0.04,
+                "TensorOps relative attention max difference \(maxDifference)")
+    }
+
+    @Test func attentionTensorOpsMatchesPortableAcrossRingWrap() throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        guard kernels.tensorOpsPrefillAttentionAvailable else { return }
+        var rng = SplitMix64(seed: 0xA77E_7106)
+        let HD = 128, NQ = 32, NKV = 8, dRel = 16
+        let start = 700, rows = 13, end = start + rows
+        let window = 512, ring = 640, extent = window
+        let q = Self.buffer(context.device,
+                            Self.randomHalf(rows * NQ * HD, &rng))
+        let relative = Self.buffer(context.device,
+                                   Self.randomHalf(rows * NQ * dRel, &rng))
+        let rowWidth = NKV * HD
+        let logicalK = Self.randomHalf(end * rowWidth, &rng)
+        let logicalV = Self.randomHalf(end * rowWidth, &rng)
+        var physicalK = [Float16](repeating: 0, count: ring * rowWidth)
+        var physicalV = [Float16](repeating: 0, count: ring * rowWidth)
+        for position in 0..<end {
+            let slot = position % ring
+            physicalK.replaceSubrange(
+                (slot * rowWidth)..<((slot + 1) * rowWidth),
+                with: logicalK[(position * rowWidth)..<((position + 1) * rowWidth)])
+            physicalV.replaceSubrange(
+                (slot * rowWidth)..<((slot + 1) * rowWidth),
+                with: logicalV[(position * rowWidth)..<((position + 1) * rowWidth)])
+        }
+        let k = Self.buffer(context.device, physicalK)
+        let v = Self.buffer(context.device, physicalV)
+        let proj = Self.buffer(context.device, (0..<dRel * extent).map { _ in
+            Self.bf16(rng.uniform(0, 1) - 0.5)
+        })
+        let byteCount = rows * NQ * HD * MemoryLayout<Float16>.size
+        let portable = context.device.makeBuffer(
+            length: byteCount, options: .storageModeShared)!
+        let tensorOps = context.device.makeBuffer(
+            length: byteCount, options: .storageModeShared)!
+
+        func encode(_ output: MTLBuffer, preferTensorOps: Bool) {
+            Self.run(context) { cb in
+                kernels.encodeAttentionPrefill(
+                    commandBuffer: cb,
+                    q: q, k: k, v: v, rel: relative,
+                    proj: proj, projOffset: 0, out: output,
+                    headDim: UInt32(HD), numQHeads: UInt32(NQ),
+                    numKVHeads: UInt32(NKV),
+                    startPosition: UInt32(start), rows: UInt32(rows),
+                    slidingWindow: UInt32(window), relExtent: UInt32(extent),
+                    dRel: UInt32(dRel), ringCapacity: UInt32(ring),
+                    logScalingFloor: 128_000,
+                    scale: 1 / Float(HD), logScalingAlpha: 0.1,
+                    preferTensorOps: preferTensorOps)
+            }
+        }
+        encode(portable, preferTensorOps: false)
+        encode(tensorOps, preferTensorOps: true)
+
+        let expected = portable.contents().bindMemory(
+            to: Float16.self, capacity: rows * NQ * HD)
+        let actual = tensorOps.contents().bindMemory(
+            to: Float16.self, capacity: rows * NQ * HD)
+        var maxDifference: Float = 0
+        for i in 0..<rows * NQ * HD {
+            maxDifference = max(
+                maxDifference, abs(Float(actual[i]) - Float(expected[i])))
+        }
+        #expect(maxDifference <= 0.04,
+                "ring TensorOps relative attention max difference \(maxDifference)")
+    }
+
     // MARK: - Sigmoid router
 
     @Test func routerSelectMatchesReference() throws {
@@ -301,6 +666,77 @@ import MferenceValidationSupport
                 #expect(abs(gotGammas[s] - refWeights[topK + s]) < 1e-3,
                         "trial \(trial) gamma \(s)")
             }
+        }
+    }
+
+    @Test func routerPrefillMatchesDecodeRows() throws {
+        let context = try MetalContext()
+        let kernels = try Self.makeKernels(context)
+        var rng = SplitMix64(seed: 0x60D_BA7C)
+        let T = 5, D = 64, routed = 32, shared = 2, topK = 6
+        let weights = Self.buffer(context.device, (0..<(routed + shared) * D).map { _ in
+            Self.bf16(rng.uniform(0, 1) - 0.5)
+        })
+        let hidden = Self.buffer(context.device, Self.randomHalf(T * D, &rng, scale: 2))
+        let ones = Self.buffer(context.device, [UInt16](repeating: 0x3F80, count: D))
+        let bias = Self.buffer(context.device, (0..<routed).map { _ in
+            rng.uniform(0, 1) * 0.5 - 0.25
+        })
+        let global = Self.buffer(context.device, [Float(1.25)])
+        let scalarIdx = context.device.makeBuffer(length: T * 8 * 4,
+                                                   options: .storageModeShared)!
+        let scalarW = context.device.makeBuffer(length: T * 8 * 2,
+                                                 options: .storageModeShared)!
+        let scalarGamma = context.device.makeBuffer(length: T * shared * 4,
+                                                     options: .storageModeShared)!
+        Self.run(context) { cb in
+            for t in 0..<T {
+                kernels.encodeRouter(
+                    commandBuffer: cb,
+                    weights: weights, weightsOffset: 0,
+                    hidden: hidden, hiddenOffset: t * D * 2,
+                    onesScale: ones,
+                    gateBias: bias, gateBiasOffset: 0,
+                    globalScale: global, globalScaleOffset: 0,
+                    outIndices: scalarIdx, outIndicesOffset: t * 8 * 4,
+                    outWeights: scalarW, outWeightsOffset: t * 8 * 2,
+                    gammasOut: scalarGamma, gammasOffset: t * shared * 4,
+                    numRouted: UInt32(routed), numShared: UInt32(shared),
+                    topK: UInt32(topK), routeScale: 8, d: UInt32(D))
+            }
+        }
+        let batchIdx = context.device.makeBuffer(length: T * 8 * 4,
+                                                  options: .storageModeShared)!
+        let batchW = context.device.makeBuffer(length: T * 8 * 2,
+                                                options: .storageModeShared)!
+        let batchGamma = context.device.makeBuffer(length: T * shared * 4,
+                                                    options: .storageModeShared)!
+        let logits = context.device.makeBuffer(length: T * (routed + shared) * 4,
+                                                options: .storageModeShared)!
+        Self.run(context) { cb in
+            kernels.encodeRouterPrefill(
+                commandBuffer: cb,
+                weights: weights, weightsOffset: 0,
+                hidden: hidden, effectiveScale: ones, logits: logits,
+                gateBias: bias, gateBiasOffset: 0,
+                globalScale: global, globalScaleOffset: 0,
+                outIndices: batchIdx, outWeights: batchW, gammasOut: batchGamma,
+                numRouted: UInt32(routed), numShared: UInt32(shared),
+                topK: UInt32(topK), routeScale: 8,
+                d: UInt32(D), rows: UInt32(T))
+        }
+        let sIdx = scalarIdx.contents().bindMemory(to: UInt32.self, capacity: T * 8)
+        let bIdx = batchIdx.contents().bindMemory(to: UInt32.self, capacity: T * 8)
+        let sW = scalarW.contents().bindMemory(to: Float16.self, capacity: T * 8)
+        let bW = batchW.contents().bindMemory(to: Float16.self, capacity: T * 8)
+        let sG = scalarGamma.contents().bindMemory(to: Float.self, capacity: T * shared)
+        let bG = batchGamma.contents().bindMemory(to: Float.self, capacity: T * shared)
+        for t in 0..<T {
+            for i in 0..<topK {
+                #expect(bIdx[t * 8 + i] == sIdx[t * 8 + i])
+                #expect(bW[t * 8 + i] == sW[t * 8 + i])
+            }
+            for i in 0..<shared { #expect(bG[t * shared + i] == sG[t * shared + i]) }
         }
     }
 }

--- a/docs/INKLING_SMALL.md
+++ b/docs/INKLING_SMALL.md
@@ -427,7 +427,7 @@ the next one:
 | `h1` / `h2` after the gamma combine | yes | 7 064 of 65 504 at the worst observed token |
 | dense MLP down projection, layers 0-1 | **no** — `mlp.global_scale` applies after, same pattern | not overflowing: the L0/L1 residual peaks near 1e2, so ~500× margin. Left FP16 deliberately; widen it if those layers ever grow. |
 
-### Prefill cost profile (2026-08-04)
+### Historical prefill cost profile (2026-08-04)
 
 Measured on an M3 Ultra / 256 GB with `MFERENCE_PREFILL_BREAKDOWN=1`, greedy,
 `--verify trusted-receipt --prefill-chunk auto`. Three changes landed together:
@@ -455,12 +455,11 @@ path — streaming *and* compute — is ~15 % of prefill. It also grows
 superlinearly, 13.3x for 6.6x the tokens, because 7 of 42 layers are global
 while the other 35 are capped at window 512.
 
-Two consequences for whoever picks this up:
+Those measurements identified two follow-ups:
 
-1. **Batched prefill attention is the remaining work.** `PrefillAttention` /
-   `attention_prefill_causal_tiled` already exist and serve the other three
-   families; Inkling is the only one still replaying attention per token, and
-   that is why Gemma 4 prefills at 134 tok/s on this host and Inkling at 13.5.
+1. **Batched prefill attention was the main compute opportunity.** The
+   chunk-wide portable and Apple10 TensorOps paths described below now cover
+   Inkling's relative-position attention, including a wrapped sliding KV ring.
 2. **Expert streaming is serialized.** `prefillInklingChunk` awaits a fetch,
    encodes, then drains, so the fetch never overlaps GPU work.
    `PrefillRoutedTileScheduler` implements the pipelined alternative.
@@ -471,6 +470,50 @@ prompt sizes. That fit was total prefill time divided by pair count, so it
 silently contained attention, the tail, and streaming — it looked constant
 because it measured everything, and every extrapolation from it was wrong by
 5-20x. Profile with `MFERENCE_PREFILL_BREAKDOWN=1` before optimizing.
+
+### Batched prefill kernels (2026-08-05)
+
+Inkling prefill now operates on a whole chunk through dedicated FP32 RMSNorm,
+INT4 projection, fixed-K short-convolution, Q/K normalization, relative GQA
+attention, BF16 routing, and fused short-convolution/residual kernels. Below
+512 tokens, the portable relative-attention kernel avoids cooperative-tile
+setup cost. On Apple10, chunks starting at position 512 use an 8-query x 64-key
+TensorOps online-softmax kernel. A wrapped sliding-window range is split into
+its two physical KV spans, so QK/PV tiles never require a staging copy or cross
+the ring boundary.
+
+Targeted prefill A/B on an Apple M5 MacBook Pro (10 cores, 24 GB), macOS 26.5,
+Swift 6.3.3, with a clean release build of base commit `aae03d4` and the same
+warm local model/cache state:
+
+| Prompt | Base | Batched kernels | Gain |
+|---|---:|---:|---:|
+| medium-review, 421 tok | 64.05 s | 56.52 s | 1.13x |
+| long-synthesis, 2 785 tok | 580.81 s | 412.09 s | **1.41x** |
+
+The long case saves 168.72 s (29.0%). Both commands exited 0. Complete timing
+footers were:
+
+```text
+[stop=maxTokens prefill=2785tok/580.81s new=1tok decode=0.01s tok/s=100.969]
+[stop=maxTokens prefill=2785tok/412.09s new=1tok decode=0.00s tok/s=303.210]
+```
+
+The command shape was:
+
+```bash
+.build/release/MferenceCLI \
+  --model /Users/zidane/Downloads/inklingsmall.gturbo \
+  --messages-file docs/benchmark-prompts/real-generation-v1/long-synthesis.json \
+  --max-new 1 --max-context 4096 --temperature 0 \
+  --top-k 64 --top-p 0.95 --seed 20260723 \
+  --verify trusted-receipt
+```
+
+This is an isolated-prefill measurement, not the public community generation
+protocol: it uses one new token, trusted-receipt verification, one measured run
+per binary, and the production 128-token chunk default. Treat it as a local A/B
+measurement rather than a performance ceiling.
 
 Bring-up config note: the fused QKV GEMV and the constant-folded INT4 GEMV
 variants are bypassed for this family (plain generic GEMVs) — they were

--- a/docs/INKLING_SMALL.md
+++ b/docs/INKLING_SMALL.md
@@ -483,31 +483,52 @@ its two physical KV spans, so QK/PV tiles never require a staging copy or cross
 the ring boundary.
 
 Targeted prefill A/B on an Apple M5 MacBook Pro (10 cores, 24 GB), macOS 26.5,
-Swift 6.3.3, with a clean release build of base commit `aae03d4` and the same
-warm local model/cache state:
+Swift 6.3.3, with a clean release build of base commit
+`aae03d4c59dc8167f8c1031c864e05afe9cc8b90` and the optimized source tree
+recorded as commit `7282abebd00c6ef312d2d40a3c4c9324644725c0`, using the same warm local
+model/cache state:
 
 | Prompt | Base | Batched kernels | Gain |
 |---|---:|---:|---:|
 | medium-review, 421 tok | 64.05 s | 56.52 s | 1.13x |
 | long-synthesis, 2 785 tok | 580.81 s | 412.09 s | **1.41x** |
 
-The long case saves 168.72 s (29.0%). Both commands exited 0. Complete timing
-footers were:
+The long case saves 168.72 s (29.0%). Every command below exited 0. Complete
+timing footers, in base/optimized order, were:
 
 ```text
+[stop=maxTokens prefill=421tok/64.05s new=1tok decode=0.00s tok/s=371.342]
+[stop=maxTokens prefill=421tok/56.52s new=1tok decode=0.00s tok/s=669.375]
 [stop=maxTokens prefill=2785tok/580.81s new=1tok decode=0.01s tok/s=100.969]
 [stop=maxTokens prefill=2785tok/412.09s new=1tok decode=0.00s tok/s=303.210]
 ```
 
-The command shape was:
+The exact medium commands were:
 
 ```bash
+# aae03d4c59dc8167f8c1031c864e05afe9cc8b90; exit 0
+benchmark-results/inkling-prefill-baseline/bin-base/MferenceCLI \
+  --model /Users/zidane/Downloads/inklingsmall.gturbo \
+  --messages-file docs/benchmark-prompts/real-generation-v1/medium-review.json \
+  --max-new 1 --max-context 4096 --temperature 0 \
+  --top-k 64 --top-p 0.95 --seed 20260722 \
+  --verify trusted-receipt
+
+# 7282abebd00c6ef312d2d40a3c4c9324644725c0; exit 0
 .build/release/MferenceCLI \
   --model /Users/zidane/Downloads/inklingsmall.gturbo \
-  --messages-file docs/benchmark-prompts/real-generation-v1/long-synthesis.json \
+  --messages-file docs/benchmark-prompts/real-generation-v1/medium-review.json \
   --max-new 1 --max-context 4096 --temperature 0 \
-  --top-k 64 --top-p 0.95 --seed 20260723 \
+  --top-k 64 --top-p 0.95 --seed 20260722 \
   --verify trusted-receipt
+```
+
+The exact long commands used the same two binaries and options, replacing the
+messages file and seed as follows:
+
+```bash
+--messages-file docs/benchmark-prompts/real-generation-v1/long-synthesis.json
+--seed 20260723
 ```
 
 This is an isolated-prefill measurement, not the public community generation


### PR DESCRIPTION
## Summary

- replace Inkling's token-at-a-time prefill orchestration with a chunked, layer-major path
- add dedicated Metal kernels for fixed-width causal sconv, fused sconv residual updates, batched Q/K normalization, relative causal attention, FP32 RMS, and router selection
- add an Apple TensorOps attention kernel specialized for Inkling's 32Q/8KV/128-head-dimension layout, including wrapped ring-cache support
- retain the portable Metal attention path for short chunks, unsupported devices, and non-Inkling shapes
- add kernel-level correctness coverage and document the benchmark protocol and results

## Why

Inkling prefill was dominated by per-token command encoding, kernel launches, and repeated intermediate-buffer traffic. The relative-attention path also processed each query row separately even though the prompt was already available as a chunk. This change batches those operations across the prompt and uses matrix hardware for sufficiently large attention workloads.

Decode behavior is unchanged.

## Performance

Measured on a MacBook Pro (Apple M5, 10 CPU cores, 24 GB RAM), macOS 26.5, Swift 6.3.3.

| Prompt | Clean baseline | This PR | Speedup |
| --- | ---: | ---: | ---: |
| 421 prompt tokens | 64.05s | 56.52s | **1.13x** |
| 2,785 prompt tokens | 580.81s | 412.09s | **1.41x** |

The long prompt saves 168.72 seconds of prefill time, a 29.1% reduction.

The baseline was built from `aae03d4`. Measurements used the local complete Inkling Small artifact, `--max-new 1`, `--max-context 4096`, deterministic seeds, trusted-receipt verification, production 128-token chunks, and a warm OS model cache. These are targeted isolated-prefill measurements rather than full-response generation benchmarks.

## Validation

- `Scripts/test.sh`: **896 tests in 145 suites passed**
- focused `InklingKernelTests`: 10 tests passed, covering:
  - chunked sconv and fused residual equivalence
  - batched Q/K normalization
  - portable global and wrapped-ring attention
  - TensorOps global and wrapped-ring attention against the portable reference
  - batched router selection
- real Inkling model short-generation health check passed
- real Inkling model finite-logit health check passed
- `swift build -c release --product MferenceCLI` passed
- `git diff --check` passed

## Dispatch and fallback

The TensorOps attention path is used only for the exact Inkling geometry, chunks with at least eight rows, and positions at or beyond the 512-token crossover. Other workloads continue through the portable batched kernel. Existing decode kernels remain unchanged.
