### PR TITLE
docs: bring README and docs current with the landed campaign and Maple

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ Mference currently runs five pinned instruction checkpoints:
   276B total, ~12B active per token, in ~9 GB of memory.
 - **[Maple Preview](https://huggingface.co/deepgrove/maple-preview-2bit-mlx)** —
   a 20B total, ~1B active per token, from the ternary (1.58 bit per parameter) quantization, using ~645 MiB
-  of memory.
+  of memory. Its chat template opens a live `<think>` reasoning block, so give
+  it a generous max-token allowance; an approximate FlashHead decode head is an
+  opt-in via `--flash-head`.
   
 The runtime, streaming installer, CLI, native Mac app, and loopback
 OpenAI-compatible server are written in Swift and Metal. Mference is
 model-specific rather than a wrapper around MLX or llama.cpp: each
 architecture is enumerated explicitly, with its own pinned checkpoint,
-compile-time baseline, and manifest contract.
+compile-time baseline, and manifest contract. New families merge through the
+[family acceptance gate](docs/FAMILY_GATE.md).
 
 ## Try it
 
@@ -111,12 +114,12 @@ swift run -c release MferenceCLI \
 | --- | --- |
 | Models | Gemma 4 26B-A4B IT (26B total, ~3.88B active) · Qwen 3.6 35B-A3B (35B total, ~3B active) · DeepSeek-V4-Flash 284B-A13B (experimental) · Inkling-Small 276B-A12B (276B total, ~12B active) · Maple Preview (20B total, ~1B active) |
 | Weights | MLX affine or ternary, group 64/128; INT8 or BF16 routers; 4-bit or 2-bit routed experts |
-| Memory | ~2 GB (Gemma 4) · ~1.45 GB at 16 slots (Qwen 3.6; larger-host CLI/server auto uses 32) · est. ~6.8 GB (DeepSeek-V4-Flash) · ~9 GB (Inkling-Small), including a 4K KV cache · 490.64 MiB (Maple, 128-token prompt) |
+| Memory | ~2 GB (Gemma 4) · ~1.45 GB at 16 slots (Qwen 3.6; CLI/server auto uses 96 slots on 24 GiB+ hosts, 32 on 16 GiB+) · est. ~6.8 GB (DeepSeek-V4-Flash) · ~9 GB (Inkling-Small), including a 4K KV cache · 490.64 MiB (Maple, 128-token prompt) |
 | Storage | ~14.3 GB installed (Gemma 4) · ~19.6 GB (Qwen 3.6) · ~91 GB (DeepSeek-V4-Flash) · ~148 GB (Inkling-Small) · ~6.6 GB (Maple) |
 | Hardware | Apple Silicon Mac; 8 GB of RAM |
 | Platform | macOS 15+, Metal 3 (MSL 3.2), Swift 6.1+; running on macOS 26 with an Apple10 GPU adds the Metal 4 tensor-ops prefill path |
 | Measured decode, Gemma 4 | 5.1–6.3 tok/s (8 GB M2 Air) · 31–35 tok/s (24 GB M5 Pro) |
-| Measured decode, Qwen 3.6 | 23.5–29.3 tok/s (24 GB M5, automatic 32-slot profile) |
+| Measured decode, Qwen 3.6 | 23.5–29.3 tok/s (24 GB M5, 32-slot profile; auto now selects 96 slots on that host) |
 | Measured decode, DeepSeek-V4-Flash | 5.3–6.1 tok/s (256 GB M3 Ultra) at a 5,671–5,679 MiB peak footprint |
 | Measured decode, Inkling-Small | 3.0–3.7 tok/s (24 GB M5, optimized native top-6 path) · 5.3–6.9 tok/s (256 GB M3 Ultra) at an 8,936–8,939 MiB peak footprint |
 | Measured, Maple Preview | Exact head: 18.9–24.6 tok/s decode, 25.1–44.9 tok/s prefill, and 491–1,211 MiB peak process footprint on 128-8192 context (16 GB M4) |
@@ -126,10 +129,11 @@ Qwen 3.6 numbers follow the frozen
 prompts and seeds, one discarded warmup, measured runs in fresh processes, and
 every run reaching a natural end of turn. The optimized short, medium, and long
 cases decode at 29.293, 27.460, and 23.470 tok/s. Their outputs are byte-identical
-to matching 16-slot controls, making the model-aware 32-slot default worth an
+to matching 16-slot controls, making the model-aware 32-slot rung worth an
 18.1% geometric-mean decode gain. Long-prompt prefill fell from 58.45 to 26.54
-seconds, a 2.20× speedup. Hosts below 16 GiB and the Mac app retain the 16-slot
-memory-first path. See [Benchmarks](docs/BENCHMARKS.md) and the
+seconds, a 2.20× speedup. With the GPU-resident slot map, auto has since moved
+24 GiB-class hosts to a 96-slot rung. Hosts below 16 GiB and the Mac app retain
+the 16-slot memory-first path. See [Benchmarks](docs/BENCHMARKS.md) and the
 [Qwen 3.6 performance notes](docs/QWEN36_PERFORMANCE.md) for exact commands,
 token counts, memory behavior, and rejected experiments.
 
@@ -182,10 +186,17 @@ runtime keeps the common weights mapped read-only, holds a small per-layer LFU
 expert cache, and `pread`s only the experts each layer's router selects for the
 current token. Inkling dispatches six experts; Gemma, Qwen, and Maple dispatch
 eight.
-The memory-first path uses 16 slots; CLI and server auto select 32 for Qwen on
-hosts with at least 16 GiB because its 256 experts per layer benefit measurably
-from the added coverage. Inkling remains at 16 because a 24-slot control
-warmup on the 24 GB M5 entered memory pressure and regressed sharply.
+The memory-first path uses 16 slots; CLI and server auto select larger rungs
+for Qwen — 96 slots on hosts with at least 24 GiB, 32 with at least 16 GiB —
+because its 256 experts per layer benefit measurably from the added coverage.
+Inkling remains at 16 because a 24-slot control warmup on the 24 GB M5 entered
+memory pressure and regressed sharply. Each layer's slots share one contiguous
+wired buffer, and on Qwen a GPU-resident expert-to-slot map lets layers whose
+eight experts are all cached run their routed branch without a CPU round-trip;
+the routed command buffer also commits eagerly, gated on a shared event that
+fires as expert fills land. An explicit `resident` mode that maps every layer
+file once exists as an opt-in, but it measured slower than the slot rungs under
+page-cache pressure.
 
 Qwen 3.6's linear-attention layers replace KV storage entirely: each keeps a
 2 MiB delta-rule state and a 3-row convolution tail, updated in place every

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ because its 256 experts per layer benefit measurably from the added coverage.
 Inkling remains at 16 because a 24-slot control warmup on the 24 GB M5 entered
 memory pressure and regressed sharply. Each layer's slots share one contiguous
 wired buffer, and on Qwen a GPU-resident expert-to-slot map lets layers whose
-eight experts are all cached run their routed branch without a CPU round-trip;
+eight experts are all cached run their routed branch from pre-encoded,
+GPU-guarded commands, with no CPU expert planning or fetching;
 the routed command buffer also commits eagerly, gated on a shared event that
 fires as expert fills land. An explicit `resident` mode that maps every layer
 file once exists as an opt-in, but it measured slower than the slot rungs under

--- a/Sources/MferenceCLI/Args.swift
+++ b/Sources/MferenceCLI/Args.swift
@@ -10,8 +10,9 @@ public enum PrefillChunkChoice: Equatable, Sendable {
 }
 
 /// Routed-expert cache selection. Auto keeps the 16-slot memory-first default
-/// for every family except Qwen 3.6 on hosts with at least 16 GiB, whose 256
-/// experts per layer measurably benefit from 32 slots.
+/// for every family except Qwen 3.6, whose 256 experts per layer measurably
+/// benefit from larger rungs: 96 slots on hosts with at least 24 GiB,
+/// 32 with at least 16 GiB.
 public enum ExpertCacheSlotChoice: Equatable, Sendable {
     case fixed(Int)
     case resident

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -16,9 +16,9 @@ Decode rate excludes model installation, model loading, and prompt prefill.
 | 8 GB M2, Mference | 5.10-6.30 tok/s | ~1.9-2.1 GB footprint |
 | 24 GB M5 Pro, Mference | 31-35 tok/s | ~2.1 GB footprint |
 | 24 GB M5 Pro, mlx-lm | 76.33-82.07 tok/s | 8.3-9.8 GB RSS; 14.7-15.3 GB GPU allocation |
-| M5, Mference, Qwen 3.6 35B-A3B | 23.5-29.3 tok/s | 32-slot Qwen auto profile |
+| M5, Mference, Qwen 3.6 35B-A3B | 23.5-29.3 tok/s | 32-slot Qwen profile (auto as of 2026-08-06) |
 
-A separate report covers all four model families on a 256 GB M3 Ultra,
+A separate report covers the four pre-Maple model families on a 256 GB M3 Ultra,
 including the first measured DeepSeek-V4-Flash and Inkling-Small rows:
 [M3 Ultra benchmarks](BENCHMARKS_M3_ULTRA.md).
 
@@ -79,7 +79,7 @@ loop.
 
 ## Qwen 3.6 35B-A3B measured decode
 
-The current optimized production run was recorded on 2026-08-06 on an M5
+This optimized production run was recorded on 2026-08-06 on an M5
 MacBook Pro (`Mac17,2`) with 24 GB, macOS 26.5, and Swift 6.3.3. The CLI's
 automatic profile selected 32 Qwen expert-cache slots; no experimental flag or
 profiler was active. One discarded warmup preceded one fresh-process measured
@@ -97,6 +97,13 @@ model-aware default, on top of the custom Qwen decode kernels. Long-prompt
 prefill is 2.20x faster than the original 58.45 s baseline. The original and
 current generated token counts differ, so only the same-output controls are
 used for the decode speedup claim.
+
+Since this run, the 2026-08 performance campaign (PR #16, merged 2026-08-13)
+changed the Qwen production defaults: the automatic profile now selects 96
+expert-cache slots on hosts with at least 24 GiB (32 with at least 16 GiB,
+else 16), with the GPU-resident slot map and eager routed commit on by
+default. The rows above therefore describe the 2026-08-06 32-slot automatic
+profile, not a current checkout.
 
 ### Historical 16-slot run
 

--- a/docs/BENCHMARKS_M3_ULTRA.md
+++ b/docs/BENCHMARKS_M3_ULTRA.md
@@ -1,8 +1,8 @@
 # Mference benchmark results — Mac Studio M3 Ultra, 256 GB
 
-All four supported model families installed, hash-verified, and benchmarked
-under the frozen community protocol. Every measured run reached a natural end
-of turn (36/36).
+All four model families supported at the time (Maple landed later) installed,
+hash-verified, and benchmarked under the frozen community protocol. Every
+measured run reached a natural end of turn (36/36).
 
 ## Host
 
@@ -43,9 +43,9 @@ pass.
 The frozen community protocol ([COMMUNITY_BENCHMARKS.md](COMMUNITY_BENCHMARKS.md)): the three
 `real-generation-v1` prompts with fixed seeds (20260721 / 20260722 / 20260723),
 temperature 0.2, Top-K 64, Top-P 0.95, 4,096-token context, up to 1,024
-generated tokens, production runtime defaults (16 expert-cache slots, prefill
-on, RDADVISE off), one discarded warmup per case, each measured run in a fresh
-process with no other model process running.
+generated tokens, the runtime defaults at the measured commit (16 expert-cache
+slots, prefill on, RDADVISE off), one discarded warmup per case, each measured
+run in a fresh process with no other model process running.
 
 Stated deviation: **three** measured repetitions per case instead of one, so
 medians and run-to-run spread can be reported. Generated token counts were
@@ -154,8 +154,9 @@ requires ~60% of expert reads served from RAM. Here the entire 90 GB expert
 pool fits in page cache after warmup (`vm_stat` showed ~139 GB of cached pages
 during the runs), so the ~2.03 GB/token of expert reads is served from memory.
 Throughput still sits below the document's ~8–12 tok/s GPU-compute ceiling
-estimate, consistent with the roadmap item that expert I/O is not yet
-overlapped with GPU work.
+estimate, consistent with the then-open roadmap item that expert I/O was not
+yet overlapped with GPU work (the DSV4 shadow speculative prefetch has since
+landed as that family's default).
 
 ### Inkling-Small — beats its estimate
 
@@ -230,7 +231,7 @@ configuration that can keep their expert pools resident.
 
 ```bash
 swift build -c release
-.build/release/MferenceRepack --model <gemma4|qwen36|deepseekv4flash|inklingsmall> \
+.build/release/MferenceRepack --model <gemma4|qwen36|deepseekv4flash|inklingsmall|maple> \
   --output scratch/<name>.gturbo
 .build/release/MferenceRepack --verify-install --input-gturbo scratch/<name>.gturbo
 ./run-benchmark.sh <label> scratch/<name>.gturbo 3

--- a/docs/DEEPSEEK_V4_FLASH.md
+++ b/docs/DEEPSEEK_V4_FLASH.md
@@ -97,8 +97,9 @@ Streamed experts: one expert blob = 25.17M params at 2-bit ≈ **7.87 MB**
 of expert reads per token** at 0% cache hit.
 
 Expert-slot memory and the throughput ladder (per-layer slot pools, like
-Gemma/Qwen; the runtime's allowed slot counts are 8/16/24/32, and top-6
-routing needs at least 6 in-flight blobs per layer):
+Gemma/Qwen; the runtime's allowed slot counts are now 8/16/24/32/64/96/128
+plus an explicit `resident` mode, and top-6 routing needs at least 6
+in-flight blobs per layer):
 
 | Slots/layer | Slot RAM | Peak footprint | Expected decode |
 | ---: | ---: | ---: | --- |
@@ -167,9 +168,12 @@ global `expertStride` — plus ~4 GB resident file).
   structure; CSA layers add an indexer-score readback only once the
   compressed count exceeds `index_topk` (context > 2048), i.e. never at the
   default 4K context's first half.
-- Prefill v1 runs the decode path token-by-token (the Qwen port's
+- Prefill v1 ran the decode path token-by-token (the Qwen port's
   chunked-prefill ≡ sequential-decode guarantee is the correctness
-  contract; the chunked implementation is follow-up work).
+  contract). The chunked implementation has since landed
+  (`DSV4ChunkedPrefill`): a span's eligible prefix is batched, and only
+  the remainder past the lightning-selection cutover replays
+  token-by-token.
 
 ## First-install verification record
 
@@ -225,7 +229,8 @@ The first slice of that overlap work shipped: the pilot lookahead router
 (layer L+1's routing computed from layer L's state) now feeds an
 asynchronous prefetcher that joins the critical path only when a predicted
 expert is actually routed, reads at user-initiated I/O priority, and issues
-at most two weight-ranked predictions per layer. Output is byte-identical;
+at most two weight-ranked predictions per layer (`MFERENCE_SHADOW_BUDGET`
+overrides the budget). Output is byte-identical;
 the mode is the DSV4 production default (`MFERENCE_SPEC_PREFETCH` still
 overrides). Community-protocol A/B on the two naturally-terminating cases,
 16 slots + adaptive:

--- a/docs/IMPLEMENTATION_REFERENCES.md
+++ b/docs/IMPLEMENTATION_REFERENCES.md
@@ -1,11 +1,13 @@
 # Implementation references
 
 Mference builds on work by other developers and researchers. These are
-the sources that materially shaped its Gemma 4 implementation, Metal kernels,
-out-of-core runtime, and experiments under the 8 GB memory constraint.
+the sources that materially shaped its Gemma 4 and Maple implementations,
+Metal kernels, out-of-core runtime, and experiments under the 8 GB memory
+constraint.
 
-Upstream code references whose exact behavior mattered are pinned to commits
-checked on 2026-07-16. Project home pages remain branch-level when they are
+Upstream code references whose exact behavior mattered are pinned to the
+commits checked when each reference was adopted (the original Gemma 4 set on
+2026-07-16). Project home pages remain branch-level when they are
 included for broader design context rather than a line-level claim.
 
 ## Model and weights

--- a/docs/INKLING_SMALL.md
+++ b/docs/INKLING_SMALL.md
@@ -57,9 +57,12 @@ BF16 router too, so whatever the repacker does there already applies.
 The 3-bit and mixed-2-bit builds are genuinely attractive on decode bandwidth
 (see below), and the 3-bit build in particular protects the every-token path.
 Both are rejected for the same structural reason rather than a quality one:
-they leave attention and embeddings in **BF16**, and Mference has no resident
-BF16 matmul path — the attention slot is required to be INT4 and every decode
-GEMV is an INT4 or INT8 kernel. Adopting either means adding a BF16 weight path
+they leave attention and embeddings in **BF16**, and Mference's shared
+streamed-expert engine has no resident BF16 matmul path — the attention slot
+is required to be INT4 and every decode GEMV is an INT4 or INT8 kernel. (The
+later Maple family's self-contained runner carries its own ternary and BF16
+paths, but they do not extend to this engine.) Adopting either means adding
+a BF16 weight path
 *and* (for 3-bit) an INT3 unpack kernel whose weights straddle `u32` word
 boundaries (3 does not divide 32). That is a second project layered on top of
 an already large one.

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -212,11 +212,10 @@ Chat Completions supports JSON and Server-Sent Events responses. Set
 
 Requests may contain system, developer, user, assistant, and tool messages.
 Guidance must precede the conversation, and consecutive messages of the same
-guidance role are merged into one block separated by a blank line. Qwen's chat
-template has no `developer` role, so with a Qwen model loaded a `developer`
-message is treated as a `system` message — it merges with adjacent system
-guidance instead of rendering as its own block. Gemma keeps the two roles
-distinct.
+guidance role are merged into one block separated by a blank line. Only
+Gemma's chat template has a distinct `developer` role; with any other family
+loaded a `developer` message is treated as a `system` message — it merges
+with adjacent system guidance instead of rendering as its own block.
 Supported options include `temperature`, `top_p`, `top_k`,
 `repetition_penalty`, `seed`, `stop`, `max_tokens`,
 `max_completion_tokens`, and function-tool fields.
@@ -225,7 +224,14 @@ The server supports one model and one choice. It does not support the Responses
 API, legacy Completions, embeddings, multimodal input, structured output,
 batching, log probabilities, or remote model switching.
 
+Maple's chat template opens a live `<think>` reasoning block at the start of
+every completion. The server suppresses the reasoning text from the response,
+but those tokens still count as completion tokens, so give Maple requests a
+generous allowance — around 2048 `max_completion_tokens` (when neither cap is
+set the server uses 4096) — or the reasoning budget swallows the visible
+answer and the request finishes with `finish_reason` `"length"`.
+
 Context length can be 4K, 8K, 16K, 32K, 64K, or 128000 tokens; the default is
 16K. Maple supports 128000 tokens in the server and uses native BF16 KV with
-sequential prefill; existing families use FP16 KV. On an 8 GB Mac, run one
-model process at a time and watch memory pressure.
+layer-major chunked prefill; existing families use FP16 KV. On an 8 GB Mac,
+run one model process at a time and watch memory pressure.

--- a/docs/OPTIMIZATION_JOURNEY.md
+++ b/docs/OPTIMIZATION_JOURNEY.md
@@ -120,6 +120,9 @@ stopped speculative cross-layer prefetch before it reached the runtime.
 
 Past routing decisions identified weights worth keeping. The tested signal
 could not identify the next layer's weights early enough to prefetch them.
+A later DeepSeek-V4-Flash predictor that runs the next layer's router against
+the current token's state did pay off, and its shadow prefetch is now that
+family's default. The Gemma cross-layer signal stayed rejected.
 
 The always-resident shared MLP offered a safer way to hide read time. The GPU
 can execute it while the CPU fills routed-expert misses. In a later paired

--- a/docs/QWEN36_PERFORMANCE.md
+++ b/docs/QWEN36_PERFORMANCE.md
@@ -14,11 +14,12 @@ sensitive to OS page-cache state; see [Warming the page cache backfires]
 
 ## Production acceleration (2026-08-06)
 
-The production CLI and server now resolve their expert-cache default by model
-family and physical memory: Qwen uses 32 slots per layer on hosts with at least
-16 GiB and 16 slots on smaller hosts. An explicit `--expert-cache-slots 16`
-keeps the lower-memory path. The Mac app retains its explicit 16-slot setting
-and offers 32 in the inspector.
+The production CLI and server resolve their expert-cache default by model
+family and physical memory; at this record's date Qwen used 32 slots per layer
+on hosts with at least 16 GiB and 16 slots on smaller hosts (the ≥24 GiB rung
+has since moved to 96 slots — see round 3 below). An explicit
+`--expert-cache-slots 16` keeps the lower-memory path. The Mac app keeps 16 as
+its explicit default and offers every allowed slot count in the inspector.
 
 On the M5/24 GB host, the exact community protocol at commit `3d6996b` produced:
 
@@ -115,6 +116,13 @@ That is inherent to the streaming design — a layer's routed experts cannot be
 read until that layer's router has run, and the next layer cannot start until
 this layer's MoE has finished.
 
+The table is the July 16-slot record; the 2026-08-08 defaults relaxed the
+serialization — on all-hit layers the GPU slot map skips the CPU plan
+entirely, and on miss layers the eager routed commit runs the preads in the
+background (see round 3 below). The phase report now also splits the I/O
+await into GPU-overlapped and exposed time, and prints the all-hit
+layer-step rate, GPU busy/span/gap, and the speculative-prefetch counters.
+
 Per token the runtime touches about 1.6 GB of weights, of which roughly
 540 MiB is routed-expert data (40 layers x 8 experts x 1.69 MiB).
 
@@ -132,9 +140,11 @@ Each of these was measured before being ruled out.
   0.25 ms/token difference — not worth restructuring for.
 - **Expert cache policy.** The July workload moved from 19.0 to 19.8 tok/s when
   raising slots from 16 to 32, but the frozen August same-output cases gained
-  9.2–36.3%. LFU remains the replacement policy and slot counts above 32 are
-  not offered. Auto uses 32 only for Qwen on hosts with at least 16 GiB; the
-  8 GB path and every other family retain 16.
+  9.2–36.3%. LFU remains the replacement policy. Slot counts above 32 were not
+  offered at the time of this record; the allowed set has since grown to
+  8/16/24/32/64/96/128 plus an explicit `resident` mode, and auto now gives
+  Qwen 96 slots on hosts with at least 24 GiB and 32 at 16 GiB; the 8 GB path
+  and every other family retain 16.
 - **RDADVISE read-ahead.** `--rdadvise default` cut the I/O await from 3474 to
   2931 ms, but the synchronous advice calls cost what the reads saved; total
   decode was unchanged (19.3 vs 19.3 tok/s). It stays off by default.
@@ -210,8 +220,9 @@ MFERENCE_PHASES=1 .build/release/MferenceCLI \
   --max-new 128 --temperature 0
 ```
 
-`--expert-cache-slots` (8, 16, 24, 32) and `--rdadvise`
-(off, default, bounded, adaptive) vary the two policies discussed above.
+`--expert-cache-slots` (8, 16, 24, 32, 64, 96, 128, `resident`, or `auto`)
+and `--rdadvise` (off, default, bounded, adaptive) vary the two policies
+discussed above.
 
 ## Production acceleration round 2 (2026-08-08)
 
@@ -219,7 +230,8 @@ Two accepted defaults on the 24 GB M5, both byte-identical to their
 controls under the community protocol:
 
 - **64 expert-cache slots** on hosts with ≥24 GiB (16 GiB hosts keep 32):
-  +4.6–5.9% decode across all three cases.
+  +4.6–5.9% decode across all three cases. The auto rung has since moved
+  to 96 — see round 3 below.
 - **GPU-resident slot map** (`MFERENCE_SLOT_MAP=0` to disable): the router
   top-k is resolved to slot-slab offsets on-GPU, and the ~30% of
   layer-steps whose experts are all cached complete their routed FFN
@@ -232,3 +244,29 @@ Community-protocol medians moved from 29.29 / 27.46 / 23.47 tok/s
 decode gain with unchanged outputs. mlx-lm cannot load this model on the
 same host (see
 [experiments/summaries/11](experiments/summaries/11-mlx-qwen-baseline.md)).
+
+## Production acceleration round 3 (2026-08-08)
+
+Two further accepted defaults, byte-identical to their controls:
+
+- **96 expert-cache slots** as the auto rung on hosts with ≥24 GiB (16 GiB
+  hosts keep 32, smaller hosts 16). The slot map changed the slot-count
+  economics: at 96 slots the all-hit layer rate doubles to 50.7% (from
+  29.9% at 64), and the pre-slot-map 96-slot regression no longer
+  reproduces.
+- **Eager routed commit** (`MFERENCE_EAGER_ROUTED=0` to disable): the
+  routed command buffer is encoded against the plan's slot-slab views,
+  committed gated on a shared fill event, and the preads run in the
+  background — the fetch leaves the CPU critical path, and the phase
+  report's `expert io await` reads near zero. +1.5–3.3% median by case on
+  top of the round-2 state. A failed eager expert read aborts the decode
+  step with `ModelError.eagerExpertFillFailed` instead of letting a
+  partially filled slot corrupt output.
+
+Community-protocol medians moved to **34.85 / 33.97 / 28.27 tok/s**. An
+explicit `--expert-cache-slots resident` mode (map every layer file once,
+no slot cache) also exists but lost the community A/B on this 24 GB host
+on every case (short −2%, long −56% from page-cache thrash), so auto
+always uses the slot cache and resident stays opt-in. Details:
+[experiments/summaries/15](experiments/summaries/15-gpu-slot-map.md) and
+[10](experiments/summaries/10-qwen-resident-rung.md).

--- a/docs/RUNTIME_CONTROLS.md
+++ b/docs/RUNTIME_CONTROLS.md
@@ -67,7 +67,7 @@ benchmark protocol.
 
 | Control | Values | CLI flag | Production default | Effect |
 | --- | --- | --- | --- | --- |
-| Expert-cache slots | 8, 16, 24, 32; CLI also accepts auto | `--expert-cache-slots` | App: 16; CLI/server auto | Auto selects 32 for Qwen on hosts with at least 16 GiB and 16 otherwise. Other families stay at 16. More slots retain more routed experts and reduce later reads at the cost of RAM. |
+| Expert-cache slots | 8, 16, 24, 32, 64, 96, 128; CLI also accepts resident and auto | `--expert-cache-slots` | App: 16; CLI/server auto | Auto always uses the slot cache: Qwen gets 96 slots on hosts with at least 24 GiB, 32 with at least 16 GiB, and 16 otherwise; other families get 16. `resident` maps every layer file once and skips the slot cache entirely — it lost the community A/B to the slot rungs (page-cache thrash), so it remains an explicit opt-in. More slots retain more routed experts and reduce later reads at the cost of RAM. |
 | Prompt prefill | On, off | — | On | On requests the family prefill path. Maple uses a native-BF16 chunked path that preserves token-ordered K/V commits and attention; other families use their own supported paths. Off selects correctness-first scalar replay rather than skipping prompt processing. |
 | RDADVISE | Off, Default, Bounded, Adaptive | `--rdadvise` | Off | Applies experimental read advice. Its effect depends on the workload; it may help a short decode and slow a long one. |
 | Prefill chunk tokens | 32, 64, 128, 256, 512, 1024, 2048, 4096, or auto | `--prefill-chunk` | Auto (one-shot); 128 (`--chat`) | Tokens processed per prefill chunk. Larger chunks re-read the routed experts fewer times, which lowers prefill I/O and time. `auto` picks the smallest allowed size that covers a one-shot prompt; interactive `--chat` resolves auto to 128 for its growing conversation. Maple stages each chunk layer-major but preserves its fixed 512-slot sliding-cache semantics by committing and attending rows in time order. |
@@ -76,14 +76,29 @@ benchmark protocol.
 
 The prefill chunk size and FlashHead switch are CLI controls; the Mac app uses the default exact head. The Mac
 app also keeps its explicit 16-slot default so an existing memory preference is
-never silently enlarged; Qwen users on larger Macs can select 32 in the
-inspector.
+never silently enlarged; Qwen users on larger Macs can select a larger rung in
+the inspector.
 The CLI applies these settings when it loads the model, so each run uses the
 values passed on its command line. Setting `MFERENCE_PHASES=1` makes the
-CLI print the decode phase split (`cb1`, expert I/O await, `cb2`, and GPU
-waits) after the timing footer; `MFERENCE_PREFILL_BREAKDOWN=1` prints the
+CLI print the decode phase report after the timing footer: `cb1` and `cb2`
+encode-and-commit time, expert I/O await split into GPU-overlapped and exposed
+time, the all-hit layer-step rate, GPU busy/span/gap, speculative-prefetch
+counters, and unaccounted GPU waits. `MFERENCE_PREFILL_BREAKDOWN=1` prints the
 Inkling prefill routed-expert split (fetch, encode, drain). Both are
 diagnostics and do not change behavior.
+
+The accepted decode defaults carry environment kill-switches for A/B runs.
+`MFERENCE_SLOT_MAP=0` disables the GPU-resident expert-to-slot map that lets
+Qwen layers whose eight experts are all cached skip the CPU round-trip
+(default on). `MFERENCE_EAGER_ROUTED=0` disables the eager routed commit,
+which commits the routed command buffer before its expert fills land, gated on
+a shared event; a failed eager fill aborts the decode step with an error
+rather than emitting corrupt output (default on). `MFERENCE_ROUTER_EVENT=0`
+disables the early mid-buffer router readback. `MFERENCE_SPEC_PREFETCH`
+selects the speculative-prefetch mode — shadow prefetch is the accepted
+DeepSeek-V4-Flash default, off elsewhere — and `MFERENCE_SHADOW_BUDGET` caps
+its per-layer speculative reads. All are byte-identical toggles, not quality
+controls.
 
 Changing context length, expert-cache slots, RDADVISE, model verification,
 prompt-prefill enablement, the prefill chunk size, or FlashHead selection

--- a/docs/RUNTIME_CONTROLS.md
+++ b/docs/RUNTIME_CONTROLS.md
@@ -89,8 +89,9 @@ diagnostics and do not change behavior.
 
 The accepted decode defaults carry environment kill-switches for A/B runs.
 `MFERENCE_SLOT_MAP=0` disables the GPU-resident expert-to-slot map that lets
-Qwen layers whose eight experts are all cached skip the CPU round-trip
-(default on). `MFERENCE_EAGER_ROUTED=0` disables the eager routed commit,
+Qwen layers whose eight experts are all cached skip CPU expert planning,
+fetching, and routed-command encoding — the router readback itself remains on
+the CPU (default on). `MFERENCE_EAGER_ROUTED=0` disables the eager routed commit,
 which commits the routed command buffer before its expert fills land, gated on
 a shared event; a failed eager fill aborts the decode step with an error
 rather than emitting corrupt output (default on). `MFERENCE_ROUTER_EVENT=0`

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -345,8 +345,10 @@ makes the layer tail wait for both the shared and routed branches.
 Three accepted decode defaults tighten this handoff further. For Qwen, the
 GPU-resident slot map (`router_slot_lookup_k8`) resolves the router's top-8
 IDs against the per-layer expert-to-slot table on the GPU; a layer whose
-selected experts are all cached completes its routed branch entirely on-GPU
-and skips the CPU round-trip (`MFERENCE_SLOT_MAP=0` disables). The eager
+selected experts are all cached runs its routed branch from pre-encoded,
+GPU-guarded commands, skipping CPU expert planning, fetching, and
+routed-command encoding — the router readback and LFU bookkeeping remain on
+the CPU every layer (`MFERENCE_SLOT_MAP=0` disables). The eager
 routed commit submits the routed command buffer before its expert fills land,
 gated on an `MTLSharedEvent` the fill completions signal
 (`MFERENCE_EAGER_ROUTED=0` disables); a failed eager fill aborts the decode

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -1,7 +1,8 @@
 # System design
 
-Mference is a Swift and Metal runtime for Gemma 4 26B-A4B on Apple
-Silicon. The text-only installation is about 14.3 GB, but the target machine
+Mference is a Swift and Metal runtime for pinned MoE checkpoints on Apple
+Silicon; Gemma 4 26B-A4B is the founding family and this document's running
+example. Its text-only installation is about 14.3 GB, but the target machine
 has 8 GB of memory. The runtime keeps the common weights and working state
 available to Metal. It stores routed experts in per-layer files and reads only
 the experts chosen for the current token or prefill chunk.
@@ -155,7 +156,7 @@ Streamed expert resources:
 
 | Resource | Current size or capacity | Ownership and behavior |
 | --- | ---: | --- |
-| Routed-expert slots | 16 per opened layer; one page-rounded 3,358,720-byte blob per slot | App-owned buffers allocated with 2 MiB alignment and wrapped by Metal without another copy. Opening all 30 layer streamers reserves about 1.50 GiB of slot capacity; pages become resident as reads fill them. |
+| Routed-expert slots | 16 per opened layer; one page-rounded 3,358,720-byte blob per slot | App-owned. All of a layer's slots live in one contiguous 2 MiB-aligned allocation wrapped by a single Metal buffer; consumers address slots as (buffer, offset, length) slices. Opening all 30 layer streamers reserves about 1.50 GiB of slot capacity; pages become resident as reads fill them. |
 | Routed-expert files | 12,897,484,800 bytes (12.01 GiB) on disk | Thirty per-layer files. Only selected blobs enter explicit slots; the files are not mapped as one resident pool. |
 | macOS unified file cache | Dynamic | OS-owned second-chance cache. It may make a `pread` cheap, but it is not a guaranteed part of the app budget. |
 
@@ -170,9 +171,13 @@ The loader maps `model_weights.bin` read-only and wraps its aligned regions in
 `MTLBuffer` objects without copying them into Swift collections.
 
 Routed-expert files open lazily. Each opened layer owns one file descriptor and
-a fixed group of slot buffers with 2 MiB alignment. Each slot is allocated
-once, registered with Metal through `makeBuffer(bytesNoCopy:)`, filled with
-`pread`, and reused until the layer streamer is released.
+one contiguous 2 MiB-aligned slot slab holding all of its slots, registered
+with Metal once through `makeBuffer(bytesNoCopy:)`. Slot `n` is the fixed
+offset `n × slot-stride` within the slab; each slot is filled with `pread` and
+reused until the layer streamer is released. The layer also keeps a small
+GPU-visible expert-to-slot table (`Int16` per expert, −1 for absent), mirrored
+on every cache mutation, so a lookup kernel can resolve routed experts to slab
+offsets without the CPU.
 
 The expert cache records which expert occupies each slot. Production uses
 least-frequently used (LFU) eviction with recency as the tie-breaker. A hit
@@ -337,6 +342,21 @@ Routed work for cache hits may start while reads for missing experts are still
 running. Work for a cache miss starts after its slot is filled. Queue order
 makes the layer tail wait for both the shared and routed branches.
 
+Three accepted decode defaults tighten this handoff further. For Qwen, the
+GPU-resident slot map (`router_slot_lookup_k8`) resolves the router's top-8
+IDs against the per-layer expert-to-slot table on the GPU; a layer whose
+selected experts are all cached completes its routed branch entirely on-GPU
+and skips the CPU round-trip (`MFERENCE_SLOT_MAP=0` disables). The eager
+routed commit submits the routed command buffer before its expert fills land,
+gated on an `MTLSharedEvent` the fill completions signal
+(`MFERENCE_EAGER_ROUTED=0` disables); a failed eager fill aborts the decode
+step with `ModelError.eagerExpertFillFailed` rather than emitting corrupt
+output. For DeepSeek-V4-Flash, shadow speculative prefetch issues a bounded
+number of non-blocking reads per layer from a router-lookahead prediction
+(`MFERENCE_SPEC_PREFETCH` selects the mode, `MFERENCE_SHADOW_BUDGET` caps the
+reads); other families keep speculation off. All three are byte-identical to
+their disabled paths.
+
 After layer 30, the tied 4-bit head has two output modes. A pure-greedy
 configuration (temperature `0` and repetition penalty `1`) returns the argmax
 token directly. Other configurations write the full logits vector for the
@@ -449,7 +469,8 @@ runtime, CLI, and server accept up to 128,000 tokens, but no final acceptance
 run establishes that boundary. Vision input, training, fine-tuning, server
 batching, and generic model discovery are outside the current scope. Each of
 the five architectures is explicitly enumerated with its own pinned checkpoint,
-compile-time baseline, and manifest contract. The optional HTTP server owns one
+compile-time baseline, and manifest contract; a new family merges only after
+passing the [family acceptance gate](FAMILY_GATE.md). The optional HTTP server owns one
 warm model, serializes generation, and retains one verified conversational KV
 prefix by default. It binds to loopback unless the user explicitly selects the
 machine's exact Tailnet address. See the [local server guide](OPENAI_SERVER.md).
@@ -460,8 +481,11 @@ paths; Maple uses native BF16 KV and layer-major chunked prefill with a
 token-ordered cache/attention sweep. Its exact full head remains the default;
 the CLI can explicitly select the approximate singleton-decode FlashHead when
 the installed model contains its validated centroid/map data. The memory-first
-expert cache has 16 slots per layer, with model-aware alternatives where
-documented. File-read advice (`RDADVISE`) is off by default.
+expert cache defaults to 16 slots per layer; the allowed rungs are 8, 16, 24,
+32, 64, 96, and 128, plus an explicit `resident` opt-in, and the CLI/server
+auto profile always uses the slot cache — 96 slots for Qwen on hosts with at
+least 24 GiB, 32 on at least 16 GiB, and 16 everywhere else. File-read advice
+(`RDADVISE`) is off by default.
 
 ## Read next
 

--- a/docs/experiments/EXPERIMENT_INVENTORY.md
+++ b/docs/experiments/EXPERIMENT_INVENTORY.md
@@ -57,6 +57,18 @@ resident set size; and **NLL** is negative log-likelihood. See
 | Validation methodology | [False rejections, holdouts, thermal state, and benchmark artifacts](summaries/09-validation-and-measurement-lessons.md) | 9 |
 | **Total** | | **103** |
 
+The 2026-08 Qwen/DSV4 performance campaign is recorded in narrative
+summaries rather than tabled entries:
+[Qwen resident rung](summaries/10-qwen-resident-rung.md),
+[mlx-lm Qwen baseline attempt](summaries/11-mlx-qwen-baseline.md),
+[decode attribution](summaries/12-decode-attribution-qwen-dsv4.md),
+[DSV4 streaming iterations](summaries/13-dsv4-streaming-iterations.md),
+[DSV4 shadow prefetch](summaries/14-dsv4-shadow-prefetch.md), and the
+[GPU-resident slot map](summaries/15-gpu-slot-map.md). The campaign landed
+on main via PR #16 (merge `e030f4e`, 2026-08-13), alongside the Maple
+family from PR #15. The 103 tabled entries below are the original Gemma 4
+program.
+
 ## All 103 experiments
 
 ### Model installation and expert I/O


### PR DESCRIPTION
Post-landing documentation sweep: every current-state claim in README and docs/ re-verified against the code after PR #16 (performance campaign) and PR #15 (Maple).

- Slot ladder 8–128 + `resident` documented everywhere; `auto` described as it is implemented (Qwen 96 at ≥24 GiB / 32 at ≥16 GiB / else 16; always the slot cache — resident is an explicit opt-in that lost the community A/B).
- GPU-resident slot map, eager routed commit (including the new fill-failure abort), and DSV4 shadow prefetch documented as defaults with their env kill-switches; `MFERENCE_PHASES=1` report contents updated.
- SYSTEM_DESIGN describes the slot-slab (one wired buffer per layer, offset-addressed slices) and the GPU expert-to-slot table.
- Maple covered where families are enumerated: think-block token allowance (server default cap 4096), `--flash-head` opt-in, layer-major chunked BF16 prefill; developer-role mapping corrected to Gemma-only.
- QWEN36_PERFORMANCE gains the round-3 record (96-slot rung, eager routed commit, 34.85/33.97/28.27 medians, sourced from experiments summaries 15 and 10); historical records reframed as dated snapshots with all measured numbers untouched.
- Experiment inventory indexes campaign summaries 10–15 and the landing; one stale doc comment in Args.swift fixed to the implemented auto rule.

No behavior changes (one source comment only). Link checker passes: 40 files, all local links and anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)