### PR TITLE
Accelerate Inkling decode with native top-6 Metal

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
 </p>
 
 <p align="center">
-  <strong>Qwen 3.6 on a 24 GB M5: 23.5–29.3 tok/s decode · 2.20× faster long-prompt prefill</strong>
+  <strong>Qwen 3.6 on a 24 GB M5: 23.5–29.3 tok/s decode · 2.20× faster long-prompt prefill</strong><br>
+  <strong>Inkling-Small on the same host: 3.0–3.7 tok/s decode · 16.4% faster with native top-6 Metal</strong>
 </p>
 
 Mixture-of-experts models activate only a few billion (cough) parameters per token.
@@ -113,7 +114,7 @@ swift run -c release MferenceCLI \
 | Measured decode, Gemma 4 | 5.1–6.3 tok/s (8 GB M2 Air) · 31–35 tok/s (24 GB M5 Pro) |
 | Measured decode, Qwen 3.6 | 23.5–29.3 tok/s (24 GB M5, automatic 32-slot profile) |
 | Measured decode, DeepSeek-V4-Flash | 5.3–6.1 tok/s (256 GB M3 Ultra) at a 5,671–5,679 MiB peak footprint |
-| Measured decode, Inkling-Small | 5.3–6.9 tok/s (256 GB M3 Ultra) at a 8,936–8,939 MiB peak footprint |
+| Measured decode, Inkling-Small | 3.0–3.7 tok/s (24 GB M5, optimized native top-6 path) · 5.3–6.9 tok/s (256 GB M3 Ultra) at an 8,936–8,939 MiB peak footprint |
 
 Qwen 3.6 numbers follow the frozen
 [community benchmark protocol](docs/COMMUNITY_BENCHMARKS.md) — three fixed
@@ -126,6 +127,13 @@ seconds, a 2.20× speedup. Hosts below 16 GiB and the Mac app retain the 16-slot
 memory-first path. See [Benchmarks](docs/BENCHMARKS.md) and the
 [Qwen 3.6 performance notes](docs/QWEN36_PERFORMANCE.md) for exact commands,
 token counts, memory behavior, and rejected experiments.
+
+Inkling-Small uses its own six-expert INT4 Metal pipeline rather than padding
+the router result to eight experts. Resident-expert phase 1 runs while cache
+misses stream from SSD; across the same frozen short, medium, and long cases,
+decode improved from 2.909/2.961/2.819 to 3.434/3.670/3.038 tok/s. That is a
+16.4% geometric-mean gain, with byte-identical generated output in every A/B.
+See the [Inkling performance notes](docs/INKLING_SMALL.md#native-top-6-decode-2026-08-06).
 
 ## Products
 
@@ -166,10 +174,12 @@ revision and repacks them directly into an on-disk layout (`.gturbo`) built
 for per-expert reads: resident tensors in one mapped file, and each layer's
 routed experts as fixed-stride, page-aligned blobs. At generation time the
 runtime keeps the common weights mapped read-only, holds a small per-layer LFU
-expert cache, and `pread`s only the eight experts each layer's router selects
-for the current token. The memory-first path uses 16 slots; CLI and server auto
-select 32 for Qwen on hosts with at least 16 GiB because its 256 experts per
-layer benefit measurably from the added coverage.
+expert cache, and `pread`s only the experts each layer's router selects for the
+current token. Inkling dispatches six experts; Gemma and Qwen dispatch eight.
+The memory-first path uses 16 slots; CLI and server auto select 32 for Qwen on
+hosts with at least 16 GiB because its 256 experts per layer benefit measurably
+from the added coverage. Inkling remains at 16 because a 24-slot control
+warmup on the 24 GB M5 entered memory pressure and regressed sharply.
 
 Qwen 3.6's linear-attention layers replace KV storage entirely: each keeps a
 2 MiB delta-rule state and a 3-row convolution tail, updated in place every
@@ -185,8 +195,7 @@ engine are in [System design](docs/SYSTEM_DESIGN.md) and the
 
 - More architectures — the model layer is built for enumeration, and the
   Qwen 3.6 port is the template for the next one
-- Overlapping expert I/O with GPU work (decode is currently ~53% expert-read
-  wait, serialized with compute)
+- Extend resident-expert compute/I/O overlap to every model family and prefill
 - Per-model quality validation (KLD against reference implementations)
 - Longer contexts, vision towers, and a hardware benchmark matrix
 

--- a/Sources/Mference/Kernels/MoE/MoE.swift
+++ b/Sources/Mference/Kernels/MoE/MoE.swift
@@ -33,7 +33,7 @@ final class MoE {
 
     private let realDecodeD: UInt32
     private let realDecodeF: UInt32
-    private static let realDecodeTopK: UInt32 = 8
+    private let realDecodeTopK: UInt32
     private let realDecodeNumExperts: UInt32
 
     private let routerGemvPSO: MTLComputePipelineState
@@ -47,6 +47,8 @@ final class MoE {
     private let phase1SubsetU16SpecializedPSO: MTLComputePipelineState
     private let phase2ReduceK8PSO: MTLComputePipelineState
     private let phase2ReduceK8SpecializedPSO: MTLComputePipelineState
+    private let phase2ReduceK6PSO: MTLComputePipelineState
+    private let phase2ReduceK6SpecializedPSO: MTLComputePipelineState
     private let routedArgEncoder: MTLArgumentEncoder
     private let reusableRoutedArgBuffer: MTLBuffer
 
@@ -58,9 +60,13 @@ final class MoE {
          siluActivation: Bool = false,
          specializedD: UInt32 = 2816,
          specializedF: UInt32 = 704,
-         specializedNumExperts: UInt32 = 128) throws {
+         specializedNumExperts: UInt32 = 128,
+         specializedTopK: UInt32 = 8) throws {
+        precondition(specializedTopK == 6 || specializedTopK == 8,
+                     "routed INT4 decode supports top-k 6 or 8")
         self.realDecodeD = specializedD
         self.realDecodeF = specializedF
+        self.realDecodeTopK = specializedTopK
         self.realDecodeNumExperts = specializedNumExperts
         let activationConstants: [MetalFunctionConstant] = siluActivation
             ? [MetalFunctionConstant(index: 4, value: .bool(true))]
@@ -68,13 +74,13 @@ final class MoE {
         let moeConstants: [MetalFunctionConstant] = [
             MetalFunctionConstant(index: 0, value: .uint32(specializedD)),
             MetalFunctionConstant(index: 1, value: .uint32(specializedF)),
-            MetalFunctionConstant(index: 2, value: .uint32(Self.realDecodeTopK)),
+            MetalFunctionConstant(index: 2, value: .uint32(specializedTopK)),
             MetalFunctionConstant(index: 3, value: .bool(true)),
         ] + activationConstants
         let routerConstants: [MetalFunctionConstant] = [
             MetalFunctionConstant(index: 40, value: .uint32(specializedNumExperts)),
             MetalFunctionConstant(index: 41, value: .uint32(specializedD)),
-            MetalFunctionConstant(index: 42, value: .uint32(Self.realDecodeTopK)),
+            MetalFunctionConstant(index: 42, value: .uint32(specializedTopK)),
             MetalFunctionConstant(index: 43, value: .bool(true)),
         ]
         let routerName = "router_gemv_gemma4_r4"
@@ -105,6 +111,10 @@ final class MoE {
         self.phase2ReduceK8PSO = try context.pipeline("moe_phase2_down_reduce_k8")
         self.phase2ReduceK8SpecializedPSO = try context.pipeline(
             "moe_phase2_down_reduce_k8",
+            constants: moeConstants)
+        self.phase2ReduceK6PSO = try context.pipeline("moe_phase2_down_reduce_k6")
+        self.phase2ReduceK6SpecializedPSO = try context.pipeline(
+            "moe_phase2_down_reduce_k6",
             constants: moeConstants)
 
         guard let logits = context.device.makeBuffer(
@@ -212,7 +222,7 @@ final class MoE {
         var expertCount = topK
         guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
         encoder.setComputePipelineState(
-            useRealDecodeConstants(d: d, f: f)
+            useRealDecodeConstants(d: d, f: f, topK: topK)
                 ? phase1U16SpecializedPSO
                 : phase1U16PSO)
         encoder.setBuffer(routedArgBuffer, offset: 0, index: 0)
@@ -253,7 +263,7 @@ final class MoE {
         var active = activeCount
         guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
         encoder.setComputePipelineState(
-            useRealDecodeConstants(d: d, f: f)
+            useRealDecodeConstants(d: d, f: f, topK: topK)
                 ? phase1SubsetU16SpecializedPSO
                 : phase1SubsetU16PSO)
         encoder.setBuffer(routedArgBuffer, offset: 0, index: 0)
@@ -292,10 +302,14 @@ final class MoE {
         var dimension = d
         var intermediate = f
         guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
-        encoder.setComputePipelineState(
-            useRealDecodeConstants(d: d, f: f)
-                ? phase2ReduceK8SpecializedPSO
-                : phase2ReduceK8PSO)
+        let specialized = useRealDecodeConstants(d: d, f: f, topK: topK)
+        if topK == 6 {
+            encoder.setComputePipelineState(
+                specialized ? phase2ReduceK6SpecializedPSO : phase2ReduceK6PSO)
+        } else {
+            encoder.setComputePipelineState(
+                specialized ? phase2ReduceK8SpecializedPSO : phase2ReduceK8PSO)
+        }
         encoder.setBuffer(routedArgBuffer, offset: 0, index: 0)
         for buffer in routedBlobs { encoder.useResource(buffer, usage: .read) }
         var offsets = routedOffsets
@@ -308,12 +322,14 @@ final class MoE {
         encoder.setBytes(&intermediate, length: MemoryLayout<UInt32>.stride, index: 7)
         encoder.dispatchThreadgroups(
             MTLSize(width: Int(d), height: 1, depth: 1),
-            threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+            threadsPerThreadgroup: MTLSize(
+                width: Int(topK) * 32, height: 1, depth: 1))
         encoder.endEncoding()
     }
 
     private func validate(routedBlobs: [MTLBuffer], topK: UInt32) {
-        precondition(topK == UInt32(Self.maxStreamedExperts))
+        precondition(topK == 6 || topK == 8,
+                     "routed INT4 decode supports top-k 6 or 8")
         precondition(routedBlobs.count == Int(topK))
     }
 
@@ -325,7 +341,9 @@ final class MoE {
         }
     }
 
-    private func useRealDecodeConstants(d: UInt32, f: UInt32) -> Bool {
-        d == realDecodeD && f == realDecodeF
+    private func useRealDecodeConstants(d: UInt32,
+                                        f: UInt32,
+                                        topK: UInt32) -> Bool {
+        d == realDecodeD && f == realDecodeF && topK == realDecodeTopK
     }
 }

--- a/Sources/Mference/Kernels/MoE/MoE.swift
+++ b/Sources/Mference/Kernels/MoE/MoE.swift
@@ -189,13 +189,9 @@ final class MoE {
     func makeRoutedArgumentBuffer(routedBlobs: [MTLBuffer],
                                          topK: UInt32) -> MTLBuffer? {
         validate(routedBlobs: routedBlobs, topK: topK)
-        guard let buffer = routedBlobs.first?.device.makeBuffer(
-            length: routedArgEncoder.encodedLength,
-            options: .storageModeShared) else {
-            return nil
-        }
-        encodeRoutedArgumentBuffer(buffer, routedBlobs: routedBlobs)
-        return buffer
+        encodeRoutedArgumentBuffer(reusableRoutedArgBuffer,
+                                   routedBlobs: routedBlobs)
+        return reusableRoutedArgBuffer
     }
 
     func makeReusedRoutedArgumentBuffer(routedBlobs: [MTLBuffer],

--- a/Sources/Mference/Metal/MoE/moe.metal
+++ b/Sources/Mference/Metal/MoE/moe.metal
@@ -1069,6 +1069,44 @@ kernel void moe_phase2_down_reduce_int2_k6(
     }
 }
 
+kernel void moe_phase2_down_reduce_k6(
+    device const RoutedBlobs& routed [[buffer(0)]],
+    constant ExpertOffsets& routed_offsets [[buffer(1)]],
+    device const half* acts [[buffer(2)]],
+    device const half* routing_w [[buffer(3)]],
+    device const half* residual [[buffer(4)]],
+    device half* y [[buffer(5)]],
+    constant uint& D [[buffer(6)]],
+    constant uint& F [[buffer(7)]],
+    uint d [[threadgroup_position_in_grid]],
+    uint sg_idx [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    threadgroup float partial[6];
+    const uint DD = moe_fc_d(D);
+    const uint FF = moe_fc_f(F);
+    if (d >= DD) return;
+
+    device const uint8_t* base = routed.blob[sg_idx];
+    const ExpertOffsets re = routed_offsets;
+    device const uint8_t* dW = base + re.down_W_off;
+    device const bfloat* dS = (device const bfloat*)(base + re.down_s_off);
+    device const bfloat* dB = (device const bfloat*)(base + re.down_b_off);
+    device const half* act_slot = acts + sg_idx * FF;
+
+    const float value = moe_int4_gemv_row_simd_dev_vec(
+        dW, dS, dB, act_slot, d, FF, lane);
+    if (lane == 0) partial[sg_idx] = float(routing_w[sg_idx]) * value;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (sg_idx == 0 && lane == 0) {
+        float acc = float(residual[d]);
+        acc += partial[0]; acc += partial[1]; acc += partial[2];
+        acc += partial[3]; acc += partial[4]; acc += partial[5];
+        y[d] = half(acc);
+    }
+}
+
 kernel void moe_phase2_down_reduce_k8(
     device const RoutedBlobs& routed [[buffer(0)]],
     constant ExpertOffsets& routed_offsets [[buffer(1)]],

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -477,7 +477,8 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                  siluActivation: silu,
                                  specializedD: UInt32(cfg.hiddenSize),
                                  specializedF: UInt32(cfg.moeIntermediateSize),
-                                 specializedNumExperts: UInt32(cfg.numExperts))
+                                 specializedNumExperts: UInt32(cfg.numExperts),
+                                 specializedTopK: UInt32(cfg.topKExperts))
         self.fusionHead = try LMHeadChainInt4(context: context,
                                               maxD: cfg.hiddenSize,
                                               maxVocab: cfg.vocabSize)
@@ -3102,22 +3103,28 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         let kvDim = UInt32(cfg.numKVHeads * cfg.headDim)
         let seqLen = UInt32(position + 1)
         let sconvK = UInt32(cfg.sconvKernelSize)
-        let paddedK = MoE.maxStreamedExperts
         let rel = cfg.relativePosition
 
         struct PendingInkling {
             let cb: MTLCommandBuffer
             let attentionCB: MTLCommandBuffer
+            let phase1HitCB: MTLCommandBuffer?
         }
         var pending: PendingInkling?
         func finishPending(_ p: PendingInkling, waitIfNeeded: Bool) {
             if waitIfNeeded {
                 waitForCompletion(p.attentionCB)
+                if let hitCB = p.phase1HitCB { waitForCompletion(hitCB) }
                 waitForCompletion(p.cb)
             } else {
                 if let err = p.cb.error { print("CB error: \(err)") }
                 if let err = p.attentionCB.error { print("CB error: \(err)") }
+                if let err = p.phase1HitCB?.error { print("CB error: \(err)") }
             }
+        }
+        func writeActiveSlots(_ slots: [UInt32], into buffer: MTLBuffer) {
+            let ptr = buffer.contents().assumingMemoryBound(to: UInt32.self)
+            for i in 0..<slots.count { ptr[i] = slots[i] }
         }
 
         // Embed lookup, then the family's embed norm (in place).
@@ -3389,33 +3396,95 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             waitForRouterSignal(routerSignal, fallback: cb)
             if let p = pending { finishPending(p, waitIfNeeded: false); pending = nil }
 
-            // CPU readback of the 6 routed experts; the streamed list pads to
-            // the MoE contract's 8 slots with duplicates whose weight slots
-            // were pinned to zero at init.
+            // CPU readback of the six routed experts. A mixed cache plan sends
+            // the resident subset to Metal immediately, then preads only the
+            // misses while the shared branch and resident phase 1 execute.
             let idxPtr = outIndices.contents().bindMemory(to: UInt32.self,
                                                           capacity: cfg.topKExperts)
             var experts = [Int](repeating: 0, count: cfg.topKExperts)
             for i in 0..<cfg.topKExperts {
                 experts[i] = min(Int(idxPtr[i]), cfg.numExperts - 1)
             }
-            let tIoStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
-            let blobs = try await model.fetchRoutedExperts(layer: L, experts: experts)
-            totalIoNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tIoStart
-            var routedBufs = blobs.map { $0.buffer }
-            while routedBufs.count < paddedK { routedBufs.append(routedBufs[0]) }
-
+            let topK = UInt32(cfg.topKExperts)
             let routedOffsets = model.routedExpertOffsets(layer: L)
+            let plannedFetch = try model.planRoutedExperts(layer: L, experts: experts)
+            let missSet = Set(plannedFetch?.misses ?? [])
+            let phase1HitSlots = (0..<cfg.topKExperts)
+                .filter { !missSet.contains($0) }
+                .map { UInt32($0) }
+            let phase1MissSlots = (plannedFetch?.misses ?? []).map { UInt32($0) }
+            var phase1HitCB: MTLCommandBuffer?
+            var splitArgBuf: MTLBuffer?
+            var splitRoutedBufs: [MTLBuffer] = []
+
+            if let plan = plannedFetch,
+               plan.hits > 0,
+               !plan.misses.isEmpty {
+                splitRoutedBufs = try model.routedExpertBuffers(for: plan)
+                    .map(\.buffer)
+                splitArgBuf = moe.makeRoutedArgumentBuffer(
+                    routedBlobs: splitRoutedBufs, topK: topK)
+                if let argBuf = splitArgBuf {
+                    writeActiveSlots(phase1HitSlots, into: moeHitActiveSlots)
+                    let hitCB = ctx.queue.makeCommandBuffer()!
+                    moe.encodeRoutedPersistentPhase1SubsetU16Load(
+                        commandBuffer: hitCB,
+                        routedArgBuffer: argBuf,
+                        routedBlobs: splitRoutedBufs,
+                        routedOffsets: routedOffsets,
+                        x: routedX,
+                        acts: moeActs,
+                        activeSlots: moeHitActiveSlots,
+                        activeSlotIndices: phase1HitSlots,
+                        activeCount: UInt32(phase1HitSlots.count),
+                        d: D,
+                        f: FmoE,
+                        topK: topK)
+                    hitCB.commit()
+                    phase1HitCB = hitCB
+                }
+            }
+
+            let tIoStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+            let blobs: [TensorView]
+            if let plannedFetch {
+                blobs = try await model.fetchRoutedExperts(plan: plannedFetch)
+            } else {
+                blobs = try await model.fetchRoutedExperts(layer: L, experts: experts)
+            }
+            totalIoNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tIoStart
+            let routedBufs = blobs.map(\.buffer)
+
             let routedCB = ctx.queue.makeCommandBuffer()!
-            let argBuf = moe.makeReusedRoutedArgumentBuffer(
-                routedBlobs: routedBufs, topK: UInt32(paddedK))
-            moe.encodeRoutedPersistentPhase1U16Load(commandBuffer: routedCB,
-                                                    routedArgBuffer: argBuf,
-                                                    routedBlobs: routedBufs,
-                                                    routedOffsets: routedOffsets,
-                                                    x: routedX,
-                                                    acts: moeActs,
-                                                    d: D, f: FmoE,
-                                                    topK: UInt32(paddedK))
+            let argBuf = splitArgBuf ?? moe.makeReusedRoutedArgumentBuffer(
+                routedBlobs: routedBufs, topK: topK)
+            if splitArgBuf != nil {
+                writeActiveSlots(phase1MissSlots, into: moeMissActiveSlots)
+                moe.encodeRoutedPersistentPhase1SubsetU16Load(
+                    commandBuffer: routedCB,
+                    routedArgBuffer: argBuf,
+                    routedBlobs: routedBufs,
+                    routedOffsets: routedOffsets,
+                    x: routedX,
+                    acts: moeActs,
+                    activeSlots: moeMissActiveSlots,
+                    activeSlotIndices: phase1MissSlots,
+                    activeCount: UInt32(phase1MissSlots.count),
+                    d: D,
+                    f: FmoE,
+                    topK: topK)
+            } else {
+                moe.encodeRoutedPersistentPhase1U16Load(
+                    commandBuffer: routedCB,
+                    routedArgBuffer: argBuf,
+                    routedBlobs: routedBufs,
+                    routedOffsets: routedOffsets,
+                    x: routedX,
+                    acts: moeActs,
+                    d: D,
+                    f: FmoE,
+                    topK: topK)
+            }
             // Phase 2 seeds y with the shared-expert branch, so the sum is
             // routed + shared exactly as the reference computes it.
             moe.encodeRoutedPersistentPhase2Reduce(commandBuffer: routedCB,
@@ -3427,7 +3496,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                                    residual: h1Buf,
                                                    y: h2Buf,
                                                    d: D, f: FmoE,
-                                                   topK: UInt32(paddedK))
+                                                   topK: topK)
             inkling.encodeSconvStepF32Out(commandBuffer: routedCB,
                                           x: h2Buf, state: conv.mlp,
                                           weight: mlpSconvW.buffer,
@@ -3479,7 +3548,9 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                       "w=\((0..<8).map { Float(w[$0]) }) " +
                       "idx=\((0..<6).map { idx[$0] })")
             }
-            pending = PendingInkling(cb: routedCB, attentionCB: cb)
+            pending = PendingInkling(cb: routedCB,
+                                     attentionCB: cb,
+                                     phase1HitCB: phase1HitCB)
             if Self.inklingSyncMode {
                 finishPending(pending!, waitIfNeeded: true)
                 pending = nil

--- a/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/RealForwardRunner.swift
@@ -3422,6 +3422,8 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                !plan.misses.isEmpty {
                 splitRoutedBufs = try model.routedExpertBuffers(for: plan)
                     .map(\.buffer)
+                // Router readback is a same-queue fence for the prior layer,
+                // so MoE's preallocated argument storage is no longer in use.
                 splitArgBuf = moe.makeRoutedArgumentBuffer(
                     routedBlobs: splitRoutedBufs, topK: topK)
                 if let argBuf = splitArgBuf {

--- a/Tests/Mference/Core/Kernels/MoE/MoEFusedFFNTests.swift
+++ b/Tests/Mference/Core/Kernels/MoE/MoEFusedFFNTests.swift
@@ -7,15 +7,28 @@ import MferenceValidationSupport
 @Suite struct MoEFusedFFNTests {
     private static let dimension = 128
     private static let intermediate = 64
-    private static let topK = 8
 
     private struct RoutedBlob {
         let bytes: [UInt8]
         let offsets: MoEExpertOffsets
     }
 
-    @Test func productionRoutedPipelineAndHitSplitMatchReference() throws {
-        var rng = SeedTree(0x2D3).key("production-routed-moe")
+    @Test func productionTop8PipelineAndHitSplitMatchReference() throws {
+        try Self.checkPipeline(topK: 8,
+                               splitSlots: [[0, 1, 2, 3], [4, 5, 6, 7]],
+                               seedKey: "production-routed-moe-top8")
+    }
+
+    @Test func inklingTop6PipelineAndHitSplitMatchReference() throws {
+        try Self.checkPipeline(topK: 6,
+                               splitSlots: [[0, 2, 4], [1, 3, 5]],
+                               seedKey: "inkling-routed-moe-top6")
+    }
+
+    private static func checkPipeline(topK: Int,
+                                      splitSlots: [[UInt32]],
+                                      seedKey: String) throws {
+        var rng = SeedTree(0x2D3).key(seedKey)
         func matrix(rows: Int, columns: Int) -> [[Float]] {
             (0..<rows).map { _ in
                 (0..<columns).map { _ in rng.uniform(-0.4, 0.4) }
@@ -25,7 +38,7 @@ import MferenceValidationSupport
         var gates = [[[Float]]]()
         var ups = [[[Float]]]()
         var downs = [[[Float]]]()
-        for _ in 0..<Self.topK {
+        for _ in 0..<topK {
             gates.append(matrix(rows: Self.intermediate, columns: Self.dimension))
             ups.append(matrix(rows: Self.intermediate, columns: Self.dimension))
             downs.append(matrix(rows: Self.dimension, columns: Self.intermediate))
@@ -36,7 +49,7 @@ import MferenceValidationSupport
         let residual = (0..<Self.dimension).map { _ in
             Float(Float16(rng.uniform(-0.5, 0.5)))
         }
-        let routingWeights = (0..<Self.topK).map {
+        let routingWeights = (0..<topK).map {
             Float(Float16(0.04 + Float($0) * 0.015))
         }
         let expected = MoeRef.applyStreamedRouted(
@@ -51,42 +64,45 @@ import MferenceValidationSupport
             routedDown: downs.map { rows in
                 rows.map { Quantization.quantizeInt4Affine($0) }
             },
-            indices: Array(0..<Self.topK),
+            indices: Array(0..<topK),
             routingWeights: routingWeights,
             d: Self.dimension,
             f: Self.intermediate)
-        let blobs = (0..<Self.topK).map {
+        let blobs = (0..<topK).map {
             Self.makeBlob(gate: gates[$0], up: ups[$0], down: downs[$0])
         }
 
         let context = try MetalContext()
-        let kernel = try MoE(context: context)
+        let kernel = try MoE(context: context,
+                             specializedD: UInt32(Self.dimension),
+                             specializedF: UInt32(Self.intermediate),
+                             specializedNumExperts: 128,
+                             specializedTopK: UInt32(topK))
         let routedBuffers = blobs.compactMap {
             context.device.makeBuffer(bytes: $0.bytes,
                                       length: $0.bytes.count,
                                       options: .storageModeShared)
         }
-        guard routedBuffers.count == Self.topK,
+        let activeBuffers = splitSlots.compactMap { slots in
+            context.device.makeBuffer(
+                bytes: slots,
+                length: slots.count * MemoryLayout<UInt32>.stride,
+                options: .storageModeShared)
+        }
+        guard routedBuffers.count == topK,
+              activeBuffers.count == splitSlots.count,
               let xBuffer = Fp16Buffer.make(context.device, values: x),
               let residualBuffer = Fp16Buffer.make(context.device, values: residual),
               let routingBuffer = Fp16Buffer.make(context.device, values: routingWeights),
               let fullActs = Fp16Buffer.make(
-                context.device, count: Self.topK * Self.intermediate),
+                context.device, count: topK * Self.intermediate),
               let splitActs = Fp16Buffer.make(
-                context.device, count: Self.topK * Self.intermediate),
+                context.device, count: topK * Self.intermediate),
               let fullOutput = Fp16Buffer.make(context.device, count: Self.dimension),
               let splitOutput = Fp16Buffer.make(context.device, count: Self.dimension),
-              let lowSlots = context.device.makeBuffer(
-                bytes: [UInt32](0...3),
-                length: 4 * MemoryLayout<UInt32>.stride,
-                options: .storageModeShared),
-              let highSlots = context.device.makeBuffer(
-                bytes: [UInt32](4...7),
-                length: 4 * MemoryLayout<UInt32>.stride,
-                options: .storageModeShared),
               let argumentBuffer = kernel.makeRoutedArgumentBuffer(
                 routedBlobs: routedBuffers,
-                topK: UInt32(Self.topK)) else {
+                topK: UInt32(topK)) else {
             Issue.record("buffer allocation failed")
             return
         }
@@ -101,7 +117,7 @@ import MferenceValidationSupport
             acts: fullActs,
             d: UInt32(Self.dimension),
             f: UInt32(Self.intermediate),
-            topK: UInt32(Self.topK))
+            topK: UInt32(topK))
         kernel.encodeRoutedPersistentPhase2Reduce(
             commandBuffer: fullCommand,
             routedArgBuffer: argumentBuffer,
@@ -113,14 +129,13 @@ import MferenceValidationSupport
             y: fullOutput,
             d: UInt32(Self.dimension),
             f: UInt32(Self.intermediate),
-            topK: UInt32(Self.topK))
+            topK: UInt32(topK))
         fullCommand.commit()
         fullCommand.waitUntilCompleted()
         #expect(fullCommand.error == nil)
 
         let splitCommand = context.queue.makeCommandBuffer()!
-        for (slots, activeSlots) in [([UInt32](0...3), lowSlots),
-                                     ([UInt32](4...7), highSlots)] {
+        for (slots, activeSlots) in zip(splitSlots, activeBuffers) {
             kernel.encodeRoutedPersistentPhase1SubsetU16Load(
                 commandBuffer: splitCommand,
                 routedArgBuffer: argumentBuffer,
@@ -133,7 +148,7 @@ import MferenceValidationSupport
                 activeCount: UInt32(slots.count),
                 d: UInt32(Self.dimension),
                 f: UInt32(Self.intermediate),
-                topK: UInt32(Self.topK))
+                topK: UInt32(topK))
         }
         kernel.encodeRoutedPersistentPhase2Reduce(
             commandBuffer: splitCommand,
@@ -146,7 +161,7 @@ import MferenceValidationSupport
             y: splitOutput,
             d: UInt32(Self.dimension),
             f: UInt32(Self.intermediate),
-            topK: UInt32(Self.topK))
+            topK: UInt32(topK))
         splitCommand.commit()
         splitCommand.waitUntilCompleted()
         #expect(splitCommand.error == nil)

--- a/Tests/Mference/Core/Kernels/MoE/MoEFusedFFNTests.swift
+++ b/Tests/Mference/Core/Kernels/MoE/MoEFusedFFNTests.swift
@@ -13,6 +13,22 @@ import MferenceValidationSupport
         let offsets: MoEExpertOffsets
     }
 
+    @Test func routedArgumentBufferReusesPreallocatedStorage() throws {
+        let context = try MetalContext()
+        let kernel = try MoE(context: context, specializedTopK: 6)
+        let routedBuffers = (0..<6).compactMap { _ in
+            context.device.makeBuffer(length: 1, options: .storageModeShared)
+        }
+        #expect(routedBuffers.count == 6)
+
+        let first = try #require(kernel.makeRoutedArgumentBuffer(
+            routedBlobs: routedBuffers, topK: 6))
+        let second = try #require(kernel.makeRoutedArgumentBuffer(
+            routedBlobs: routedBuffers, topK: 6))
+
+        #expect(first === second)
+    }
+
     @Test func productionTop8PipelineAndHitSplitMatchReference() throws {
         try Self.checkPipeline(topK: 8,
                                splitSlots: [[0, 1, 2, 3], [4, 5, 6, 7]],

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -144,6 +144,54 @@ This is emulated pressure on M5 hardware, not a measurement on a physical 8 GB
 Mac; a real 8 GB machine has a slower SSD and GPU and should be expected to
 decode more slowly, as the M2 rows above show for Gemma 4.
 
+## Inkling-Small 276B-A12B measured decode
+
+The native top-6 decode path was measured on 2026-08-06 on the same 24 GB M5
+MacBook Pro (`Mac17,2`), with macOS 26.5 and Swift 6.3.3. The untouched base
+was `6bf428f`; the optimized implementation was `485df08`. Both used release
+builds, the production automatic 16-slot cache, strict full-SHA verification,
+and the frozen community prompts and sampling settings. One discarded warmup
+preceded one measured fresh process per case; every process exited 0 and
+reported `stop=endOfTurn`.
+
+| Case | Prompt / generated tokens | Base decode | Native top-6 decode | Gain |
+| --- | --- | ---: | ---: | ---: |
+| short-explanation | 59 / 469 | 2.909 tok/s | 3.434 tok/s | 18.0% |
+| medium-review | 421 / 576 | 2.961 tok/s | 3.670 tok/s | 23.9% |
+| long-synthesis | 2,785 / 372 | 2.819 tok/s | 3.038 tok/s | 7.8% |
+
+The geometric-mean decode gain is **16.4%**. Each optimized output is
+byte-identical to its base output, so the table compares the same generated
+tokens and expert-routing workload. Complete measured timing footers, in
+base/optimized order, were:
+
+```text
+[stop=endOfTurn prefill=59tok/64.89s new=469tok decode=161.22s tok/s=2.909]
+[stop=endOfTurn prefill=59tok/64.25s new=469tok decode=136.57s tok/s=3.434]
+[stop=endOfTurn prefill=421tok/79.61s new=576tok decode=194.53s tok/s=2.961]
+[stop=endOfTurn prefill=421tok/76.41s new=576tok decode=156.95s tok/s=3.670]
+[stop=endOfTurn prefill=2785tok/169.39s new=372tok decode=131.94s tok/s=2.819]
+[stop=endOfTurn prefill=2785tok/180.48s new=372tok decode=122.46s tok/s=3.038]
+```
+
+Inkling routes six experts, but the old runtime padded them to the shared
+top-8 INT4 contract with two duplicate buffers and zero weights. The optimized
+path dispatches a dedicated six-SIMD-group down/reduce Metal kernel, runs only
+six phase-1 expert slots, and submits resident phase-1 work while the CPU reads
+cache misses. It preserves the FP32 shared-sink/residual path.
+
+A production 24-slot warmup was also tried with the same short workload. It
+produced byte-identical output but decoded at 0.710 tok/s while free-memory
+pressure fell to 24%, versus 3.374 tok/s for the optimized 16-slot warmup.
+Because the first larger cache already exceeded the useful memory envelope,
+32 slots were not run and Inkling's automatic default remains 16.
+
+The exact measured command was:
+
+```text
+.build/release/MferenceCLI --model scratch/inklingsmall.gturbo --messages-file docs/benchmark-prompts/real-generation-v1/<case>.json --max-new 1024 --max-context 4096 --temperature 0.2 --top-k 64 --top-p 0.95 --seed <seed>
+```
+
 ## Same-host MLX comparison
 
 The same M5 Pro ran MLX 0.32.0 and mlx-lm 0.31.3 against the same checkpoint,

--- a/docs/INKLING_SMALL.md
+++ b/docs/INKLING_SMALL.md
@@ -6,9 +6,10 @@ Checkpoint selection, memory budget, and the architecture gap list for running
 document is the architecture contract for the `inklingSmall` family.
 
 Conversion has been run and verified against the real checkpoint (see
-**Status**), and the forward pass has since shipped: measured decode is
-5.3–6.9 tok/s at an ~8.9 GiB peak footprint on an M3 Ultra
-([BENCHMARKS_M3_ULTRA.md](BENCHMARKS_M3_ULTRA.md)). Throughput figures
+**Status**), and the forward pass has since shipped. The current native top-6
+path measures 3.0–3.7 tok/s on a 24 GB M5, a 16.4% geometric-mean gain over
+the prior engine. A 256 GB M3 Ultra measures 5.3–6.9 tok/s at an ~8.9 GiB peak
+footprint ([BENCHMARKS_M3_ULTRA.md](BENCHMARKS_M3_ULTRA.md)). Throughput figures
 elsewhere in this document that are labeled *estimates* predate those runs
 and are kept for the planning context they carried; the benchmark document
 is the measured record.
@@ -320,9 +321,10 @@ The decode path is implemented end to end: `produceTokenInkling` in
 with no V norm, single-token GQA attention with the relative-position bias
 computed inline plus ring/window/log-`tau` handling, and the sigmoid router
 select with shared-expert sinks), each parity-tested against a CPU reference
-on random data (`InklingKernelTests`). Routed experts reuse the existing INT4
-MoE phase kernels by padding top-6 to the contract's 8 slots with weight-0
-duplicates (cache hits, no extra I/O). Prefill v1 replays the decode path
+on random data (`InklingKernelTests`). The first implementation reused the
+existing INT4 MoE phase kernels by padding top-6 to eight slots with
+weight-zero duplicates; the native top-6 path described below removed that
+compute waste. Prefill v1 replays the decode path
 token by token — the DSV4-v1 pattern; conv state makes batched prefill a
 follow-up, not a correctness need. The `.inkling` chat dialect implements the
 shipped Jinja's framing (role tokens + `<|content_text|>` + `<|end_message|>`,
@@ -422,7 +424,7 @@ the next one:
 
 | Store | Prescaled before it? | Measured headroom |
 |---|---|---|
-| routed down projection (decode, `moe_phase2_down_reduce_k8`) | yes — `routing_w` carries ÷32 and the reduce is FP32 | `h2` peaked at 4 764 of 65 504 |
+| routed down projection (decode, `moe_phase2_down_reduce_k6`) | yes — `routing_w` carries ÷32 and the reduce is FP32 | `h2` peaked at 4 764 of 65 504 |
 | shared down projection (decode + prefill) | **no** — gamma applies after | **overflowed**; now FP32 |
 | `h1` / `h2` after the gamma combine | yes | 7 064 of 65 504 at the worst observed token |
 | dense MLP down projection, layers 0-1 | **no** — `mlp.global_scale` applies after, same pattern | not overflowing: the L0/L1 residual peaks near 1e2, so ~500× margin. Left FP16 deliberately; widen it if those layers ever grow. |
@@ -535,6 +537,43 @@ This is an isolated-prefill measurement, not the public community generation
 protocol: it uses one new token, trusted-receipt verification, one measured run
 per binary, and the production 128-token chunk default. Treat it as a local A/B
 measurement rather than a performance ceiling.
+
+### Native top-6 decode (2026-08-06)
+
+Inkling now has a dedicated top-6 INT4 MoE decode path. The old implementation
+padded six selected experts to the shared top-8 contract: duplicate buffers
+cost no extra SSD reads, but phase 1 still evaluated eight gate/up rows and
+phase 2 still evaluated eight down projections. `moe_phase2_down_reduce_k6`
+launches six SIMD groups per output row and reduces the six routed values in
+router order. Phase 1 specializes its existing function-constant top-k to six.
+
+The runtime also plans the six cache slots before reading. On a mixed hit/miss
+layer, it submits resident phase 1 immediately, reads only the misses, and then
+submits the missing subset before the native top-6 reduction. The shared sinks
+and FP32 residual path retain their original ordering and arithmetic.
+
+Release A/B at base `6bf428f` and optimized commit `485df08` followed the full
+[community protocol](COMMUNITY_BENCHMARKS.md) on a 24 GB M5 (`Mac17,2`),
+macOS 26.5, and Swift 6.3.3. Runs used strict verification, production defaults,
+one discarded warmup, and one measured fresh process per case. Every command
+exited 0 and ended naturally.
+
+| Case | Prompt / generated | Base | Native top-6 | Gain |
+|---|---|---:|---:|---:|
+| short-explanation | 59 / 469 | 2.909 tok/s | 3.434 tok/s | 18.0% |
+| medium-review | 421 / 576 | 2.961 tok/s | 3.670 tok/s | 23.9% |
+| long-synthesis | 2,785 / 372 | 2.819 tok/s | 3.038 tok/s | 7.8% |
+
+The geometric-mean gain is **16.4%**, and every optimized stdout file is
+byte-identical to its base counterpart. Full timing footers and the generic
+reproduction command are recorded in
+[BENCHMARKS.md](BENCHMARKS.md#inkling-small-276b-a12b-measured-decode).
+
+A 24-slot short warmup was rejected: it fell to 0.710 tok/s and pushed
+free-memory pressure to 24%, while the optimized 16-slot warmup reached 3.374
+tok/s with identical output. Since 24 slots already crossed the useful memory
+envelope on this host, 32 was not run; Inkling remains on the 16-slot automatic
+default.
 
 Bring-up config note: the fused QKV GEMV and the constant-folded INT4 GEMV
 variants are bypassed for this family (plain generic GEMVs) — they were

--- a/docs/superpowers/plans/2026-08-06-inkling-decode-implementation.md
+++ b/docs/superpowers/plans/2026-08-06-inkling-decode-implementation.md
@@ -1,0 +1,120 @@
+# Inkling Decode Acceleration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Inkling's padded top-8 decode work with a native top-6 Metal path, overlap resident-expert phase 1 with cache-miss reads, and prove an end-to-end decode gain.
+
+**Architecture:** Generalize the shared INT4 routed-MoE wrapper only at its top-k boundary while retaining the existing top-8 kernels for Gemma and Qwen. Inkling selects a dedicated six-SIMD-group down/reduce kernel and uses the existing cache-plan API to split phase 1 into resident and missing slot subsets.
+
+**Tech Stack:** Swift 6.3, Metal Shading Language, Swift Testing, Mference's pread expert cache and community benchmark CLI.
+
+## Global Constraints
+
+- Preserve Inkling top-6 routing order, two shared-expert sinks, and FP32 residual semantics.
+- Preserve the existing top-8 Gemma and Qwen paths.
+- Allocate no buffers in the per-token decode loop.
+- Run real-model tests only after the macOS, Swift, disk, memory-pressure, install, and process checks in `AGENTS.md` pass.
+- Publish performance only from release builds following `docs/COMMUNITY_BENCHMARKS.md`, with deviations stated.
+
+---
+
+### Task 1: Native top-6 routed-MoE kernel
+
+**Files:**
+- Modify: `Tests/Mference/Core/Kernels/MoE/MoEFusedFFNTests.swift`
+- Modify: `Sources/Mference/Kernels/MoE/MoE.swift`
+- Modify: `Sources/Mference/Metal/MoE/moe.metal`
+
+**Interfaces:**
+- Consumes: `MoEExpertOffsets`, eight-entry `RoutedBlobs` argument-buffer layout, FP16 routed activations and weights.
+- Produces: `MoE.init(..., specializedTopK: UInt32)` supporting 6 or 8 and `encodeRoutedPersistentPhase2Reduce(..., topK:)` selecting the matching reduction kernel.
+
+- [ ] **Step 1: Write the failing top-6 parity test**
+
+  Add a six-distinct-expert case that constructs `MoE(context:siluActivation:specializedD:specializedF:specializedNumExperts:specializedTopK:)`, runs both full phase 1 and a 3-hit/3-miss subset split, then compares both outputs to `MoeRef.applyStreamedRouted`.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+  Run `Scripts/test.sh --filter MoEFusedFFNTests`. Expect compilation to fail because `specializedTopK` and a top-6 reduction path do not exist.
+
+- [ ] **Step 3: Implement the native top-6 kernels**
+
+  Add `moe_phase2_down_reduce_k6` with six SIMD groups and ordered FP32 accumulation. Store `specializedTopK` in `MoE`, use it in phase-1 function constants, load the top-6 PSO, allow only top-k 6 or 8, and bind only the requested number of expert buffers.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+  Run `Scripts/test.sh --filter MoEFusedFFNTests` and require both the new top-6 parity case and existing top-8 case to pass.
+
+### Task 2: Inkling cache-hit phase-1 overlap
+
+**Files:**
+- Modify: `Sources/Mference/Runtime/Inference/RealForwardRunner.swift`
+- Test: `Tests/Mference/Core/Kernels/MoE/MoEFusedFFNTests.swift`
+- Test: `Tests/Mference/Core/Runtime/InklingGenerationRegressionTests.swift`
+
+**Interfaces:**
+- Consumes: `Model.planRoutedExperts`, `Model.routedExpertBuffers(for:)`, `Model.fetchRoutedExperts(plan:)`, `MoE.encodeRoutedPersistentPhase1SubsetU16Load`, and runner-owned active-slot buffers.
+- Produces: Inkling decode that submits hit phase 1 before awaiting misses and computes each of six expert slots exactly once.
+
+- [ ] **Step 1: Verify the subset test catches a missing slot**
+
+  Temporarily omit one of the six active slots in the test's split dispatch and run `Scripts/test.sh --filter MoEFusedFFNTests`; require an output mismatch, then restore the complete split.
+
+- [ ] **Step 2: Integrate planned fetch and hit/miss dispatch**
+
+  Initialize `MoE` with `specializedTopK: UInt32(cfg.topKExperts)`. In `produceTokenInkling`, plan the six selected experts, submit the hit subset when the plan is mixed, await only planned misses, submit the miss subset, and reduce with `topK == 6`. Retain the full-dispatch fallback for all-hit, all-miss, or unavailable planning.
+
+- [ ] **Step 3: Run focused unit and real-model regression tests**
+
+  Run `Scripts/test.sh --filter MoEFusedFFNTests`, then run the env-gated Inkling generation regression with `MFERENCE_INKLING_GTURBO=scratch/inklingsmall.gturbo`. Require matching expected output and no non-finite logit failure.
+
+### Task 3: Select the production cache default by measurement
+
+**Files:**
+- Modify if justified: `Tests/Mference/Core/Runtime/Configuration/RuntimeConfigurationTests.swift`
+- Modify if justified: `Sources/Mference/Runtime/Configuration/RuntimeConfiguration.swift`
+- Modify if justified: `docs/RUNTIME_CONTROLS.md`
+
+**Interfaces:**
+- Consumes: `RuntimeConfiguration.defaultExpertCacheSlots(for:physicalMemoryBytes:)` and CLI `--expert-cache-slots` controls.
+- Produces: an Inkling-aware automatic slot count only if measured benefit and memory pressure justify it.
+
+- [ ] **Step 1: Run matched 16-, 24-, and 32-slot controls**
+
+  Use the same release binary, frozen prompt, seed, sampling settings, generated-token limit, and warm-cache procedure. Capture complete footers, output hashes, peak memory, and `memory_pressure -Q` after each run.
+
+- [ ] **Step 2: Add a failing automatic-policy test if a larger cache wins**
+
+  Add literal expectations at memory boundaries that select the smallest winning Inkling cache size while leaving Qwen and other families unchanged. Run `Scripts/test.sh --filter RuntimeConfigurationTests` and require RED before editing production policy.
+
+- [ ] **Step 3: Implement and document the measured policy**
+
+  Change only `defaultExpertCacheSlots`, its tests, and the runtime-controls table. Explicit CLI and app settings remain unchanged.
+
+### Task 4: Full verification and publication
+
+**Files:**
+- Modify: `docs/INKLING_SMALL.md`
+- Modify: `docs/BENCHMARKS.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: final release binary and frozen community prompts.
+- Produces: reproducible end-to-end performance evidence and user-facing numbers.
+
+- [ ] **Step 1: Run full static and package verification**
+
+  Run `swift build -c release --product MferenceCLI`, `Scripts/test.sh`, `git diff --check origin/main`, and `LANG=en_US.UTF-8 ruby Scripts/check_markdown_links.rb`. Require zero failures.
+
+- [ ] **Step 2: Run the final community benchmark**
+
+  Run one discarded warmup and one fresh-process measurement for short, medium, and long cases with the final production defaults. Require `stop=endOfTurn`, coherent complete output, and matched generated tokens for every A/B claim.
+
+- [ ] **Step 3: Update performance documentation**
+
+  Record baseline/final footers, speedups, hardware, RAM, macOS, Swift, commit, exact generic command, exit codes, output comparison, and protocol deviations. Update landing-page numbers only with verified final results.
+
+- [ ] **Step 4: Review, commit, push, and raise the PR**
+
+  Inspect the complete diff, run the verification commands again after documentation edits, commit the implementation and evidence, push `codex/inkling-decode-speedup`, and open a ready pull request against `main`.
+

--- a/docs/superpowers/specs/2026-08-06-inkling-decode-design.md
+++ b/docs/superpowers/specs/2026-08-06-inkling-decode-design.md
@@ -1,0 +1,87 @@
+# Inkling Decode Acceleration Design
+
+## Goal
+
+Materially increase Inkling-Small decode throughput while preserving its
+top-6 router, two shared-expert sinks, FP32 residual stream, and generated
+output. The gain must hold in the public community generation protocol, not
+only in an isolated kernel benchmark.
+
+## Baseline
+
+The untouched `main` build at `6bf428f` generated 469 tokens for the frozen
+`short-explanation` case on a 24 GB M5 (`Mac17,2`). After one discarded
+warmup, the measured run reported 2.909 tok/s. The command used the production
+automatic cache choice (16 slots), strict verification, sampling defaults,
+and no profiler or experimental control.
+
+Inkling routes six experts per MoE layer. The current runtime pads that list to
+the shared eight-expert contract, duplicates two expert buffers, and keeps the
+two padding weights at zero. The duplicates avoid additional I/O but still run
+gate/up/activation and down-projection work. The current Inkling loop also
+waits for every expert-cache miss before launching phase 1, even when some of
+the selected experts are already resident.
+
+## Design
+
+### Native top-6 routed MoE
+
+`MoE` will accept a specialized decode top-k of either 6 or 8. Its existing
+phase-1 kernels already consume a runtime/function-constant top-k, so Inkling
+will dispatch exactly six slots. A dedicated INT4
+`moe_phase2_down_reduce_k6` Metal kernel will launch six SIMD groups per output
+row, evaluate only the six real down projections, reduce them in router order,
+and seed the sum with Inkling's shared-expert result exactly as today.
+
+Gemma and Qwen retain the current top-8 pipeline and pipeline states. The
+argument-buffer layout remains eight entries wide, but a top-6 dispatch binds
+and reads only entries 0 through 5.
+
+### Cache-hit compute overlap
+
+After the Inkling router signal completes, the runtime will create an expert
+cache plan for the six selected experts. If the plan contains both hits and
+misses, it will bind all six reserved slot buffers and immediately submit the
+phase-1 subset for hit slots. The CPU then reads misses while that command
+buffer and the shared-expert branch execute. Once reads finish, a second
+phase-1 subset computes only the miss slots; the dedicated top-6 phase-2 kernel
+then combines all six activations with the shared branch.
+
+All-hit, all-miss, and planning-fallback cases use a single full phase-1
+dispatch. Buffers are allocated during runner initialization, and no new
+allocation occurs in the token loop. The existing command-buffer ordering and
+final token drain remain the lifetime boundary for cache-slot contents.
+
+### Cache capacity
+
+The documented 16-, 24-, and 32-slot settings will be compared on the same
+frozen prompt and generated workload. An Inkling-specific automatic default
+will be added only if it materially improves end-to-end decode on the 24 GB
+host without unacceptable memory pressure. Explicit user choices and the Mac
+app's existing setting remain authoritative.
+
+## Correctness
+
+A Metal parity test will cover the native top-6 full and hit/miss-split paths
+against the CPU routed-MoE reference. It must use six distinct expert blobs and
+non-zero weights so any missing, duplicated, or reordered slot changes output.
+Existing top-8 parity remains unchanged.
+
+The env-gated Inkling real-model regression will compare token output after the
+runtime integration. Final community A/B runs must have matching prompt and
+generated token counts, `stop=endOfTurn`, coherent output, and no non-finite
+logit error. Any cache-default claim additionally requires byte-identical
+generated output at the compared slot counts.
+
+## Measurement
+
+Build release once per source state. Run one discarded warmup and then one
+fresh-process measurement for each frozen community case, using temperature
+0.2, Top-K 64, Top-P 0.95, the frozen seed, 4K context, and up to 1,024 new
+tokens. Record commit, hardware/RAM, macOS, Swift, exact command, exit code,
+complete timing footer, output quality, and every protocol deviation.
+
+The optimization is successful only if the geometric-mean decode rate rises
+meaningfully across the matched cases. Kernel-only timing is diagnostic and
+will not be used as the headline result.
+


### PR DESCRIPTION
## Summary

Meaningfully accelerate Inkling-Small decode on Apple Silicon without changing model output:

- add a dedicated six-SIMD-group INT4 down/reduce Metal kernel for Inkling's native top-6 router
- specialize phase 1 for six experts and stop evaluating two padded zero-weight expert slots
- overlap resident-expert phase 1 with SSD reads for cache misses on mixed hit/miss layers
- add independent CPU-reference parity coverage for full and split top-6 execution
- publish the measured results and generic reproduction command in the README and model/benchmark documentation

The previous Inkling path padded six selected experts to the shared top-8 contract. That avoided extra I/O but still performed two unnecessary gate/up and down projections per routed layer, while resident GPU work waited behind miss reads.

## Validation

- `swift build -c release --product MferenceCLI`
- `Scripts/test.sh` — 906 tests in 145 suites passed in 80.366 seconds
- focused top-6 and top-8 Metal/CPU parity tests, including split hit/miss slot execution
- env-gated real Inkling generation regression passed against the installed model
- community benchmark protocol: one discarded warmup and one measured fresh process for each fixed short, medium, and long case
- every optimized benchmark stdout was byte-identical to its base counterpart; every process exited 0 with `stop=endOfTurn`
- Markdown links/anchors, diff whitespace, and private-path audits passed

Generic measured command:

```bash
.build/release/MferenceCLI \
  --model scratch/inklingsmall.gturbo \
  --messages-file docs/benchmark-prompts/real-generation-v1/<case>.json \
  --max-new 1024 --max-context 4096 \
  --temperature 0.2 --top-k 64 --top-p 0.95 --seed <seed>
```

## Memory and performance

Measured on a 24 GB M5 MacBook Pro, macOS 26.5, Swift 6.3.3, release builds, strict full-SHA verification, and the production automatic 16-slot cache. Base is `6bf428f`; optimized implementation is `485df08`.

| Case | Prompt / generated | Base decode | Optimized decode | Gain |
| --- | --- | ---: | ---: | ---: |
| short-explanation | 59 / 469 | 2.909 tok/s | 3.434 tok/s | 18.0% |
| medium-review | 421 / 576 | 2.961 tok/s | 3.670 tok/s | 23.9% |
| long-synthesis | 2,785 / 372 | 2.819 tok/s | 3.038 tok/s | 7.8% |

Geometric-mean decode gain: **16.4%**.

The optimization retains bounded streaming: common weights and the configured expert cache remain resident, while only routed cache misses are read into reserved cache buffers. It never stages the checkpoint or complete expert pool in Swift heap memory.

A 24-slot short control warmup was rejected. It produced identical output but fell to 0.710 tok/s while free-memory pressure reached 24%, versus 3.374 tok/s for the optimized 16-slot warmup. Because 24 slots already crossed the useful memory envelope, 32 slots were not attempted and Inkling's automatic default remains 16.

## Remaining limitations

- Inkling prefill still replays the stateful decode path token by token; this PR is scoped to decode.
- Larger Inkling cache profiles remain unsuitable for 24 GB hosts under the measured memory envelope.

- [x] The change does not load a complete checkpoint, shard, or large model tensor into Swift heap memory.
- [x] Logs and artifacts contain no credentials, private paths, or model weights.
