### PR TITLE
feat: Qwen 3.8 27B dense family — MTP speculative decode, 2.35× mlx

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Mference currently runs five pinned instruction checkpoints:
   of memory. Its chat template opens a live `<think>` reasoning block, so give
   it a generous max-token allowance; an approximate FlashHead decode head is an
   opt-in via `--flash-head`.
+- **[Qwen 3.8 27B](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit)** —
+  the first dense family: 27B parameters, all active, text-only port of the
+  multimodal checkpoint, fully resident in ~15 GB (24 GB Macs). Ships MTP
+  speculative decoding with byte-identical greedy output — 15.0 tok/s decode
+  on a 24 GB M5 (2.35× mlx-vlm on the same checkpoint). Its chat template
+  also opens a live `<think>` block.
   
 The runtime, streaming installer, CLI, native Mac app, and loopback
 OpenAI-compatible server are written in Swift and Metal. Mference is
@@ -112,7 +118,7 @@ swift run -c release MferenceCLI \
 
 | Metric | Value |
 | --- | --- |
-| Models | Gemma 4 26B-A4B IT (26B total, ~3.88B active) · Qwen 3.6 35B-A3B (35B total, ~3B active) · DeepSeek-V4-Flash 284B-A13B (experimental) · Inkling-Small 276B-A12B (276B total, ~12B active) · Maple Preview (20B total, ~1B active) |
+| Models | Gemma 4 26B-A4B IT (26B total, ~3.88B active) · Qwen 3.6 35B-A3B (35B total, ~3B active) · DeepSeek-V4-Flash 284B-A13B (experimental) · Inkling-Small 276B-A12B (276B total, ~12B active) · Maple Preview (20B total, ~1B active) · Qwen 3.8 27B (dense, MTP speculative decode) |
 | Weights | MLX affine or ternary, group 64/128; INT8 or BF16 routers; 4-bit or 2-bit routed experts |
 | Memory | ~2 GB (Gemma 4) · ~1.45 GB at 16 slots (Qwen 3.6; CLI/server auto uses 96 slots on 24 GiB+ hosts, 32 on 16 GiB+) · est. ~6.8 GB (DeepSeek-V4-Flash) · ~9 GB (Inkling-Small), including a 4K KV cache · 490.64 MiB (Maple, 128-token prompt) |
 | Storage | ~14.3 GB installed (Gemma 4) · ~19.6 GB (Qwen 3.6) · ~91 GB (DeepSeek-V4-Flash) · ~148 GB (Inkling-Small) · ~6.6 GB (Maple) |
@@ -123,6 +129,7 @@ swift run -c release MferenceCLI \
 | Measured decode, DeepSeek-V4-Flash | 5.3–6.1 tok/s (256 GB M3 Ultra) at a 5,671–5,679 MiB peak footprint |
 | Measured decode, Inkling-Small | 3.0–3.7 tok/s (24 GB M5, optimized native top-6 path) · 5.3–6.9 tok/s (256 GB M3 Ultra) at an 8,936–8,939 MiB peak footprint |
 | Measured, Maple Preview | Exact head: 18.9–24.6 tok/s decode, 25.1–44.9 tok/s prefill, and 491–1,211 MiB peak process footprint on 128-8192 context (16 GB M4) |
+| Measured, Qwen 3.8 27B | 15.0 tok/s decode (MTP speculative, byte-identical; 7.9 plain) · ~60 tok/s prefill (24 GB M5); mlx-vlm on the same checkpoint: 6.41 decode / 40.5 prefill |
 
 Qwen 3.6 numbers follow the frozen
 [community benchmark protocol](docs/COMMUNITY_BENCHMARKS.md) — three fixed

--- a/Sources/Mference/Infrastructure/ModelIO/ManifestReader.swift
+++ b/Sources/Mference/Infrastructure/ModelIO/ManifestReader.swift
@@ -247,6 +247,40 @@ public enum ManifestReader {
 
     private static func validateQuant(_ quant: ManifestQuant,
                                       expected: ArchConfig) throws {
+        if expected.family == .qwen38 {
+            let affine: [(String, ManifestQuantSlot)] = [
+                ("embedding", quant.embedding),
+                ("attention", quant.attention),
+            ]
+            for (name, slot) in affine {
+                guard slot.weightBits == 4,
+                      slot.scheme.lowercased() == "affine",
+                      slot.scaleType.lowercased() == "bf16",
+                      slot.biasType.lowercased() == "bf16",
+                      slot.groupSize == Quantization.groupSize else {
+                    throw ModelError.indexCorrupt(
+                        detail: "unsupported Qwen3.8 quantization for \(name)")
+                }
+            }
+            // Dense: the manifest must mark the router, shared-expert and
+            // routed-expert slots absent.
+            let absent: [(String, ManifestQuantSlot)] = [
+                ("router", quant.router),
+                ("sharedExpert", quant.sharedExpert),
+                ("routedExpert", quant.routedExpert),
+            ]
+            for (name, slot) in absent {
+                guard slot.weightBits == 0,
+                      slot.scheme.lowercased() == "none",
+                      slot.scaleType.lowercased() == "none",
+                      slot.biasType.lowercased() == "none",
+                      slot.groupSize == 0 else {
+                    throw ModelError.indexCorrupt(
+                        detail: "Qwen3.8 manifest must mark \(name) absent")
+                }
+            }
+            return
+        }
         if expected.family == .maple {
             let affine: [(String, ManifestQuantSlot, Int)] = [
                 ("embedding", quant.embedding, 4),

--- a/Sources/Mference/Infrastructure/ModelIO/ModelTypes.swift
+++ b/Sources/Mference/Infrastructure/ModelIO/ModelTypes.swift
@@ -8,6 +8,7 @@ import Metal
 public enum ModelFamily: String, Sendable, Hashable {
     case gemma4 = "gemma4"
     case qwen36 = "qwen36"
+    case qwen38 = "qwen38"
     case deepseekV4Flash = "deepseekV4Flash"
     case inklingSmall = "inklingSmall"
     case maple = "maple"
@@ -454,6 +455,60 @@ public struct ArchConfig: Sendable, Equatable {
         return mask
     }
 
+    /// Canonical Qwen3.8-27B baseline (text stack of the multimodal
+    /// checkpoint; the vision tower is excluded at repack). A 64-layer dense
+    /// hybrid: 48 gated-DeltaNet linear-attention layers and 16 full-attention
+    /// layers (every 4th layer), one SwiGLU MLP per layer — no routed experts,
+    /// no shared expert, no router. Sigmoid attention output gate, QK norms,
+    /// partial RoPE over 64 of 256 dims, untied 248k-row lm_head. Everything
+    /// is resident: with zero experts per layer the expert streamer never
+    /// opens a pool.
+    public static let qwen38_27B = ArchConfig(
+        hiddenSize: 5120,
+        intermediateSize: 17_408,
+        moeIntermediateSize: 0,
+        numHeads: 24,
+        numKVHeads: 4,
+        numFullKVHeads: 4,
+        headDim: 256,
+        fullHeadDim: 256,
+        vocabSize: 248_320,
+        slidingWindow: 0,
+        finalLogitSoftcap: 0.0,
+        ropeTheta: 10_000_000.0,
+        fullRopeTheta: 10_000_000.0,
+        partialRotaryFactor: 0.25,
+        numLayers: 64,
+        numExperts: 0,
+        topKExperts: 0,
+        tieWordEmbeddings: false,
+        attentionKEqV: false,
+        fullAttentionLayerMask: Self.qwen38LayerMask(),
+        hiddenActivation: "silu",
+        family: .qwen38,
+        attnOutputGate: true,
+        attentionScale: 0.0625,   // 256^-0.5
+        embeddingScaledBySqrtHidden: false,
+        routerScaled: false,
+        ffnSandwichNorms: false,
+        sharedExpertGated: false,
+        ropeNeoxSubdim: true,
+        linearAttention: LinearAttentionConfig(
+            numKHeads: 16, numVHeads: 48,
+            keyHeadDim: 128, valueHeadDim: 128,
+            convKernelSize: 4),
+        numSharedExperts: 0,
+        numDenseLayers: 64,
+        denseIntermediateSize: 17_408
+    )
+
+    private static func qwen38LayerMask() -> [UInt8] {
+        // Same 3:1 hybrid shape as Qwen 3.6 (full_attention_interval = 4).
+        var mask = [UInt8](repeating: 2, count: 64)
+        for i in stride(from: 3, to: 64, by: 4) { mask[i] = 1 }
+        return mask
+    }
+
     /// Canonical Maple Preview baseline: 24 plain pre-norm MoE layers with
     /// 256 routed experts (top-8) and no shared expert. Three sliding layers
     /// are followed by one global NoPE layer.
@@ -650,6 +705,7 @@ public struct ArchConfig: Sendable, Equatable {
     public static let knownArchitectures: [ModelFamily: ArchConfig] = [
         .gemma4: .gemma4_26B_A4B,
         .qwen36: .qwen36_35B_A3B,
+        .qwen38: .qwen38_27B,
         .deepseekV4Flash: .deepseekV4Flash_284B_A13B,
         .inklingSmall: .inklingSmall_276B_A12B,
         .maple: .maplePreview,
@@ -692,6 +748,11 @@ public struct ArchConfig: Sendable, Equatable {
         if numSharedExperts > 0 {
             shapes.append((m: intermediateSize, n: hiddenSize))
             shapes.append((m: hiddenSize, n: intermediateSize))
+        }
+        if numDenseLayers == numLayers, denseIntermediateSize > 0 {
+            // Fully dense family: every layer runs one resident SwiGLU MLP.
+            shapes.append((m: denseIntermediateSize, n: hiddenSize))
+            shapes.append((m: hiddenSize, n: denseIntermediateSize))
         }
         return shapes
     }

--- a/Sources/Mference/Infrastructure/ModelIO/ResidentBuffer.swift
+++ b/Sources/Mference/Infrastructure/ModelIO/ResidentBuffer.swift
@@ -2,20 +2,116 @@ import Foundation
 import Darwin
 import Metal
 
-/// `mmap`'d view of `model_weights.bin`'s tensor data region, wrapped in
-/// one shared `MTLBuffer`. All resident `TensorView`s alias byte offsets
-/// inside `buffer`.
+/// `mmap`'d view of `model_weights.bin`'s tensor data region, wrapped in one
+/// or more shared `MTLBuffer` chunks. One chunk covers the whole region when
+/// it fits under the device's `maxBufferLength`; a larger region (Qwen 3.8's
+/// fully-resident 15 GB exceeds the 24 GB M5's 13.3 GB limit) is cut between
+/// tensor spans so every tensor and its scale/bias companions stay inside a
+/// single buffer. All resident `TensorView`s alias byte offsets inside one
+/// chunk's buffer.
 final class ResidentBuffer {
-    let buffer: MTLBuffer
+    struct Chunk {
+        /// Region-relative byte range this chunk's buffer covers.
+        let start: UInt64
+        let end: UInt64
+        let buffer: MTLBuffer
+    }
 
-    /// `mmap` the page-aligned window covering `[fileOffset, fileOffset + residentSize)`
-    /// inside the file at `fileURL`. The wrapped `MTLBuffer` starts at the
-    /// (sub-page) offset within the mapping so the resident bytes start at
-    /// byte 0 of the buffer.
+    let chunks: [Chunk]
+
+    /// Backwards-compatible single-chunk accessor for regions that fit in one
+    /// buffer (every family before Qwen 3.8, and all test fixtures).
+    var buffer: MTLBuffer {
+        precondition(chunks.count == 1,
+                     "resident region is chunked; resolve through chunk(containing:)")
+        return chunks[0].buffer
+    }
+
+    /// `tensorSpans` are region-relative `[start, end)` byte spans that must
+    /// not be split across chunks (a tensor plus its companions). They are
+    /// only consulted when the region exceeds the device's buffer limit.
     init(fileURL: URL,
-                fileOffset: UInt64,
-                residentSize: UInt64,
-                device: MTLDevice) throws {
+         fileOffset: UInt64,
+         residentSize: UInt64,
+         device: MTLDevice,
+         tensorSpans: [(start: UInt64, end: UInt64)] = []) throws {
+        let limit = UInt64(device.maxBufferLength)
+        let ranges: [(start: UInt64, end: UInt64)]
+        if residentSize <= limit {
+            ranges = [(0, residentSize)]
+        } else {
+            ranges = try Self.chunkRanges(regionSize: residentSize,
+                                          limit: limit,
+                                          tensorSpans: tensorSpans)
+        }
+        self.chunks = try ranges.map { range in
+            try Chunk(fileURL: fileURL,
+                      regionFileOffset: fileOffset,
+                      start: range.start,
+                      end: range.end,
+                      device: device)
+        }
+    }
+
+    /// The chunk whose range contains `[start, end)`, or nil when the span
+    /// straddles a cut (impossible for spans passed to the initializer).
+    func chunk(containing start: UInt64, _ end: UInt64) -> Chunk? {
+        // Few chunks (2 for Qwen 3.8): linear scan beats a binary search.
+        chunks.first { $0.start <= start && end <= $0.end }
+    }
+
+    /// Greedy sweep over the sorted tensor spans: extend the open chunk while
+    /// it stays under `limit`, cut at the previous span boundary otherwise.
+    /// Trailing region bytes after the last span ride in the final chunk.
+    static func chunkRanges(regionSize: UInt64,
+                           limit: UInt64,
+                           tensorSpans: [(start: UInt64, end: UInt64)])
+        throws -> [(start: UInt64, end: UInt64)] {
+        guard !tensorSpans.isEmpty else {
+            throw ModelError.indexCorrupt(
+                detail: "resident region \(regionSize) exceeds the device " +
+                        "buffer limit \(limit) and no tensor spans were given")
+        }
+        let sorted = tensorSpans.sorted { $0.start < $1.start }
+        var ranges: [(start: UInt64, end: UInt64)] = []
+        var chunkStart: UInt64 = 0
+        var chunkEnd: UInt64 = 0
+        for span in sorted {
+            let extended = max(chunkEnd, span.end)
+            if extended - chunkStart > limit {
+                guard chunkEnd > chunkStart else {
+                    throw ModelError.indexCorrupt(
+                        detail: "resident tensor span \(span.start)..<\(span.end) " +
+                                "exceeds the device buffer limit \(limit)")
+                }
+                ranges.append((chunkStart, chunkEnd))
+                chunkStart = min(span.start, chunkEnd)
+                chunkEnd = span.end
+                guard chunkEnd - chunkStart <= limit else {
+                    throw ModelError.indexCorrupt(
+                        detail: "resident tensor span \(span.start)..<\(span.end) " +
+                                "exceeds the device buffer limit \(limit)")
+                }
+            } else {
+                chunkEnd = extended
+            }
+        }
+        // Cover any padding after the last tensor if it still fits.
+        let tail = regionSize > chunkEnd && regionSize - chunkStart <= limit
+            ? regionSize : chunkEnd
+        ranges.append((chunkStart, tail))
+        return ranges
+    }
+}
+
+private extension ResidentBuffer.Chunk {
+    /// `mmap` the page-aligned window covering the chunk's file range and
+    /// wrap it so the chunk's first byte is byte 0 of the buffer.
+    init(fileURL: URL,
+         regionFileOffset: UInt64,
+         start: UInt64,
+         end: UInt64,
+         device: MTLDevice) throws {
         let pageSize = Int(getpagesize())
 
         let fd = open(fileURL.path, O_RDONLY)
@@ -24,9 +120,11 @@ final class ResidentBuffer {
         }
         defer { close(fd) }
 
+        let fileOffset = regionFileOffset + start
+        let chunkSize = end - start
         let alignedOffset = (fileOffset / UInt64(pageSize)) * UInt64(pageSize)
         let sliceShift = Int(fileOffset - alignedOffset)
-        let mappedLen = sliceShift + Int(residentSize)
+        let mappedLen = sliceShift + Int(chunkSize)
         let mapped = mmap(nil, mappedLen, PROT_READ, MAP_PRIVATE,
                           fd, off_t(alignedOffset))
         if mapped == MAP_FAILED {
@@ -44,7 +142,7 @@ final class ResidentBuffer {
         let captureLen = mappedLen
         guard let buf = device.makeBuffer(
             bytesNoCopy: sliceStart,
-            length: Int(residentSize),
+            length: Int(chunkSize),
             options: .storageModeShared,
             deallocator: { _, _ in
                 munmap(captureBase, captureLen)
@@ -54,6 +152,6 @@ final class ResidentBuffer {
             throw ModelError.residentBufferWrapFailed
         }
 
-        self.buffer = buf
+        self.init(start: start, end: end, buffer: buf)
     }
 }

--- a/Sources/Mference/Kernels/Attention/Attention.swift
+++ b/Sources/Mference/Kernels/Attention/Attention.swift
@@ -30,16 +30,20 @@ final class Attention {
     private let psoCombine: MTLComputePipelineState
     private let psoPartialSWA: MTLComputePipelineState
     private let psoPartialQwenFull: MTLComputePipelineState
+    private let psoPartialQwen38Full: MTLComputePipelineState
     private let psoPartialFull: MTLComputePipelineState
     private let psoGQAPartialSWA: MTLComputePipelineState
     private let psoGQAPartialSWAChunks16: MTLComputePipelineState
     private let psoPartialQwenFullChunks16: MTLComputePipelineState
+    private let psoPartialQwen38FullChunks16: MTLComputePipelineState
     private let psoPartialFullChunks16: MTLComputePipelineState
     private let psoCombineSWA: MTLComputePipelineState
     private let psoCombineQwenFull: MTLComputePipelineState
+    private let psoCombineQwen38Full: MTLComputePipelineState
     private let psoCombineFull: MTLComputePipelineState
     private let psoCombineSWAChunks16: MTLComputePipelineState
     private let psoCombineQwenFullChunks16: MTLComputePipelineState
+    private let psoCombineQwen38FullChunks16: MTLComputePipelineState
     private let psoCombineFullChunks16: MTLComputePipelineState
 
     /// Mirrors `kAttnThreads` in `attention.metal`. The kernel was authored
@@ -80,6 +84,11 @@ final class Attention {
                                                                headDim: 256,
                                                                numQHeads: 16,
                                                                numKVHeads: 2)
+        self.psoPartialQwen38Full = try Self.specializedPipeline(context,
+                                                                 "attention_decode_partial",
+                                                                 headDim: 256,
+                                                                 numQHeads: 24,
+                                                                 numKVHeads: 4)
         self.psoPartialFull = try Self.specializedPipeline(context,
                                                            "attention_decode_partial",
                                                            headDim: 512,
@@ -102,6 +111,12 @@ final class Attention {
                                                                        numQHeads: 16,
                                                                        numKVHeads: 2,
                                                                        numChunks: 16)
+        self.psoPartialQwen38FullChunks16 = try Self.specializedPipeline(context,
+                                                                         "attention_decode_partial",
+                                                                         headDim: 256,
+                                                                         numQHeads: 24,
+                                                                         numKVHeads: 4,
+                                                                         numChunks: 16)
         self.psoPartialFullChunks16 = try Self.specializedPipeline(context,
                                                                    "attention_decode_partial",
                                                                    headDim: 512,
@@ -118,6 +133,11 @@ final class Attention {
                                                                headDim: 256,
                                                                numQHeads: 16,
                                                                numKVHeads: 2)
+        self.psoCombineQwen38Full = try Self.specializedPipeline(context,
+                                                                 "attention_decode_combine",
+                                                                 headDim: 256,
+                                                                 numQHeads: 24,
+                                                                 numKVHeads: 4)
         self.psoCombineFull = try Self.specializedPipeline(context,
                                                            "attention_decode_combine",
                                                            headDim: 512,
@@ -135,6 +155,12 @@ final class Attention {
                                                                        numQHeads: 16,
                                                                        numKVHeads: 2,
                                                                        numChunks: 16)
+        self.psoCombineQwen38FullChunks16 = try Self.specializedPipeline(context,
+                                                                         "attention_decode_combine",
+                                                                         headDim: 256,
+                                                                         numQHeads: 24,
+                                                                         numKVHeads: 4,
+                                                                         numChunks: 16)
         self.psoCombineFullChunks16 = try Self.specializedPipeline(context,
                                                                    "attention_decode_combine",
                                                                    headDim: 512,
@@ -388,6 +414,9 @@ final class Attention {
         if !useGQAPartial && headDim == 256 && numQHeads == 16 && numKVHeads == 2 {
             return numChunks == 16 ? psoPartialQwenFullChunks16 : psoPartialQwenFull
         }
+        if !useGQAPartial && headDim == 256 && numQHeads == 24 && numKVHeads == 4 {
+            return numChunks == 16 ? psoPartialQwen38FullChunks16 : psoPartialQwen38Full
+        }
         if !useGQAPartial && headDim == 512 && numQHeads == 16 && numKVHeads == 2 {
             if numChunks == 16 {
                 return psoPartialFullChunks16
@@ -406,6 +435,9 @@ final class Attention {
         }
         if headDim == 256 && numQHeads == 16 && numKVHeads == 2 {
             return numChunks == 16 ? psoCombineQwenFullChunks16 : psoCombineQwenFull
+        }
+        if headDim == 256 && numQHeads == 24 && numKVHeads == 4 {
+            return numChunks == 16 ? psoCombineQwen38FullChunks16 : psoCombineQwen38Full
         }
         if headDim == 512 && numQHeads == 16 && numKVHeads == 2 {
             return numChunks == 16 ? psoCombineFullChunks16 : psoCombineFull

--- a/Sources/Mference/Kernels/Attention/Attention.swift
+++ b/Sources/Mference/Kernels/Attention/Attention.swift
@@ -48,9 +48,10 @@ final class Attention {
     static let threadsPerGroup: Int = 256
 
     /// Project ceilings for the split-KV partial scratch. `kAttnMaxHeadDim` in
-    /// attention.metal is 512; the model has 16 Q heads; `maxChunks` bounds the
-    /// split factor (and therefore the scratch size: 16·64·512 FP32 ≈ 2 MB).
-    static let maxQHeads = 16
+    /// attention.metal is 512; the widest family (Qwen 3.8) has 24 Q heads;
+    /// `maxChunks` bounds the split factor (and therefore the scratch size:
+    /// 24·64·512 FP32 ≈ 3 MB).
+    static let maxQHeads = 24
     static let maxHeadDim = 512
     static let maxChunks = 64
     /// Full attention uses 16 base chunks by default.

--- a/Sources/Mference/Kernels/Fusions/LMHeadGreedyMultiX.swift
+++ b/Sources/Mference/Kernels/Fusions/LMHeadGreedyMultiX.swift
@@ -1,0 +1,108 @@
+import Metal
+
+/// Multi-token fused greedy lm_head for the MTP speculative-verify pass.
+/// Consumes pre-normalized hidden rows `[T, d]` and emits one greedy token
+/// per row into `outTokens` (`[T]` UInt32). Row logits and argmax semantics
+/// are bit-identical to `LMHeadChainInt4`'s single-token pair (see
+/// `logit.metal`), while the packed lm_head is read once for all rows.
+final class LMHeadGreedyMultiX {
+    static let maxTokens = 8
+    private static let rowsPerThreadgroup = 8
+    private static let rowSummaryStride = 2
+
+    private let rowGreedyByTokens: [MTLComputePipelineState] // index = T - 1
+    private let rowReducer: MTLComputePipelineState
+    private let summariesBuffer: MTLBuffer
+    private let maxVocab: Int
+
+    init(context: MetalContext, maxVocab: Int) throws {
+        // Safe-math module compile: see `DequantInt4GEMVMultiX` — the
+        // unrolled per-token chains must not be reassociated.
+        let library = try MetalContext.moduleLibrary(device: context.device,
+                                                     module: "logit",
+                                                     safeMath: true)
+        self.rowGreedyByTokens = try (1...Self.maxTokens).map { tokens in
+            let values = MTLFunctionConstantValues()
+            var t = UInt32(tokens)
+            var use = true
+            values.setConstantValue(&t, type: .uint, index: 47)
+            values.setConstantValue(&use, type: .bool, index: 48)
+            let function = try library.makeFunction(
+                name: "lm_head_greedy_int4_rows_chunk_raw_multix",
+                constantValues: values)
+            let descriptor = MTLComputePipelineDescriptor()
+            descriptor.computeFunction = function
+            descriptor.maxTotalThreadsPerThreadgroup = 256
+            var reflection: MTLAutoreleasedComputePipelineReflection?
+            return try context.device.makeComputePipelineState(descriptor: descriptor,
+                                                               options: [],
+                                                               reflection: &reflection)
+        }
+        self.rowReducer = try context.pipeline(
+            "lm_head_greedy_int4_rows_reduce_multix",
+            constants: [],
+            maxTotalThreadsPerThreadgroup: 256)
+        self.maxVocab = maxVocab
+        let rowGroups = (maxVocab + Self.rowsPerThreadgroup - 1) / Self.rowsPerThreadgroup
+        let length = rowGroups * Self.maxTokens * Self.rowSummaryStride
+            * MemoryLayout<Float>.size
+        guard let summaries = context.device.makeBuffer(
+            length: length, options: .storageModePrivate) else {
+            throw MetalError.noDevice
+        }
+        summaries.label = "mtp.head.summaries"
+        self.summariesBuffer = summaries
+    }
+
+    /// `xNormed` holds `tokens` rows of final-norm output, `[T, d]` FP16.
+    func encode(commandBuffer: MTLCommandBuffer,
+                xNormed: MTLBuffer, xNormedOffset: Int = 0,
+                weights: MTLBuffer, weightsOffset: Int = 0,
+                scales: MTLBuffer, scalesOffset: Int = 0,
+                biases: MTLBuffer, biasesOffset: Int = 0,
+                outTokens: MTLBuffer,
+                d: Int, vocab: Int, tokens: Int) {
+        precondition(vocab <= maxVocab, "vocab \(vocab) exceeds wrapper maxVocab \(maxVocab)")
+        precondition(d % Quantization.groupSize == 0,
+                     "d must be a multiple of \(Quantization.groupSize)")
+        precondition(tokens > 0 && tokens <= Self.maxTokens,
+                     "token count \(tokens) outside 1...\(Self.maxTokens)")
+        precondition(weightsOffset % 2 == 0,
+                     "lm_head multix needs a 2-aligned weightsOffset")
+        let rowGroups = (vocab + Self.rowsPerThreadgroup - 1) / Self.rowsPerThreadgroup
+
+        if let encoder = commandBuffer.makeComputeCommandEncoder() {
+            encoder.setComputePipelineState(rowGreedyByTokens[tokens - 1])
+            encoder.setBuffer(xNormed, offset: xNormedOffset, index: 0)
+            encoder.setBuffer(weights, offset: weightsOffset, index: 1)
+            encoder.setBuffer(scales, offset: scalesOffset, index: 2)
+            encoder.setBuffer(biases, offset: biasesOffset, index: 3)
+            encoder.setBuffer(summariesBuffer, offset: 0, index: 4)
+            var dValue = UInt32(d)
+            var vocabValue = UInt32(vocab)
+            var tValue = UInt32(tokens)
+            encoder.setBytes(&dValue, length: MemoryLayout<UInt32>.size, index: 5)
+            encoder.setBytes(&vocabValue, length: MemoryLayout<UInt32>.size, index: 6)
+            encoder.setBytes(&tValue, length: MemoryLayout<UInt32>.size, index: 7)
+            encoder.dispatchThreadgroups(
+                MTLSize(width: rowGroups, height: 1, depth: 1),
+                threadsPerThreadgroup: MTLSize(width: 32 * Self.rowsPerThreadgroup,
+                                               height: 1, depth: 1))
+            encoder.endEncoding()
+        }
+
+        if let encoder = commandBuffer.makeComputeCommandEncoder() {
+            encoder.setComputePipelineState(rowReducer)
+            encoder.setBuffer(summariesBuffer, offset: 0, index: 0)
+            encoder.setBuffer(outTokens, offset: 0, index: 1)
+            var rowGroupCount = UInt32(rowGroups)
+            var tValue = UInt32(tokens)
+            encoder.setBytes(&rowGroupCount, length: MemoryLayout<UInt32>.size, index: 2)
+            encoder.setBytes(&tValue, length: MemoryLayout<UInt32>.size, index: 3)
+            encoder.dispatchThreadgroups(
+                MTLSize(width: tokens, height: 1, depth: 1),
+                threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+            encoder.endEncoding()
+        }
+    }
+}

--- a/Sources/Mference/Kernels/GDN/GDN.swift
+++ b/Sources/Mference/Kernels/GDN/GDN.swift
@@ -50,16 +50,24 @@ final class GDN {
             && config.numVHeads == 32
             && config.keyHeadDim == 128
             && config.valueHeadDim == 128
+        let isQwen38Geometry = config.numKHeads == 16
+            && config.numVHeads == 48
+            && config.keyHeadDim == 128
+            && config.valueHeadDim == 128
         self.qwenDeltaDecodePSO = useQwenDecodeSpecialization && isQwenGeometry
             ? try context.pipeline("gdn_delta_step_decode_qwen",
                                    constants: [],
                                    maxTotalThreadsPerThreadgroup: 256)
             : nil
-        self.qwenDeltaGatedDecodePSO = useQwenDecodeSpecialization && isQwenGeometry
-            ? try context.pipeline("gdn_delta_gated_decode_qwen",
-                                   constants: [],
-                                   maxTotalThreadsPerThreadgroup: 256)
-            : nil
+        if useQwenDecodeSpecialization && (isQwenGeometry || isQwen38Geometry) {
+            self.qwenDeltaGatedDecodePSO = try context.pipeline(
+                isQwenGeometry ? "gdn_delta_gated_decode_qwen"
+                               : "gdn_delta_gated_decode_qwen38",
+                constants: [],
+                maxTotalThreadsPerThreadgroup: 256)
+        } else {
+            self.qwenDeltaGatedDecodePSO = nil
+        }
         self.deltaPrefillPSO = try context.pipeline("gdn_delta_step_prefill")
         self.gatedNormPSO = try context.pipeline("gdn_gated_norm")
         self.inProjPSO = try context.pipeline("gdn_in_proj_gemv_simd",

--- a/Sources/Mference/Kernels/Quant/DequantInt4GEMVMultiX.swift
+++ b/Sources/Mference/Kernels/Quant/DequantInt4GEMVMultiX.swift
@@ -1,0 +1,83 @@
+import Metal
+
+/// Multi-token MLX-affine INT4 GEMV for the MTP speculative-verify pass:
+/// one weight read applied to up to `maxTokens` token rows, with per-token
+/// arithmetic bit-identical to `DequantInt4GEMV` (see the kernel comment in
+/// `dequant_int4.metal`). `x` is `[T, n]` row-major and `y` is `[T, m]`
+/// row-major.
+final class DequantInt4GEMVMultiX {
+    static let maxTokens = 8
+    private static let rowsPerThreadgroup = 8
+
+    private let pipelines: [MTLComputePipelineState]        // index = T - 1
+    private let f32OutPipelines: [MTLComputePipelineState]  // index = T - 1
+
+    init(context: MetalContext) throws {
+        // One pipeline per token count: the specialized T lets the compiler
+        // unroll the per-token loops and keep the accumulators in registers.
+        // Compiled from a safe-math library: fast math is free to reassociate
+        // the unrolled per-token chains, which would break the bit-identity
+        // with the decode GEMV that the speculative verify depends on
+        // (`MultiXKernelParityTests` locks this).
+        let library = try MetalContext.moduleLibrary(device: context.device,
+                                                     module: "dequant_int4",
+                                                     safeMath: true)
+        func specialized(_ name: String, tokens: Int) throws -> MTLComputePipelineState {
+            let values = MTLFunctionConstantValues()
+            var t = UInt32(tokens)
+            var use = true
+            values.setConstantValue(&t, type: .uint, index: 45)
+            values.setConstantValue(&use, type: .bool, index: 46)
+            let function = try library.makeFunction(name: name, constantValues: values)
+            let descriptor = MTLComputePipelineDescriptor()
+            descriptor.computeFunction = function
+            descriptor.maxTotalThreadsPerThreadgroup = 512
+            var reflection: MTLAutoreleasedComputePipelineReflection?
+            return try context.device.makeComputePipelineState(descriptor: descriptor,
+                                                               options: [],
+                                                               reflection: &reflection)
+        }
+        self.pipelines = try (1...Self.maxTokens).map {
+            try specialized("dequant_int4_gemv_simd_multix", tokens: $0)
+        }
+        self.f32OutPipelines = try (1...Self.maxTokens).map {
+            try specialized("dequant_int4_gemv_simd_multix_f32out", tokens: $0)
+        }
+    }
+
+    func encode(commandBuffer: MTLCommandBuffer,
+                weights: MTLBuffer, weightsOffset: Int = 0,
+                scales: MTLBuffer, scalesOffset: Int = 0,
+                biases: MTLBuffer, biasesOffset: Int = 0,
+                x: MTLBuffer, xOffset: Int = 0,
+                y: MTLBuffer, yOffset: Int = 0,
+                m: Int, n: Int, tokens: Int,
+                outputFloat32: Bool = false) {
+        precondition(n % Quantization.groupSize == 0,
+                     "N must be a multiple of \(Quantization.groupSize)")
+        precondition(weightsOffset % 2 == 0,
+                     "dequant_int4_gemv_simd_multix needs a 2-aligned weightsOffset")
+        precondition(tokens > 0 && tokens <= Self.maxTokens,
+                     "token count \(tokens) outside 1...\(Self.maxTokens)")
+        guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
+        encoder.setComputePipelineState(
+            outputFloat32 ? f32OutPipelines[tokens - 1] : pipelines[tokens - 1])
+        encoder.setBuffer(weights, offset: weightsOffset, index: 0)
+        encoder.setBuffer(scales, offset: scalesOffset, index: 1)
+        encoder.setBuffer(biases, offset: biasesOffset, index: 2)
+        encoder.setBuffer(x, offset: xOffset, index: 3)
+        encoder.setBuffer(y, offset: yOffset, index: 4)
+        var mValue = UInt32(m)
+        var nValue = UInt32(n)
+        var tValue = UInt32(tokens)
+        encoder.setBytes(&mValue, length: MemoryLayout<UInt32>.size, index: 5)
+        encoder.setBytes(&nValue, length: MemoryLayout<UInt32>.size, index: 6)
+        encoder.setBytes(&tValue, length: MemoryLayout<UInt32>.size, index: 7)
+        encoder.dispatchThreadgroups(
+            MTLSize(width: (m + Self.rowsPerThreadgroup - 1) / Self.rowsPerThreadgroup,
+                    height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 32 * Self.rowsPerThreadgroup,
+                                           height: 1, depth: 1))
+        encoder.endEncoding()
+    }
+}

--- a/Sources/Mference/Metal/GDN/gdn.metal
+++ b/Sources/Mference/Metal/GDN/gdn.metal
@@ -544,6 +544,100 @@ kernel void gdn_delta_gated_decode_qwen(
     }
 }
 
+// Qwen 3.8 variant of the fused decode recurrence + gated norm. Identical
+// structure to gdn_delta_gated_decode_qwen; only the geometry differs:
+// Hv=48 value heads over the same Hk=16 key heads, so the value-to-key head
+// mapping divides by 3 (Hv/Hk) instead of 2. Dk=Dv=128 are unchanged, so the
+// per-head lane mapping, reduction order, and norm layout carry over exactly.
+[[kernel, max_total_threads_per_threadgroup(256)]]
+kernel void gdn_delta_gated_decode_qwen38(
+    device const half*   conv_out [[buffer(0)]],
+    device const half*   a_proj   [[buffer(1)]],
+    device const half*   b_proj   [[buffer(2)]],
+    device const bfloat* A_log    [[buffer(3)]],
+    device const bfloat* dt_bias  [[buffer(4)]],
+    device float*        state    [[buffer(5)]],
+    device const half*   z        [[buffer(6)]],
+    device const bfloat* weight   [[buffer(7)]],
+    device half*         out      [[buffer(8)]],
+    constant uint&       kHeads   [[buffer(9)]],
+    constant uint&       vHeads   [[buffer(10)]],
+    constant uint&       keyDim   [[buffer(11)]],
+    constant uint&       valueDim [[buffer(12)]],
+    uint h [[threadgroup_position_in_grid]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    constexpr uint Hk = 16u;
+    constexpr uint Hv = 48u;
+    constexpr uint Dk = 128u;
+    constexpr uint Dv = 128u;
+    constexpr uint simd_groups = 8u;
+    if (h >= Hv) return;
+    if (kHeads != Hk || vHeads != Hv || keyDim != Dk || valueDim != Dv) return;
+
+    threadgroup half y_half[Dv];
+    threadgroup float norm_partial[4];
+    threadgroup float inv_rms;
+
+    const uint hk = h / 3u;   // Hv/Hk = 3
+    device const half* q = conv_out + hk * Dk;
+    device const half* k = conv_out + Hk * Dk + hk * Dk;
+    device const half* v = conv_out + 2u * Hk * Dk + h * Dv;
+    const float g = exp(-exp(float(A_log[h]))
+                        * gdn_softplus(float(a_proj[h]) + float(dt_bias[h])));
+    const float beta = 1.0f / (1.0f + exp(-float(b_proj[h])));
+
+    for (uint dv = simd_group; dv < Dv; dv += simd_groups) {
+        device float* srow = state + (h * Dv + dv) * Dk;
+        float s[4];
+        float kv = 0.0f;
+        for (uint i = 0; i < 4u; ++i) {
+            const uint idx = lane * 4u + i;
+            s[i] = srow[idx] * g;
+            kv = fma(s[i], float(k[idx]), kv);
+        }
+        kv = simd_sum(kv);
+
+        const float delta = (float(v[dv]) - kv) * beta;
+        float y_value = 0.0f;
+        for (uint i = 0; i < 4u; ++i) {
+            const uint idx = lane * 4u + i;
+            s[i] = fma(float(k[idx]), delta, s[i]);
+            y_value = fma(s[i], float(q[idx]), y_value);
+            srow[idx] = s[i];
+        }
+        y_value = simd_sum(y_value);
+        if (lane == 0u) y_half[dv] = half(y_value);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Match gdn_gated_norm's 128-thread reduction exactly: four contiguous
+    // SIMD reductions, then scalar accumulation of their lane-zero results.
+    if (simd_group < 4u) {
+        const uint dv = simd_group * 32u + lane;
+        const float y_value = float(y_half[dv]);
+        float sumsq = 0.0f;
+        sumsq = fma(y_value, y_value, sumsq);
+        sumsq = simd_sum(sumsq);
+        if (lane == 0u) norm_partial[simd_group] = sumsq;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simd_group == 0u && lane == 0u) {
+        float sumsq = 0.0f;
+        for (uint i = 0; i < 4u; ++i) sumsq += norm_partial[i];
+        inv_rms = rsqrt(sumsq / float(Dv) + kGdnRmsEps);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_group < 4u) {
+        const uint dv = simd_group * 32u + lane;
+        const float normed = float(y_half[dv]) * inv_rms * float(weight[dv]);
+        const float gate = gdn_silu(float(z[h * Dv + dv]));
+        out[h * Dv + dv] = half(normed * gate);
+    }
+}
+
 // Prefill: identical math with the token loop inside the kernel. q/k/v/a/b
 // advance by their row strides each step; state persists in registers across
 // the whole chunk and is written back once.

--- a/Sources/Mference/Metal/Quant/dequant_int4.metal
+++ b/Sources/Mference/Metal/Quant/dequant_int4.metal
@@ -339,3 +339,142 @@ kernel void dequant_int4_qkv_gemv_simd(
     dequant_int4_gemv_simd_body(W, scales, biases, x, y, M, NN,
                                 1u, local_row, 0u, lane);
 }
+
+// ============================================================================
+// Multi-token GEMV for the MTP speculative-verify pass.
+//
+// y[t][m] = sum_n W[m, n] * x[t][n] for a small batch of T token rows
+// (T <= 8), reading each packed weight row ONCE and applying it to every
+// token. Per-token arithmetic — operand order, affine factoring, FP32
+// accumulation, the final simd_sum — is an exact replica of
+// `dequant_int4_gemv_simd_body_t`, so each output row is bit-identical to
+// running the single-token decode GEMV once per token. That bit-identity is
+// what lets the speculative verify chunk emit the same greedy tokens as
+// plain decode while paying the weight-read cost of one decode step.
+// ============================================================================
+
+constant constexpr uint kMultiXMaxT = 8;
+// Token count specialized per pipeline so the per-token loops fully unroll
+// and the accumulators stay in registers (a runtime T spills the accumulator
+// array and multiplies the per-token marginal cost).
+constant uint FC_MULTIX_T [[function_constant(45)]];
+constant bool FC_MULTIX_USE_FC [[function_constant(46)]];
+
+static inline uint multix_fc_t(uint T) {
+    return (is_function_constant_defined(FC_MULTIX_USE_FC) &&
+            FC_MULTIX_USE_FC &&
+            is_function_constant_defined(FC_MULTIX_T)) ? FC_MULTIX_T : T;
+}
+
+template <typename OutT>
+static inline void dequant_int4_gemv_simd_multix_body(
+    device const uint8_t* W,
+    device const bfloat*  scales,
+    device const bfloat*  biases,
+    device const half*    x,      // [T, N] row-major
+    device OutT*          y,      // [T, M] row-major
+    uint                  M,
+    uint                  N,
+    uint                  T_param,
+    uint                  tg_idx,
+    uint                  sg_idx,
+    uint                  lane
+) {
+    const uint T = multix_fc_t(T_param);
+    constexpr uint rows_per_tg = 8;
+    const uint row = tg_idx * rows_per_tg + sg_idx;
+    if (row >= M) return;
+    const uint n_groups  = N / kGroupSize;
+    const uint row_bytes = N / 2;
+    device const uint8_t* W_row = W      + uint(row) * row_bytes;
+    device const bfloat*  s_row = scales + uint(row) * n_groups;
+    device const bfloat*  b_row = biases + uint(row) * n_groups;
+
+    float accs[kMultiXMaxT];
+    for (uint t = 0; t < kMultiXMaxT; ++t) { accs[t] = 0.0f; }
+
+    const uint full_blocks = n_groups / 4;
+    for (uint blk = 0; blk < full_blocks; ++blk) {
+        const uint byte_base = blk * 128u + lane * 4u;
+        device const ushort* wp = (device const ushort*)(W_row + byte_base);
+        const uint w4 = uint(wp[0]) | (uint(wp[1]) << 16);
+        const uint g  = blk * 4u + (lane >> 3);
+        const float s = float(s_row[g]);
+        const float b = float(b_row[g]);
+        const uint elem = byte_base * 2u;
+        const uint b0 =  w4        & 0xFFu;
+        const uint b1 = (w4 >> 8)  & 0xFFu;
+        const uint b2 = (w4 >> 16) & 0xFFu;
+        const uint b3 = (w4 >> 24) & 0xFFu;
+        for (uint t = 0; t < T; ++t) {
+            device const half* xt = x + t * N;
+            const half4 xa = *((device const half4*)(xt + elem));
+            const half4 xb = *((device const half4*)(xt + elem + 4u));
+            const float e0 = float(xa.x), e1 = float(xa.y), e2 = float(xa.z), e3 = float(xa.w);
+            const float e4 = float(xb.x), e5 = float(xb.y), e6 = float(xb.z), e7 = float(xb.w);
+            float dot = 0.0f;
+            dot = fma(float(b0 & 0x0Fu), e0, dot); dot = fma(float(b0 >> 4), e1, dot);
+            dot = fma(float(b1 & 0x0Fu), e2, dot); dot = fma(float(b1 >> 4), e3, dot);
+            dot = fma(float(b2 & 0x0Fu), e4, dot); dot = fma(float(b2 >> 4), e5, dot);
+            dot = fma(float(b3 & 0x0Fu), e6, dot); dot = fma(float(b3 >> 4), e7, dot);
+            const float sum = e0 + e1 + e2 + e3 + e4 + e5 + e6 + e7;
+            accs[t] = fma(s, dot, accs[t]);
+            accs[t] = fma(b, sum, accs[t]);
+        }
+    }
+    for (uint g = full_blocks * 4u; g < n_groups; ++g) {
+        const float s = float(s_row[g]);
+        const float b = float(b_row[g]);
+        const uint8_t byte = W_row[g * (kGroupSize / 2) + lane];
+        for (uint t = 0; t < T; ++t) {
+            device const half* xt = x + t * N;
+            const float x0 = float(xt[g * kGroupSize + lane * 2u]);
+            const float x1 = float(xt[g * kGroupSize + lane * 2u + 1u]);
+            float dot = fma(float(uint(byte & 0x0Fu)), x0, 0.0f);
+            dot = fma(float(uint(byte >> 4)), x1, dot);
+            const float sum = x0 + x1;
+            accs[t] = fma(s, dot, accs[t]);
+            accs[t] = fma(b, sum, accs[t]);
+        }
+    }
+    for (uint t = 0; t < T; ++t) {
+        const float acc = simd_sum(accs[t]);
+        if (lane == 0) {
+            y[t * M + row] = OutT(acc);
+        }
+    }
+}
+
+kernel void dequant_int4_gemv_simd_multix(
+    device const uint8_t* W      [[buffer(0)]],
+    device const bfloat*  scales [[buffer(1)]],
+    device const bfloat*  biases [[buffer(2)]],
+    device const half*    x      [[buffer(3)]],
+    device half*          y      [[buffer(4)]],
+    constant uint&        M      [[buffer(5)]],
+    constant uint&        N      [[buffer(6)]],
+    constant uint&        T      [[buffer(7)]],
+    uint                  tg_idx [[threadgroup_position_in_grid]],
+    uint                  sg_idx [[simdgroup_index_in_threadgroup]],
+    uint                  lane   [[thread_index_in_simdgroup]]
+) {
+    dequant_int4_gemv_simd_multix_body<half>(W, scales, biases, x, y,
+                                             M, N, T, tg_idx, sg_idx, lane);
+}
+
+kernel void dequant_int4_gemv_simd_multix_f32out(
+    device const uint8_t* W      [[buffer(0)]],
+    device const bfloat*  scales [[buffer(1)]],
+    device const bfloat*  biases [[buffer(2)]],
+    device const half*    x      [[buffer(3)]],
+    device float*         y      [[buffer(4)]],
+    constant uint&        M      [[buffer(5)]],
+    constant uint&        N      [[buffer(6)]],
+    constant uint&        T      [[buffer(7)]],
+    uint                  tg_idx [[threadgroup_position_in_grid]],
+    uint                  sg_idx [[simdgroup_index_in_threadgroup]],
+    uint                  lane   [[thread_index_in_simdgroup]]
+) {
+    dequant_int4_gemv_simd_multix_body<float>(W, scales, biases, x, y,
+                                              M, N, T, tg_idx, sg_idx, lane);
+}

--- a/Sources/Mference/Metal/Sampling/logit.metal
+++ b/Sources/Mference/Metal/Sampling/logit.metal
@@ -788,3 +788,194 @@ void lm_head_greedy_int4_rows_reduce(
         }
     }
 }
+
+// ============================================================================
+// Multi-token fused greedy head for the MTP speculative-verify pass.
+//
+// Same row math as `lmhead_int4_gemv_row_simd_dev` — each token's row logit
+// is bit-identical to the single-token kernel's `z` — but every packed
+// lm_head row is read ONCE and dotted against T normalized hidden rows
+// (T <= 8). The argmax semantics (FP32 comparison, non-finite rows skipped,
+// ties resolved to the lowest row index, fallback token 0) are exactly the
+// single-token pair's, so per-token winners match plain decode's fused head.
+// Summaries layout: [row_group][t][2] floats.
+// ============================================================================
+
+constant constexpr uint kLMHeadMultiXMaxT = 8;
+constant uint FC_LMHEAD_MULTIX_T [[function_constant(47)]];
+constant bool FC_LMHEAD_MULTIX_USE_FC [[function_constant(48)]];
+
+static inline uint lmhead_multix_fc_t(constant uint& T) {
+    return (is_function_constant_defined(FC_LMHEAD_MULTIX_USE_FC) &&
+            FC_LMHEAD_MULTIX_USE_FC &&
+            is_function_constant_defined(FC_LMHEAD_MULTIX_T)) ? FC_LMHEAD_MULTIX_T : T;
+}
+
+[[kernel, max_total_threads_per_threadgroup(256)]]
+void lm_head_greedy_int4_rows_chunk_raw_multix(
+    device const half*    x_normed     [[buffer(0)]],   // [T, D]
+    device const uint8_t* W            [[buffer(1)]],
+    device const bfloat*  scales       [[buffer(2)]],
+    device const bfloat*  biases       [[buffer(3)]],
+    device       float*   summaries    [[buffer(4)]],
+    constant     uint&    D            [[buffer(5)]],
+    constant     uint&    V            [[buffer(6)]],
+    constant     uint&    T_param      [[buffer(7)]],
+    uint  tg_idx         [[threadgroup_position_in_grid]],
+    uint  simd_lane_id   [[thread_index_in_simdgroup]],
+    uint  simd_group_id  [[simdgroup_index_in_threadgroup]],
+    uint  simdgroups     [[simdgroups_per_threadgroup]]
+) {
+    const uint T = lmhead_multix_fc_t(T_param);
+    threadgroup float partial_v[kLMHeadMultiXMaxT][kLogitMaxSimdGroups];
+    threadgroup uint partial_i[kLMHeadMultiXMaxT][kLogitMaxSimdGroups];
+
+    const uint row = tg_idx * kLMHeadRowsPerTG + simd_group_id;
+
+    float z[kLMHeadMultiXMaxT];
+    for (uint t = 0; t < kLMHeadMultiXMaxT; ++t) { z[t] = 0.0f; }
+
+    if (row < V) {
+        const uint n_groups  = D / kLMHeadGroupSize;
+        const uint row_bytes = D / 2u;
+        device const uint8_t* W_row = W      + uint(row) * row_bytes;
+        device const bfloat*  s_row = scales + uint(row) * n_groups;
+        device const bfloat*  b_row = biases + uint(row) * n_groups;
+
+        float accs[kLMHeadMultiXMaxT];
+        for (uint t = 0; t < kLMHeadMultiXMaxT; ++t) { accs[t] = 0.0f; }
+
+        const uint full_blocks = n_groups / 4u;
+        for (uint blk = 0; blk < full_blocks; ++blk) {
+            const uint byte_base = blk * 128u + simd_lane_id * 4u;
+            device const ushort* wp = (device const ushort*)(W_row + byte_base);
+            const uint w4 = uint(wp[0]) | (uint(wp[1]) << 16);
+            const uint g  = blk * 4u + (simd_lane_id >> 3);
+            const float s = float(s_row[g]);
+            const float b = float(b_row[g]);
+            const uint elem = byte_base * 2u;
+            const uint b0 =  w4        & 0xFFu;
+            const uint b1 = (w4 >> 8)  & 0xFFu;
+            const uint b2 = (w4 >> 16) & 0xFFu;
+            const uint b3 = (w4 >> 24) & 0xFFu;
+            for (uint t = 0; t < T; ++t) {
+                device const half* xt = x_normed + t * D;
+                const half4 xa = *((device const half4*)(xt + elem));
+                const half4 xb = *((device const half4*)(xt + elem + 4u));
+                const float e0 = float(xa.x), e1 = float(xa.y), e2 = float(xa.z), e3 = float(xa.w);
+                const float e4 = float(xb.x), e5 = float(xb.y), e6 = float(xb.z), e7 = float(xb.w);
+                float dot = 0.0f;
+                dot = fma(float(b0 & 0x0Fu), e0, dot); dot = fma(float(b0 >> 4), e1, dot);
+                dot = fma(float(b1 & 0x0Fu), e2, dot); dot = fma(float(b1 >> 4), e3, dot);
+                dot = fma(float(b2 & 0x0Fu), e4, dot); dot = fma(float(b2 >> 4), e5, dot);
+                dot = fma(float(b3 & 0x0Fu), e6, dot); dot = fma(float(b3 >> 4), e7, dot);
+                const float sum = e0 + e1 + e2 + e3 + e4 + e5 + e6 + e7;
+                accs[t] = fma(s, dot, accs[t]);
+                accs[t] = fma(b, sum, accs[t]);
+            }
+        }
+        for (uint g = full_blocks * 4u; g < n_groups; ++g) {
+            const float s = float(s_row[g]);
+            const float b = float(b_row[g]);
+            const uint8_t byte = W_row[g * (kLMHeadGroupSize / 2) + simd_lane_id];
+            for (uint t = 0; t < T; ++t) {
+                device const half* xt = x_normed + t * D;
+                const float x0 = float(xt[g * kLMHeadGroupSize + simd_lane_id * 2u]);
+                const float x1 = float(xt[g * kLMHeadGroupSize + simd_lane_id * 2u + 1u]);
+                float dot = fma(float(uint(byte & 0x0Fu)), x0, 0.0f);
+                dot = fma(float(uint(byte >> 4)), x1, dot);
+                const float sum = x0 + x1;
+                accs[t] = fma(s, dot, accs[t]);
+                accs[t] = fma(b, sum, accs[t]);
+            }
+        }
+        for (uint t = 0; t < T; ++t) {
+            z[t] = simd_sum(accs[t]);
+        }
+    }
+
+    for (uint t = 0; t < T; ++t) {
+        float best_v = -INFINITY;
+        uint best_i = 0xFFFFFFFFu;
+        if (row < V && simd_lane_id == 0 && isfinite(z[t])) {
+            best_v = z[t];
+            best_i = row;
+        }
+        if (simd_lane_id == 0) {
+            partial_v[t][simd_group_id] = best_v;
+            partial_i[t][simd_group_id] = best_i;
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_group_id == 0) {
+        for (uint t = 0; t < T; ++t) {
+            const bool active = simd_lane_id < simdgroups;
+            const float v = active ? partial_v[t][simd_lane_id] : -INFINITY;
+            const uint idx = active ? partial_i[t][simd_lane_id] : 0xFFFFFFFFu;
+            const float v_all = simd_max(v);
+            uint i_all = (v == v_all) ? idx : 0xFFFFFFFFu;
+            i_all = simd_min(i_all);
+            if (simd_lane_id == 0) {
+                device float* slot = summaries
+                    + (tg_idx * T + t) * kLMHeadRowSummaryStride;
+                slot[0] = v_all;
+                slot[1] = as_type<float>(i_all);
+            }
+        }
+    }
+}
+
+[[kernel, max_total_threads_per_threadgroup(256)]]
+void lm_head_greedy_int4_rows_reduce_multix(
+    device const float*   summaries    [[buffer(0)]],
+    device       uint*    out_tokens   [[buffer(1)]],
+    constant     uint&    row_groups   [[buffer(2)]],
+    constant     uint&    T            [[buffer(3)]],
+    uint  tg_idx         [[threadgroup_position_in_grid]],
+    uint  lid            [[thread_position_in_threadgroup]],
+    uint  lsize          [[threads_per_threadgroup]],
+    uint  simd_lane_id   [[thread_index_in_simdgroup]],
+    uint  simd_group_id  [[simdgroup_index_in_threadgroup]],
+    uint  simdgroups     [[simdgroups_per_threadgroup]]
+) {
+    // One threadgroup per token slot.
+    threadgroup float partial_v[kLogitMaxSimdGroups];
+    threadgroup uint  partial_i[kLogitMaxSimdGroups];
+    const uint t = tg_idx;
+    if (t >= T) return;
+
+    float best_v = -INFINITY;
+    uint best_i = 0xFFFFFFFFu;
+    for (uint i = lid; i < row_groups; i += lsize) {
+        device const float* slot = summaries + (i * T + t) * kLMHeadRowSummaryStride;
+        const float v = slot[0];
+        const uint idx = as_type<uint>(slot[1]);
+        if (v > best_v || (v == best_v && idx < best_i)) {
+            best_v = v;
+            best_i = idx;
+        }
+    }
+
+    float v_simd = simd_max(best_v);
+    uint i_simd = (best_v == v_simd) ? best_i : 0xFFFFFFFFu;
+    i_simd = simd_min(i_simd);
+
+    if (simd_lane_id == 0) {
+        partial_v[simd_group_id] = v_simd;
+        partial_i[simd_group_id] = i_simd;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_group_id == 0) {
+        const bool active = simd_lane_id < simdgroups;
+        const float v = active ? partial_v[simd_lane_id] : -INFINITY;
+        const uint idx = active ? partial_i[simd_lane_id] : 0xFFFFFFFFu;
+        const float v_all = simd_max(v);
+        uint i_all = (v == v_all) ? idx : 0xFFFFFFFFu;
+        i_all = simd_min(i_all);
+        if (simd_lane_id == 0) {
+            out_tokens[t] = (i_all == 0xFFFFFFFFu) ? 0u : i_all;
+        }
+    }
+}

--- a/Sources/Mference/Metal/TensorCore/tensorops.metal
+++ b/Sources/Mference/Metal/TensorCore/tensorops.metal
@@ -135,8 +135,12 @@ kernel void inkling_attention_prefill_tensorops(
     constant     float&  scale          [[buffer(16)]],
     constant     float&  logAlpha       [[buffer(17)]],
     uint3 tgid [[threadgroup_position_in_grid]],
-    uint lid [[thread_position_in_threadgroup]],
-    uint threads [[threads_per_threadgroup]]) {
+    uint3 lid3 [[thread_position_in_threadgroup]],
+    uint3 threads3 [[threads_per_threadgroup]]) {
+    // GPUCompiler 32023 requires stage-in attribute declarations to be all
+    // scalar or all vector of one width; keep the all-uint3 convention.
+    const uint lid = lid3.x;
+    const uint threads = threads3.x;
     constexpr auto qkDescriptor = matmul2d_descriptor(
         kInklingAttentionQueries,
         kInklingAttentionKeys,
@@ -225,13 +229,15 @@ kernel void inkling_attention_prefill_tensorops(
         array<int32_t, 2>({1, kInklingAttentionKeys}));
     const uint cacheCount = ringCapacity != 0u
         ? ringCapacity : startPosition + queryCount;
+    // The tensor handle type is non-const; the kernel only reads through
+    // these views, so shedding the const qualifier is safe.
     deviceHalfTensor keyTensor(
-        K + kvHead * headDim,
+        (device half *)(K + kvHead * headDim),
         dextents<int32_t, 2>(
             int32_t(headDim), int32_t(cacheCount)),
         array<int32_t, 2>({1, int32_t(kvStride)}));
     deviceHalfTensor valueTensor(
-        V + kvHead * headDim,
+        (device half *)(V + kvHead * headDim),
         dextents<int32_t, 2>(
             int32_t(headDim), int32_t(cacheCount)),
         array<int32_t, 2>({1, int32_t(kvStride)}));

--- a/Sources/Mference/Runtime/Inference/ForwardRunnerFactory.swift
+++ b/Sources/Mference/Runtime/Inference/ForwardRunnerFactory.swift
@@ -31,6 +31,15 @@ public enum ForwardRunnerFactory {
                                       ? .chunked : .off,
                                   kvStorageMode: .bf16)
         }
+        if model.config.family == .qwen38 {
+            return ForwardRuntime(producer: try Qwen38ForwardRunner(
+                model: model, context: context, maxContext: maxContext,
+                runtimeConfiguration: runtimeConfiguration),
+                                  prefillConfig: runtimeConfiguration.prefillConfig,
+                                  executedPrefillMode: runtimeConfiguration.prefillConfig.mode == .chunked
+                                      ? .chunked : .off,
+                                  kvStorageMode: .fp16)
+        }
         return ForwardRuntime(producer: try RealForwardRunner(
             model: model,
             context: context,

--- a/Sources/Mference/Runtime/Inference/Model.swift
+++ b/Sources/Mference/Runtime/Inference/Model.swift
@@ -506,12 +506,30 @@ public struct Model {
             ? entry.scaleOffset - residentFileOffset : 0
         let biasRel: UInt64 = entry.biasSize > 0
             ? entry.biasOffset - residentFileOffset : 0
+        // Resolve the chunk holding the tensor's full span; offsets in the
+        // returned view are relative to that chunk's buffer.
+        var spanLo = relativeOffset
+        var spanHi = relativeOffset + entry.sizeBytes
+        if entry.scaleSize > 0 {
+            spanLo = min(spanLo, scaleRel)
+            spanHi = max(spanHi, scaleRel + entry.scaleSize)
+        }
+        if entry.biasSize > 0 {
+            spanLo = min(spanLo, biasRel)
+            spanHi = max(spanHi, biasRel + entry.biasSize)
+        }
+        guard let chunk = residentBuffer.chunk(containing: spanLo, spanHi) else {
+            throw ModelError.indexCorrupt(
+                detail: "resident tensor \(name) straddles a chunk boundary")
+        }
         return TensorView(
-            buffer: residentBuffer.buffer,
-            offset: relativeOffset,
+            buffer: chunk.buffer,
+            offset: relativeOffset - chunk.start,
             length: entry.sizeBytes,
-            scaleOffset: scaleRel, scaleLength: entry.scaleSize,
-            biasOffset:  biasRel,  biasLength:  entry.biasSize,
+            scaleOffset: entry.scaleSize > 0 ? scaleRel - chunk.start : 0,
+            scaleLength: entry.scaleSize,
+            biasOffset:  entry.biasSize > 0 ? biasRel - chunk.start : 0,
+            biasLength:  entry.biasSize,
             shape: entry.shape,
             dtype: entry.dtype)
     }
@@ -731,11 +749,30 @@ extension Model {
             }
         }
 
+        // Region-relative spans (tensor + companions) so an oversized region
+        // can be cut into multiple buffers without splitting any tensor.
+        let regionStart = residentIndex.header.indexSize
+        let tensorSpans = residentIndex.entries.values
+            .filter { $0.fileOffset >= regionStart }
+            .map { entry -> (start: UInt64, end: UInt64) in
+                var lo = entry.fileOffset
+                var hi = entry.fileOffset + entry.sizeBytes
+                if entry.scaleSize > 0 {
+                    lo = min(lo, entry.scaleOffset)
+                    hi = max(hi, entry.scaleOffset + entry.scaleSize)
+                }
+                if entry.biasSize > 0 {
+                    lo = min(lo, entry.biasOffset)
+                    hi = max(hi, entry.biasOffset + entry.biasSize)
+                }
+                return (lo - regionStart, hi - regionStart)
+            }
         let residentBuffer = try ResidentBuffer(
             fileURL: weightsURL,
             fileOffset: residentIndex.header.indexSize,
             residentSize: residentIndex.header.residentSize,
-            device: device)
+            device: device,
+            tensorSpans: tensorSpans)
 
         let layout = try PackedExpertsLayoutReader.load(directoryURL: directoryURL)
         if resolvedIntegrityPolicy == .sizeCheckTrustedReceipt {

--- a/Sources/Mference/Runtime/Inference/Model.swift
+++ b/Sources/Mference/Runtime/Inference/Model.swift
@@ -120,14 +120,14 @@ public struct Model {
     /// `model.audio.`).
     var trunkPrefix: String {
         switch config.family {
-        case .gemma4, .qwen36: return "language_model.model."
+        case .gemma4, .qwen36, .qwen38: return "language_model.model."
         case .deepseekV4Flash, .maple: return "model."
         case .inklingSmall: return "model.llm."
         }
     }
     private var lmHeadName: String {
         switch config.family {
-        case .gemma4, .qwen36: return "language_model.lm_head.weight"
+        case .gemma4, .qwen36, .qwen38: return "language_model.lm_head.weight"
         case .deepseekV4Flash, .maple: return "lm_head.weight"
         case .inklingSmall: return "model.llm.unembed.weight"
         }
@@ -135,7 +135,7 @@ public struct Model {
     /// Inkling names the token embedding `embed`, not `embed_tokens`.
     private var embeddingName: String {
         switch config.family {
-        case .gemma4, .qwen36, .deepseekV4Flash:
+        case .gemma4, .qwen36, .qwen38, .deepseekV4Flash:
             return "\(trunkPrefix)embed_tokens.weight"
         case .maple:
             return "\(trunkPrefix)word_embeddings.weight"
@@ -180,7 +180,9 @@ public struct Model {
         switch config.family {
         case .gemma4:
             return try resident(name: "language_model.model.layers.\(L).router.proj.weight")
-        case .qwen36:
+        case .qwen36, .qwen38:
+            // Qwen 3.8 is dense and has no router tensor; the accessor throws
+            // tensorNotFound if a caller ever asks.
             return try resident(name: "language_model.model.layers.\(L).mlp.gate.weight")
         case .deepseekV4Flash:
             return try resident(name: "model.layers.\(L).ffn.gate.weight")
@@ -204,7 +206,9 @@ public struct Model {
     }
     private func sharedExpertName(_ proj: String, layer L: Int) -> String {
         switch config.family {
-        case .gemma4:
+        case .gemma4, .qwen38:
+            // For dense Qwen 3.8 these accessors serve the per-layer MLP,
+            // which the checkpoint names exactly like Gemma's shared FFN.
             return "language_model.model.layers.\(L).mlp.\(proj).weight"
         case .qwen36:
             return "language_model.model.layers.\(L).mlp.shared_expert.\(proj).weight"
@@ -223,7 +227,7 @@ public struct Model {
     }
     public func inputNorm(layer L: Int) throws -> TensorView {
         switch config.family {
-        case .gemma4, .qwen36, .maple:
+        case .gemma4, .qwen36, .qwen38, .maple:
             return try resident(name: "\(trunkPrefix)layers.\(L).input_layernorm.weight")
         case .deepseekV4Flash, .inklingSmall:
             return try resident(name: "\(trunkPrefix)layers.\(L).attn_norm.weight")
@@ -231,7 +235,7 @@ public struct Model {
     }
     public func postAttnNorm(layer L: Int) throws -> TensorView {
         switch config.family {
-        case .gemma4, .qwen36, .maple:
+        case .gemma4, .qwen36, .qwen38, .maple:
             return try resident(name: "\(trunkPrefix)layers.\(L).post_attention_layernorm.weight")
         case .deepseekV4Flash:
             return try resident(name: "\(trunkPrefix)layers.\(L).ffn_norm.weight")

--- a/Sources/Mference/Runtime/Inference/Qwen38ForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/Qwen38ForwardRunner.swift
@@ -34,8 +34,13 @@ public enum Qwen38ForwardRunnerError: Error, CustomStringConvertible {
 ///
 /// Every weight is resident (`numExperts == 0`: the expert streamer never
 /// opens), so a decode step encodes into a single command buffer with no
-/// CPU readback between layers. Prefill v1 is sequential decode replay —
-/// exact by construction; layer-major chunking is a follow-up.
+/// CPU readback between layers. Prefill is chunked and layer-major: each
+/// chunk of prompt tokens runs token-parallel projections, attention, and
+/// MLP kernels (the qwen36 prefill kernel set), with the inherently
+/// sequential DeltaNet recurrence handled by its dedicated in-kernel scan
+/// (`gdn_delta_step_prefill`), which produces the exact FP32 state of
+/// token-by-token decode. There is no router readback, so a whole chunk —
+/// all 64 layers — encodes into one command buffer.
 public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowReporting,
     ChunkedPrefillRunner, HeadlessSequentialPrefillRunner, ExactPrefillLogitProducer,
     FusedHeadLogitProducer, @unchecked Sendable {
@@ -69,6 +74,76 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
         let isLinear: Bool
     }
 
+    /// Chunk-sized prefill scratch: one FP16 row per token, device-private.
+    /// Allocated on the first chunked prefill from the resolved chunk size
+    /// and reused; reallocated only when that size changes. `attnOut` is
+    /// shared by the two attention branches, so its per-token width covers
+    /// both the full-attention output (qDim) and the gated-norm output of
+    /// the DeltaNet branch (valueDim).
+    private struct PrefillScratch {
+        let chunkTokens: Int
+        let hidden: MTLBuffer     // [T, D]
+        let normed: MTLBuffer     // [T, D] input_layernorm output
+        let mlpX: MTLBuffer       // [T, D] post_attention_layernorm output
+        let h1: MTLBuffer         // [T, D] attention-branch (o_proj) output
+        let mlpOut: MTLBuffer     // [T, D] dense MLP output
+        let qPacked: MTLBuffer    // [T, 2*qDim] packed [query ; gate]
+        let attnQ: MTLBuffer      // [T, qDim]
+        let attnGate: MTLBuffer   // [T, qDim]
+        let kStage: MTLBuffer     // [T, kvDim] pre-cache K staging
+        let vStage: MTLBuffer     // [T, kvDim] pre-cache V staging
+        let attnOut: MTLBuffer    // [T, max(qDim, valueDim)]
+        let mlpGate: MTLBuffer    // [T, F]
+        let mlpUp: MTLBuffer      // [T, F]
+        let mlpAct: MTLBuffer     // [T, F]
+        let gdnQKV: MTLBuffer     // [T, qkvDim] raw in_proj_qkv rows
+        let gdnConvOut: MTLBuffer // [T, qkvDim] conv + SiLU output
+        let gdnZ: MTLBuffer       // [T, valueDim]
+        let gdnA: MTLBuffer       // [T, numVHeads]
+        let gdnB: MTLBuffer       // [T, numVHeads]
+        let gdnY: MTLBuffer       // [T, valueDim] delta-rule output
+
+        init(device: MTLDevice, config: ArchConfig, chunkTokens: Int) throws {
+            precondition(chunkTokens > 0, "prefill scratch chunk size must be positive")
+            func buf(_ elementsPerToken: Int, _ label: String) throws -> MTLBuffer {
+                guard let made = device.makeBuffer(
+                    length: max(chunkTokens * elementsPerToken, 1) * MemoryLayout<Float16>.stride,
+                    options: .storageModePrivate) else {
+                    throw Qwen38ForwardRunnerError.invalidConfiguration(
+                        "unable to allocate Qwen 3.8 prefill scratch")
+                }
+                made.label = "qwen38.prefill.\(label)"
+                return made
+            }
+            let D = config.hiddenSize
+            let F = config.intermediateSize
+            let qDim = config.numHeads * config.fullHeadDim
+            let kvDim = config.numFullKVHeads * config.fullHeadDim
+            let la = config.linearAttention
+            self.chunkTokens = chunkTokens
+            self.hidden = try buf(D, "hidden")
+            self.normed = try buf(D, "normed")
+            self.mlpX = try buf(D, "mlpX")
+            self.h1 = try buf(D, "h1")
+            self.mlpOut = try buf(D, "mlpOut")
+            self.qPacked = try buf(2 * qDim, "qPacked")
+            self.attnQ = try buf(qDim, "attnQ")
+            self.attnGate = try buf(qDim, "attnGate")
+            self.kStage = try buf(kvDim, "kStage")
+            self.vStage = try buf(kvDim, "vStage")
+            self.attnOut = try buf(max(qDim, la.valueDim), "attnOut")
+            self.mlpGate = try buf(F, "mlpGate")
+            self.mlpUp = try buf(F, "mlpUp")
+            self.mlpAct = try buf(F, "mlpAct")
+            self.gdnQKV = try buf(la.qkvDim, "gdnQKV")
+            self.gdnConvOut = try buf(la.qkvDim, "gdnConvOut")
+            self.gdnZ = try buf(la.valueDim, "gdnZ")
+            self.gdnA = try buf(la.numVHeads, "gdnA")
+            self.gdnB = try buf(la.numVHeads, "gdnB")
+            self.gdnY = try buf(la.valueDim, "gdnY")
+        }
+    }
+
     private let model: Model
     private let ctx: MetalContext
     private let cfg: ArchConfig
@@ -87,6 +162,19 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
     private let fusionHead: LMHeadChainInt4
     private let fusedQKVGEMV: FusedQKVGEMV
     private let layers: [LayerTensors]
+
+    // Chunked-prefill kernels (token-parallel variants of the decode set).
+    private let prefillEmbed: PrefillEmbedLookupInt4
+    private let prefillRMS: PrefillRMSNorm
+    private let prefillQMM: PrefillInt4QMM
+    private let prefillMPPInt4: MPPPrefillInt4QMM
+    private let prefillQKVEpilogue: PrefillQKVEpilogue
+    private let prefillAttention: PrefillAttention
+    private let prefillMLP: PrefillSharedExpert
+    private let prefillMLPActivation: MTLComputePipelineState
+    private let mlpWeightBits: Int
+    private var prefillScratch: PrefillScratch?
+    private var prefillChunkState = PrefillChunkCommitState()
 
     // Decode scratch, allocated once. FP16 unless noted. At production shape
     // (D 5120, F 17408, qDim 24*256 = 6144, gdn qkvDim 10240, valueDim 6144)
@@ -162,6 +250,20 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
                                               maxD: cfg.hiddenSize,
                                               maxVocab: cfg.vocabSize)
         self.fusedQKVGEMV = try FusedQKVGEMV(context: context)
+        self.prefillEmbed = try PrefillEmbedLookupInt4(context: context)
+        self.prefillRMS = try PrefillRMSNorm(context: context)
+        self.prefillQMM = try PrefillInt4QMM(context: context)
+        self.prefillMPPInt4 = MPPPrefillInt4QMM(context: context)
+        self.prefillQKVEpilogue = try PrefillQKVEpilogue(context: context)
+        self.prefillAttention = try PrefillAttention(context: context)
+        let mlpWeightBits = model.manifest.quant?.attention.weightBits ?? 8
+        self.mlpWeightBits = mlpWeightBits
+        self.prefillMLP = try PrefillSharedExpert(
+            context: context,
+            weightBits: mlpWeightBits,
+            siluActivation: cfg.hiddenActivation == "silu")
+        self.prefillMLPActivation = try context.pipeline(
+            cfg.hiddenActivation == "silu" ? "silu_mul_fp16" : "gelu_mul_fp16")
 
         let device = context.device
         func buf(_ elements: Int, _ stride: Int = MemoryLayout<Float16>.stride) throws -> MTLBuffer {
@@ -255,6 +357,7 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
     // MARK: - LogitProducer
 
     public func reset() {
+        prefillChunkState.reset()
         kv.reset()
         gdnState.reset()
     }
@@ -262,6 +365,7 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
     public var continuationPosition: Int { kv.position }
 
     public func prepareForContinuation(expectedPosition: Int) throws {
+        try prefillChunkState.requireClean(operation: "prepareForContinuation")
         guard expectedPosition > 0, expectedPosition == kv.position else {
             throw PrefillError.prefillCursorMismatch(
                 "Qwen 3.8 continuation cursor \(expectedPosition) does not match \(kv.position)")
@@ -283,19 +387,22 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
                                emitHead: true, outputMode: .logits)
     }
 
-    // MARK: - Prefill (v1: sequential decode replay)
+    // MARK: - Prefill (chunked, layer-major)
 
-    /// Sequential decode-path replay: each prompt token runs the full decode
-    /// step, heads suppressed until the last token. Exact by construction —
-    /// prefill and decode share every kernel and all recurrent state. The
-    /// chunked layer-major path is a follow-up; `config.chunkTokens` only
-    /// affects progress granularity here.
+    /// Chunk-at-a-time prefill: each chunk of prompt tokens runs the whole
+    /// layer stack with token-parallel kernels, and only the DeltaNet
+    /// recurrence walks the chunk sequentially — inside its prefill kernel,
+    /// producing exactly the FP32 state of token-by-token decode. The last
+    /// chunk emits the final token's head through the decode head kernels
+    /// (same buffers, same kernels), so prefill-then-decode continues
+    /// bit-identically to pure sequential decode.
     func prefillChunked(tokens: ArraySlice<Int32>,
                         startPosition: Int,
                         outputMode: PrefillOutputMode,
                         config: PrefillRuntimeConfig,
                         into logits: MTLBuffer,
                         onProgress: (Int) -> Void) async throws -> PrefillResult {
+        try prefillChunkState.requireClean(operation: "prefillChunked")
         guard config.mode == .chunked else {
             throw PrefillError.chunkedUnsupported(
                 "Qwen 3.8 prefillChunked requires PrefillRuntimeConfig.mode == .chunked")
@@ -311,25 +418,531 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
         guard !tokens.isEmpty else {
             return PrefillResult(newPosition: startPosition, seed: .logitsWritten)
         }
+        guard tokens.allSatisfy({ $0 >= 0 && $0 < Int32(cfg.vocabSize) }) else {
+            throw Qwen38ForwardRunnerError.invalidInput(
+                "Qwen 3.8 prefill token is outside the vocabulary")
+        }
+        let emitLogitsHead = !(outputMode == .greedyIfAvailable && useFusedGreedyHead)
+        if emitLogitsHead {
+            guard logits.length >= cfg.vocabSize * MemoryLayout<Float16>.stride else {
+                throw Qwen38ForwardRunnerError.invalidInput(
+                    "Qwen 3.8 logits buffer is too small")
+            }
+        }
 
-        var position = startPosition
-        var index = 0
-        for token in tokens {
+        let scratch = try ensurePrefillScratch(config: config)
+        let spans = PrefillChunkPlanner.spans(tokenCount: tokens.count,
+                                              startPosition: startPosition,
+                                              config: config)
+        for (spanIndex, span) in spans.enumerated() {
             try Task.checkCancellation()
-            let isLast = index == tokens.count - 1
-            try await produceToken(token: token, position: position,
-                                   into: logits,
-                                   emitHead: isLast,
-                                   outputMode: outputMode)
-            position += 1
-            index += 1
-            if index % 16 == 0 { onProgress(index) }
+            let lower = tokens.index(tokens.startIndex, offsetBy: span.tokenOffset)
+            let upper = tokens.index(lower, offsetBy: span.tokenCount)
+            try executePrefillChunk(tokens: tokens[lower..<upper],
+                                    startPosition: span.startPosition,
+                                    outputMode: outputMode,
+                                    logits: logits,
+                                    scratch: scratch,
+                                    writeFinalHead: spanIndex == spans.count - 1)
+            onProgress(span.completedCount)
         }
-        onProgress(tokens.count)
         if outputMode == .greedyIfAvailable, useFusedGreedyHead {
-            return PrefillResult(newPosition: position, seed: .greedyToken(lastGreedyToken))
+            return PrefillResult(newPosition: startPosition + tokens.count,
+                                 seed: .greedyToken(lastGreedyToken))
         }
-        return PrefillResult(newPosition: position, seed: .logitsWritten)
+        return PrefillResult(newPosition: startPosition + tokens.count,
+                             seed: .logitsWritten)
+    }
+
+    private func ensurePrefillScratch(config: PrefillRuntimeConfig) throws -> PrefillScratch {
+        let chunkTokens = max(1, min(config.chunkTokens, PrefillRuntimeConfig.maxChunkTokens))
+        if let scratch = prefillScratch, scratch.chunkTokens == chunkTokens {
+            return scratch
+        }
+        let scratch = try PrefillScratch(device: ctx.device,
+                                         config: cfg,
+                                         chunkTokens: chunkTokens)
+        prefillScratch = scratch
+        return scratch
+    }
+
+    /// One prefill chunk: embed the chunk, run all layers token-parallel,
+    /// and (on the final chunk) emit the last token's head. Everything
+    /// encodes into a single command buffer — this family has no router
+    /// readback — and the KV cursor advances only after it completes.
+    private func executePrefillChunk(tokens: ArraySlice<Int32>,
+                                     startPosition: Int,
+                                     outputMode: PrefillOutputMode,
+                                     logits: MTLBuffer,
+                                     scratch: PrefillScratch,
+                                     writeFinalHead: Bool) throws {
+        let t = tokens.count
+        precondition(t > 0 && t <= scratch.chunkTokens,
+                     "prefill chunk exceeds its scratch capacity")
+        let D = cfg.hiddenSize
+        let tokenIDs = tokens.map { UInt32(bitPattern: $0) }
+        guard let tokenBuffer = ctx.device.makeBuffer(
+            bytes: tokenIDs,
+            length: tokenIDs.count * MemoryLayout<UInt32>.stride,
+            options: .storageModeShared) else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to allocate Qwen 3.8 prefill token buffer")
+        }
+
+        prefillChunkState.markDirty(startPosition: startPosition, tokenCount: t)
+        let cb = try commandBuffer()
+
+        let emb = model.embedding
+        prefillEmbed.encode(commandBuffer: cb,
+                            table: emb.buffer, tableOffset: Int(emb.offset),
+                            scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
+                            biases: emb.buffer, biasesOffset: Int(emb.biasOffset),
+                            tokens: tokenBuffer,
+                            out: scratch.hidden,
+                            t: UInt32(t), d: UInt32(D),
+                            outScale: 1.0)
+
+        for (index, layer) in layers.enumerated() {
+            prefillRMS.encodeBF16W(commandBuffer: cb,
+                                   x: scratch.hidden,
+                                   weight: layer.inputNorm.buffer,
+                                   weightOffset: Int(layer.inputNorm.offset),
+                                   out: scratch.normed,
+                                   t: UInt32(t), d: UInt32(D),
+                                   eps: Self.epsilon)
+            if layer.isLinear {
+                encodeLinearAttentionPrefill(cb, layer: layer, layerIndex: index,
+                                             scratch: scratch, tokenCount: t)
+            } else {
+                try encodeGatedFullAttentionPrefill(cb, layer: layer,
+                                                    layerIndex: index,
+                                                    scratch: scratch,
+                                                    tokenCount: t,
+                                                    startPosition: startPosition)
+            }
+            elementwise.encodeResidualAdd(commandBuffer: cb,
+                                          hidden: scratch.hidden,
+                                          delta: scratch.h1,
+                                          count: t * D)
+            prefillRMS.encodeBF16W(commandBuffer: cb,
+                                   x: scratch.hidden,
+                                   weight: layer.postAttnNorm.buffer,
+                                   weightOffset: Int(layer.postAttnNorm.offset),
+                                   out: scratch.mlpX,
+                                   t: UInt32(t), d: UInt32(D),
+                                   eps: Self.epsilon)
+            try encodeDenseMLPPrefill(cb, layer: layer, scratch: scratch,
+                                      tokenCount: t)
+            elementwise.encodeResidualAdd(commandBuffer: cb,
+                                          hidden: scratch.hidden,
+                                          delta: scratch.mlpOut,
+                                          count: t * D)
+        }
+
+        let emitGreedyHead = outputMode == .greedyIfAvailable && useFusedGreedyHead
+        if writeFinalHead {
+            // The decode head kernels over the last token's row, so the
+            // emitted logits are bit-identical to a sequential-decode head.
+            let lastRowOffset = (t - 1) * D * MemoryLayout<Float16>.stride
+            let fNorm = model.finalNorm
+            let lm = model.lmHead
+            if emitGreedyHead {
+                fusionHead.encodeGreedyDecode(commandBuffer: cb,
+                                              hidden: scratch.hidden,
+                                              hiddenOffset: lastRowOffset,
+                                              normWeight: fNorm.buffer,
+                                              normOffset: Int(fNorm.offset),
+                                              weights: lm.buffer,
+                                              weightsOffset: Int(lm.offset),
+                                              scales: lm.buffer,
+                                              scalesOffset: Int(lm.scaleOffset),
+                                              biases: lm.buffer,
+                                              biasesOffset: Int(lm.biasOffset),
+                                              outToken: greedyTokenBuf,
+                                              d: UInt32(D), vocab: UInt32(cfg.vocabSize),
+                                              rmsEps: Self.epsilon)
+            } else {
+                rms.encodeBF16W(commandBuffer: cb,
+                                x: scratch.hidden, xOffset: lastRowOffset,
+                                weight: fNorm.buffer,
+                                weightOffset: Int(fNorm.offset),
+                                out: normed,
+                                d: UInt32(D), eps: Self.epsilon)
+                int4.encode(commandBuffer: cb,
+                            weights: lm.buffer, weightsOffset: Int(lm.offset),
+                            scales: lm.buffer, scalesOffset: Int(lm.scaleOffset),
+                            biases: lm.buffer, biasesOffset: Int(lm.biasOffset),
+                            x: normed, y: logits,
+                            m: UInt32(cfg.vocabSize), n: UInt32(D))
+            }
+        }
+
+        try withExtendedLifetime(tokenBuffer) {
+            try finish(cb)
+        }
+        if writeFinalHead, emitGreedyHead {
+            lastGreedyToken = greedyTokenBuf.contents().load(as: UInt32.self)
+        }
+        kv.advance(by: t)
+        prefillChunkState.markCommitted()
+    }
+
+    /// Gated-DeltaNet linear attention over one chunk: batched qkv/z/a/b
+    /// projections, causal conv over [tail | chunk] with the tail carried
+    /// forward, per-head q/k norm, the in-kernel sequential delta scan
+    /// (exact FP32 state), gated norm, then out_proj into `h1`.
+    private func encodeLinearAttentionPrefill(_ cb: MTLCommandBuffer,
+                                              layer: LayerTensors,
+                                              layerIndex: Int,
+                                              scratch: PrefillScratch,
+                                              tokenCount t: Int) {
+        guard let qkvW = layer.linQKV, let zW = layer.linZ,
+              let aW = layer.linA, let bW = layer.linB,
+              let outW = layer.linOut, let convW = layer.linConv,
+              let aLog = layer.linALog, let dtBias = layer.linDtBias,
+              let gatedNormW = layer.linNorm else {
+            preconditionFailure("linear-attention layer without GDN tensors")
+        }
+        let la = cfg.linearAttention
+        let D = cfg.hiddenSize
+        encodePrefillInt4Projection(cb,
+                                    weights: qkvW,
+                                    x: scratch.normed, y: scratch.gdnQKV,
+                                    rows: la.qkvDim, columns: D,
+                                    tokenCount: t,
+                                    xStrideElements: D,
+                                    yStrideElements: la.qkvDim)
+        encodePrefillInt4Projection(cb,
+                                    weights: zW,
+                                    x: scratch.normed, y: scratch.gdnZ,
+                                    rows: la.valueDim, columns: D,
+                                    tokenCount: t,
+                                    xStrideElements: D,
+                                    yStrideElements: la.valueDim)
+        encodePrefillInt4Projection(cb,
+                                    weights: aW,
+                                    x: scratch.normed, y: scratch.gdnA,
+                                    rows: la.numVHeads, columns: D,
+                                    tokenCount: t,
+                                    xStrideElements: D,
+                                    yStrideElements: la.numVHeads)
+        encodePrefillInt4Projection(cb,
+                                    weights: bW,
+                                    x: scratch.normed, y: scratch.gdnB,
+                                    rows: la.numVHeads, columns: D,
+                                    tokenCount: t,
+                                    xStrideElements: D,
+                                    yStrideElements: la.numVHeads)
+        let tail = gdnState.convTailBuffer(layer: layerIndex)
+        gdn.encodeConvPrefill(commandBuffer: cb,
+                              tail: tail,
+                              qkvRows: scratch.gdnQKV,
+                              convWeight: convW.buffer,
+                              convWeightOffset: Int(convW.offset),
+                              out: scratch.gdnConvOut,
+                              rows: t)
+        gdn.encodeConvTailUpdate(commandBuffer: cb,
+                                 tail: tail,
+                                 qkvRows: scratch.gdnQKV,
+                                 rows: t)
+        gdn.encodeQKNorm(commandBuffer: cb,
+                         convOut: scratch.gdnConvOut,
+                         rows: t)
+        gdn.encodeDeltaStepPrefill(commandBuffer: cb,
+                                   convOut: scratch.gdnConvOut,
+                                   aProj: scratch.gdnA,
+                                   bProj: scratch.gdnB,
+                                   aLog: aLog.buffer, aLogOffset: Int(aLog.offset),
+                                   dtBias: dtBias.buffer, dtBiasOffset: Int(dtBias.offset),
+                                   state: gdnState.stateBuffer(layer: layerIndex),
+                                   y: scratch.gdnY,
+                                   rows: t)
+        gdn.encodeGatedNorm(commandBuffer: cb,
+                            y: scratch.gdnY,
+                            z: scratch.gdnZ,
+                            weight: gatedNormW.buffer,
+                            weightOffset: Int(gatedNormW.offset),
+                            out: scratch.attnOut,
+                            rows: t)
+        encodePrefillInt4Projection(cb,
+                                    weights: outW,
+                                    x: scratch.attnOut, y: scratch.h1,
+                                    rows: D, columns: la.valueDim,
+                                    tokenCount: t,
+                                    xStrideElements: la.valueDim,
+                                    yStrideElements: D)
+    }
+
+    /// Gated full attention over one chunk: batched packed-[query ; gate]
+    /// q_proj plus K/V projections, per-head q/k norm + NeoX sub-dim RoPE
+    /// over the chunk, KV-cache append, causal tiled prefill attention,
+    /// sigmoid output gate, then o_proj into `h1`.
+    private func encodeGatedFullAttentionPrefill(_ cb: MTLCommandBuffer,
+                                                 layer: LayerTensors,
+                                                 layerIndex: Int,
+                                                 scratch: PrefillScratch,
+                                                 tokenCount t: Int,
+                                                 startPosition: Int) throws {
+        guard let q = layer.q, let k = layer.k, let v = layer.v, let o = layer.o,
+              let qNormW = layer.qNorm, let kNormW = layer.kNorm else {
+            preconditionFailure("full-attention layer without attention tensors")
+        }
+        let D = cfg.hiddenSize
+        let headDim = cfg.fullHeadDim
+        let numKV = cfg.numFullKVHeads
+        let qDim = cfg.numHeads * headDim
+        let kvDim = numKV * headDim
+        let rotaryDim = UInt32(Double(headDim) * cfg.partialRotaryFactor)
+
+        encodePrefillInt4Projection(cb,
+                                    weights: q,
+                                    x: scratch.normed, y: scratch.qPacked,
+                                    rows: 2 * qDim, columns: D,
+                                    tokenCount: t,
+                                    xStrideElements: D,
+                                    yStrideElements: 2 * qDim)
+        encodePrefillInt4Projection(cb,
+                                    weights: k,
+                                    x: scratch.normed, y: scratch.kStage,
+                                    rows: kvDim, columns: D,
+                                    tokenCount: t,
+                                    xStrideElements: D,
+                                    yStrideElements: kvDim)
+        encodePrefillInt4Projection(cb,
+                                    weights: v,
+                                    x: scratch.normed, y: scratch.vStage,
+                                    rows: kvDim, columns: D,
+                                    tokenCount: t,
+                                    xStrideElements: D,
+                                    yStrideElements: kvDim)
+        elementwise.encodeSplitQGate(commandBuffer: cb,
+                                     packed: scratch.qPacked,
+                                     q: scratch.attnQ,
+                                     gate: scratch.attnGate,
+                                     heads: cfg.numHeads,
+                                     dim: headDim,
+                                     rows: t)
+        prefillQKVEpilogue.encodeNeoxSubdimNoVNorm(
+            commandBuffer: cb,
+            q: scratch.attnQ,
+            k: scratch.kStage,
+            qWeight: qNormW.buffer,
+            qWeightOffset: Int(qNormW.offset),
+            kWeight: kNormW.buffer,
+            kWeightOffset: Int(kNormW.offset),
+            startPosition: UInt32(startPosition),
+            queryCount: UInt32(t),
+            headDim: UInt32(headDim),
+            numQHeads: UInt32(cfg.numHeads),
+            numKVHeads: UInt32(numKV),
+            qTokenStrideElements: UInt32(qDim),
+            kvTokenStrideElements: UInt32(kvDim),
+            theta: Float(cfg.fullRopeTheta),
+            rotaryDim: rotaryDim,
+            eps: Self.epsilon)
+        try copyStagedKVToCache(cb, layer: layerIndex,
+                                startPosition: startPosition,
+                                tokenCount: t,
+                                keySource: scratch.kStage,
+                                valueSource: scratch.vStage,
+                                bytesPerToken: kvDim * MemoryLayout<Float16>.stride)
+        let params = PrefillAttentionParams(
+            startPosition: UInt32(startPosition),
+            queryCount: UInt32(t),
+            headDim: UInt32(headDim),
+            numQHeads: UInt32(cfg.numHeads),
+            numKVHeads: UInt32(numKV),
+            kvValidCount: UInt32(startPosition + t),
+            slidingWindow: UInt32(startPosition + t),
+            kvTokenStrideElements: UInt32(kvDim),
+            qTokenStrideElements: UInt32(qDim),
+            oTokenStrideElements: UInt32(qDim),
+            scale: Float(cfg.attentionScale))
+        prefillAttention.encodeCausal(
+            commandBuffer: cb,
+            q: scratch.attnQ,
+            k: kv.keyBuffer(layer: layerIndex, validTokenCount: startPosition + t),
+            v: kv.valueBuffer(layer: layerIndex, validTokenCount: startPosition + t),
+            out: scratch.attnOut,
+            params: params)
+        elementwise.encodeSigmoidGateMul(commandBuffer: cb,
+                                         out: scratch.attnOut,
+                                         gate: scratch.attnGate,
+                                         count: t * qDim)
+        encodePrefillInt4Projection(cb,
+                                    weights: o,
+                                    x: scratch.attnOut, y: scratch.h1,
+                                    rows: D, columns: qDim,
+                                    tokenCount: t,
+                                    xStrideElements: qDim,
+                                    yStrideElements: D)
+    }
+
+    /// Dense SwiGLU MLP over the chunk. With INT4 weights and a chunk tall
+    /// enough to feed the tiled QMM, all three projections go batched (gate
+    /// and up over [t, F], SiLU-mul, down over [t, D]) — this branch is the
+    /// bulk of the prefill FLOPs, D 5120 x F 17408 on all 64 layers. The
+    /// toy fixture's INT8 MLP and sub-tile chunks fall back to
+    /// `PrefillSharedExpert`, whose per-row path is the decode kernel and
+    /// therefore exact.
+    private func encodeDenseMLPPrefill(_ cb: MTLCommandBuffer,
+                                       layer: LayerTensors,
+                                       scratch: PrefillScratch,
+                                       tokenCount t: Int) throws {
+        let D = cfg.hiddenSize
+        let F = cfg.intermediateSize
+        guard mlpWeightBits == 4, t >= 32 else {
+            try prefillMLP.encodeBlock(commandBuffer: cb,
+                                       x: scratch.mlpX,
+                                       y: scratch.mlpOut,
+                                       gate: layer.mlpGate,
+                                       up: layer.mlpUp,
+                                       down: layer.mlpDown,
+                                       scratchGate: scratch.mlpGate,
+                                       scratchUp: scratch.mlpUp,
+                                       scratchAct: scratch.mlpAct,
+                                       queryCount: t,
+                                       d: D,
+                                       intermediate: F,
+                                       xStrideElements: D,
+                                       yStrideElements: D)
+            return
+        }
+        func qmm(_ proj: SharedExpertProjection, x: MTLBuffer, y: MTLBuffer,
+                 n: Int, k: Int) {
+            encodeQMMOrMPP(cb,
+                           weights: proj.weights, weightsOffset: proj.weightsOffset,
+                           scales: proj.scales, scalesOffset: proj.scalesOffset,
+                           biases: proj.biases, biasesOffset: proj.biasesOffset,
+                           x: x, y: y, t: t, n: n, k: k)
+        }
+        qmm(layer.mlpGate, x: scratch.mlpX, y: scratch.mlpGate, n: F, k: D)
+        qmm(layer.mlpUp, x: scratch.mlpX, y: scratch.mlpUp, n: F, k: D)
+        guard let activation = cb.makeComputeCommandEncoder() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 prefill MLP activation encoder")
+        }
+        activation.setComputePipelineState(prefillMLPActivation)
+        activation.setBuffer(scratch.mlpGate, offset: 0, index: 0)
+        activation.setBuffer(scratch.mlpUp, offset: 0, index: 1)
+        activation.setBuffer(scratch.mlpAct, offset: 0, index: 2)
+        var count = UInt32(t * F)
+        activation.setBytes(&count, length: MemoryLayout<UInt32>.size, index: 3)
+        let width = min(prefillMLPActivation.maxTotalThreadsPerThreadgroup, 256)
+        activation.dispatchThreads(
+            MTLSize(width: Int(count), height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: width, height: 1, depth: 1))
+        activation.endEncoding()
+        qmm(layer.mlpDown, x: scratch.mlpAct, y: scratch.mlpOut, n: D, k: F)
+    }
+
+    /// Batched INT4 projection over the chunk: the MPP TensorOps QMM when
+    /// available and the chunk is at least one tile tall, the threadgroup
+    /// QMM for tall chunks otherwise, and the decode GEMV repeated per row
+    /// for short chunks. Unlike qwen36's dispatch policy, the q family also
+    /// goes through the QMM: this family's q-side matrices (packed q_proj,
+    /// GDN in_proj_qkv) are its largest resident projections, and a per-row
+    /// replay of them would collapse the chunk back to sequential cost.
+    private func encodePrefillInt4Projection(_ cb: MTLCommandBuffer,
+                                             weights: TensorView,
+                                             x: MTLBuffer,
+                                             y: MTLBuffer,
+                                             rows: Int,
+                                             columns: Int,
+                                             tokenCount: Int,
+                                             xStrideElements: Int,
+                                             yStrideElements: Int) {
+        if tokenCount >= 32 {
+            encodeQMMOrMPP(cb,
+                           weights: weights.buffer, weightsOffset: Int(weights.offset),
+                           scales: weights.buffer, scalesOffset: Int(weights.scaleOffset),
+                           biases: weights.buffer, biasesOffset: Int(weights.biasOffset),
+                           x: x, y: y,
+                           t: tokenCount, n: rows, k: columns)
+            return
+        }
+        for row in 0..<tokenCount {
+            int4.encode(commandBuffer: cb,
+                        weights: weights.buffer, weightsOffset: Int(weights.offset),
+                        scales: weights.buffer, scalesOffset: Int(weights.scaleOffset),
+                        biases: weights.buffer, biasesOffset: Int(weights.biasOffset),
+                        x: x,
+                        xOffset: row * xStrideElements * MemoryLayout<Float16>.stride,
+                        y: y,
+                        yOffset: row * yStrideElements * MemoryLayout<Float16>.stride,
+                        m: UInt32(rows), n: UInt32(columns))
+        }
+    }
+
+    private func encodeQMMOrMPP(_ cb: MTLCommandBuffer,
+                                weights: MTLBuffer, weightsOffset: Int,
+                                scales: MTLBuffer, scalesOffset: Int,
+                                biases: MTLBuffer, biasesOffset: Int,
+                                x: MTLBuffer, y: MTLBuffer,
+                                t: Int, n: Int, k: Int) {
+        if prefillMPPInt4.isAvailable {
+            let path = prefillMPPInt4.encode(commandBuffer: cb,
+                                             weights: weights, weightsOffset: weightsOffset,
+                                             scales: scales, scalesOffset: scalesOffset,
+                                             biases: biases, biasesOffset: biasesOffset,
+                                             x: x, y: y,
+                                             m: t, n: n, k: k)
+            if path == .affineThreadgroupF16 {
+                return
+            }
+        }
+        prefillQMM.encode(commandBuffer: cb,
+                          weights: weights, weightsOffset: weightsOffset,
+                          scales: scales, scalesOffset: scalesOffset,
+                          biases: biases, biasesOffset: biasesOffset,
+                          x: x, y: y,
+                          t: t, n: n, k: k)
+    }
+
+    /// Blit the chunk's staged K/V rows into the layer's cache, split into
+    /// two spans when the physical layout wraps (never for the full-attention
+    /// layers of this family, whose capacity is maxContext).
+    private func copyStagedKVToCache(_ cb: MTLCommandBuffer,
+                                     layer: Int,
+                                     startPosition: Int,
+                                     tokenCount: Int,
+                                     keySource: MTLBuffer,
+                                     valueSource: MTLBuffer,
+                                     bytesPerToken: Int) throws {
+        func copy(_ source: MTLBuffer,
+                  to destination: (buffer: MTLBuffer, offset: Int, stride: Int),
+                  sourceTokenOffset: Int,
+                  count: Int) throws {
+            guard count > 0 else { return }
+            guard let blit = cb.makeBlitCommandEncoder() else {
+                throw Qwen38ForwardRunnerError.commandFailed(
+                    "unable to create Qwen 3.8 prefill KV blit encoder")
+            }
+            blit.copy(from: source,
+                      sourceOffset: sourceTokenOffset * bytesPerToken,
+                      to: destination.buffer,
+                      destinationOffset: destination.offset,
+                      size: count * bytesPerToken)
+            blit.endEncoding()
+        }
+        let capacity = kv.capacity(layer: layer)
+        let physicalStart = startPosition % capacity
+        let firstSpan = min(tokenCount, capacity - physicalStart)
+        try copy(keySource,
+                 to: kv.kRange(layer: layer, start: startPosition, count: firstSpan),
+                 sourceTokenOffset: 0, count: firstSpan)
+        try copy(valueSource,
+                 to: kv.vRange(layer: layer, start: startPosition, count: firstSpan),
+                 sourceTokenOffset: 0, count: firstSpan)
+        guard firstSpan < tokenCount else { return }
+        let secondCount = tokenCount - firstSpan
+        let secondStart = startPosition + firstSpan
+        try copy(keySource,
+                 to: kv.kRange(layer: layer, start: secondStart, count: secondCount),
+                 sourceTokenOffset: firstSpan, count: secondCount)
+        try copy(valueSource,
+                 to: kv.vRange(layer: layer, start: secondStart, count: secondCount),
+                 sourceTokenOffset: firstSpan, count: secondCount)
     }
 
     // MARK: - Decode step
@@ -342,6 +955,7 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
                               into logits: MTLBuffer?,
                               emitHead: Bool,
                               outputMode: PrefillOutputMode) async throws {
+        try prefillChunkState.requireClean(operation: "produce")
         try Task.checkCancellation()
         guard position == kv.position, position >= 0, position < maxContext else {
             throw Qwen38ForwardRunnerError.invalidInput(

--- a/Sources/Mference/Runtime/Inference/Qwen38ForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/Qwen38ForwardRunner.swift
@@ -150,8 +150,11 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
         self.rope = try RoPE(context: context)
         self.gdn = try GDN(context: context, config: cfg.linearAttention,
                            specializedHiddenSize: cfg.hiddenSize)
+        // The dense MLP shares the attention quant (the manifest's
+        // sharedExpert slot is deliberately absent for this family); the
+        // quant-less toy manifest keeps the INT8 default.
         self.mlp = try SharedExpertRuntime(context: context,
-                                           weightBits: model.sharedExpertWeightBits,
+                                           weightBits: model.manifest.quant?.attention.weightBits ?? 8,
                                            siluActivation: cfg.hiddenActivation == "silu",
                                            specializedD: cfg.hiddenSize,
                                            specializedF: cfg.intermediateSize)

--- a/Sources/Mference/Runtime/Inference/Qwen38ForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/Qwen38ForwardRunner.swift
@@ -46,8 +46,9 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
     FusedHeadLogitProducer, @unchecked Sendable {
 
     /// Every per-layer TensorView, resolved once at init so the decode hot
-    /// path never touches the resident-index dictionary.
-    private struct LayerTensors {
+    /// path never touches the resident-index dictionary. Internal so the MTP
+    /// speculator's verify pass can reuse the resolved views.
+    struct LayerTensors {
         let inputNorm: TensorView
         let postAttnNorm: TensorView
         // Full-attention layers (mask 1) only.
@@ -210,6 +211,37 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
     public private(set) var lastGreedyToken: UInt32 = 0
     public var usesFusedGreedyHead: Bool { useFusedGreedyHead }
 
+    /// MTP speculative decoding, present when the install carries the
+    /// `mtp.*` draft tensors and `MFERENCE_MTP` is not "0". Greedy-only:
+    /// rounds run only through the fused-greedy `produce` path, which the
+    /// generation loop already restricts to temperature 0 with no
+    /// repetition penalty. Internal var so tests can disable it per-instance.
+    var mtp: Qwen38MTPSpeculator?
+
+    public struct MTPSpecStats: Sendable {
+        public let rounds: Int
+        public let draftedTokens: Int
+        public let acceptedTokens: Int
+        public let emittedTokens: Int
+        public let rollbacks: Int
+        public let draftNanos: UInt64
+        public let verifyNanos: UInt64
+        public let acceptNanos: UInt64
+    }
+
+    public var mtpSpecStats: MTPSpecStats? {
+        mtp.map {
+            MTPSpecStats(rounds: $0.stats.rounds,
+                         draftedTokens: $0.stats.draftedTokens,
+                         acceptedTokens: $0.stats.acceptedTokens,
+                         emittedTokens: $0.stats.emittedTokens,
+                         rollbacks: $0.stats.rollbacks,
+                         draftNanos: $0.stats.draftNanos,
+                         verifyNanos: $0.stats.verifyNanos,
+                         acceptNanos: $0.stats.acceptNanos)
+        }
+    }
+
     private static let epsilon: Float = 1e-6
 
     public init(model: Model, context: MetalContext, maxContext: Int,
@@ -334,6 +366,17 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
                 mlpDown: projection(try model.sharedExpertDown(layer: L), rows: D, cols: F),
                 isLinear: isLinear)
         }
+
+        if ProcessInfo.processInfo.environment["MFERENCE_MTP"] != "0" {
+            self.mtp = try Qwen38MTPSpeculator.probe(model: model,
+                                                     context: context,
+                                                     config: cfg,
+                                                     kv: kv,
+                                                     gdnState: gdnState,
+                                                     layers: layers,
+                                                     maxContext: maxContext,
+                                                     mlpWeightBits: mlpWeightBits)
+        }
     }
 
     private static func validate(config: ArchConfig, maxContext: Int) throws {
@@ -360,12 +403,17 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
         prefillChunkState.reset()
         kv.reset()
         gdnState.reset()
+        mtp?.reset()
     }
 
     public var continuationPosition: Int { kv.position }
 
     public func prepareForContinuation(expectedPosition: Int) throws {
         try prefillChunkState.requireClean(operation: "prepareForContinuation")
+        // A speculative round may have committed verified tokens past the
+        // consumed stream; the speculator rewinds the KV/GDN state when the
+        // requested cursor falls inside its last verify span.
+        if let mtp { try mtp.prepareForContinuation(expectedPosition: expectedPosition) }
         guard expectedPosition > 0, expectedPosition == kv.position else {
             throw PrefillError.prefillCursorMismatch(
                 "Qwen 3.8 continuation cursor \(expectedPosition) does not match \(kv.position)")
@@ -373,6 +421,22 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
     }
 
     public func produce(token: Int32, position: Int, into logits: MTLBuffer) async throws {
+        if let mtp, useFusedGreedyHead {
+            if let queued = try mtp.consumePending(token: token, position: position) {
+                lastGreedyToken = queued
+                return
+            }
+            if mtp.canRunRound(position: position) {
+                try prefillChunkState.requireClean(operation: "produce")
+                try Task.checkCancellation()
+                guard token >= 0, token < Int32(cfg.vocabSize) else {
+                    throw Qwen38ForwardRunnerError.invalidInput(
+                        "Qwen 3.8 token is outside the vocabulary")
+                }
+                lastGreedyToken = try mtp.runRound(bonus: token, position: position)
+                return
+            }
+        }
         try await produceToken(token: token, position: position, into: logits,
                                emitHead: true, outputMode: .greedyIfAvailable)
     }
@@ -574,6 +638,16 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
                             biases: lm.buffer, biasesOffset: Int(lm.biasOffset),
                             x: normed, y: logits,
                             m: UInt32(cfg.vocabSize), n: UInt32(D))
+            }
+            if let mtp {
+                // Seed the drafter's hidden input with the last prompt
+                // position's final-norm row.
+                rms.encodeBF16W(commandBuffer: cb,
+                                x: scratch.hidden, xOffset: lastRowOffset,
+                                weight: fNorm.buffer,
+                                weightOffset: Int(fNorm.offset),
+                                out: mtp.lastHiddenBuf,
+                                d: UInt32(D), eps: Self.epsilon)
             }
         }
 
@@ -957,6 +1031,10 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
                               outputMode: PrefillOutputMode) async throws {
         try prefillChunkState.requireClean(operation: "produce")
         try Task.checkCancellation()
+        if let mtp, mtp.hasPending {
+            throw Qwen38ForwardRunnerError.invalidInput(
+                "Qwen 3.8 decode step with unconsumed speculative tokens; reset or continue first")
+        }
         guard position == kv.position, position >= 0, position < maxContext else {
             throw Qwen38ForwardRunnerError.invalidInput(
                 "Qwen 3.8 position \(position) does not match its KV cursor \(kv.position)")
@@ -1058,6 +1136,17 @@ public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowR
                                               outToken: greedyTokenBuf,
                                               d: D, vocab: UInt32(cfg.vocabSize),
                                               rmsEps: Self.epsilon)
+            }
+            if let mtp {
+                // The drafter consumes the target's final-norm hidden of the
+                // last processed position; keep it current so a spec round
+                // can start after any plain decode step.
+                rms.encodeBF16W(commandBuffer: cb,
+                                x: hidden,
+                                weight: fNorm.buffer,
+                                weightOffset: Int(fNorm.offset),
+                                out: mtp.lastHiddenBuf,
+                                d: D, eps: Self.epsilon)
             }
         }
 

--- a/Sources/Mference/Runtime/Inference/Qwen38ForwardRunner.swift
+++ b/Sources/Mference/Runtime/Inference/Qwen38ForwardRunner.swift
@@ -1,0 +1,636 @@
+import Foundation
+import Metal
+
+public enum Qwen38ForwardRunnerError: Error, CustomStringConvertible {
+    case invalidConfiguration(String)
+    case invalidInput(String)
+    case commandFailed(String)
+
+    public var description: String {
+        switch self {
+        case .invalidConfiguration(let message), .invalidInput(let message),
+             .commandFailed(let message):
+            return message
+        }
+    }
+}
+
+/// Qwen 3.8 dense decode pass. One instance owns mutable KV / GDN / scratch
+/// state and is serial.
+///
+/// The architecture is the Qwen 3.6 layer graph with the MoE branch deleted:
+///
+///   embed_lookup_int4(token)                       // out_scale 1.0
+///   for L in 0..<64:
+///     a = rmsnorm_bf16w(h, input_layernorm)
+///     attn = (mask 2) gated-DeltaNet linear attention(a)      // FP32 state
+///          | (mask 1) gated full attention(a)                 // packed
+///            [query ; gate] q_proj, per-head q/k norm, NeoX sub-dim RoPE
+///            over 64 of 256 dims, sigmoid(gate) before o_proj
+///     h += attn
+///     m = rmsnorm_bf16w(h, post_attention_layernorm)
+///     h += SwiGLU(m)                               // one dense MLP per layer
+///   head = greedy fused lm_head | full-logits GEMV over rmsnorm(h)
+///
+/// Every weight is resident (`numExperts == 0`: the expert streamer never
+/// opens), so a decode step encodes into a single command buffer with no
+/// CPU readback between layers. Prefill v1 is sequential decode replay —
+/// exact by construction; layer-major chunking is a follow-up.
+public final class Qwen38ForwardRunner: ContinuableLogitProducer, ContextWindowReporting,
+    ChunkedPrefillRunner, HeadlessSequentialPrefillRunner, ExactPrefillLogitProducer,
+    FusedHeadLogitProducer, @unchecked Sendable {
+
+    /// Every per-layer TensorView, resolved once at init so the decode hot
+    /// path never touches the resident-index dictionary.
+    private struct LayerTensors {
+        let inputNorm: TensorView
+        let postAttnNorm: TensorView
+        // Full-attention layers (mask 1) only.
+        let q: TensorView?
+        let k: TensorView?
+        let v: TensorView?
+        let o: TensorView?
+        let qNorm: TensorView?
+        let kNorm: TensorView?
+        // Gated-DeltaNet layers (mask 2) only.
+        let linQKV: TensorView?
+        let linZ: TensorView?
+        let linA: TensorView?
+        let linB: TensorView?
+        let linOut: TensorView?
+        let linConv: TensorView?
+        let linALog: TensorView?
+        let linDtBias: TensorView?
+        let linNorm: TensorView?
+        // Dense SwiGLU MLP (every layer; served by the sharedExpert accessors).
+        let mlpGate: SharedExpertProjection
+        let mlpUp: SharedExpertProjection
+        let mlpDown: SharedExpertProjection
+        let isLinear: Bool
+    }
+
+    private let model: Model
+    private let ctx: MetalContext
+    private let cfg: ArchConfig
+    private let kv: KVCacheManager
+    private let gdnState: GDNStateManager
+
+    // Kernels
+    private let embedInt4: EmbedLookupInt4
+    private let rms: RMSNorm
+    private let int4: DequantInt4GEMV
+    private let attention: Attention
+    private let elementwise: Elementwise
+    private let rope: RoPE
+    private let gdn: GDN
+    private let mlp: SharedExpertRuntime
+    private let fusionHead: LMHeadChainInt4
+    private let fusedQKVGEMV: FusedQKVGEMV
+    private let layers: [LayerTensors]
+
+    // Decode scratch, allocated once. FP16 unless noted. At production shape
+    // (D 5120, F 17408, qDim 24*256 = 6144, gdn qkvDim 10240, valueDim 6144)
+    // the whole set is ~293 KB:
+    //   5 x D vectors (hidden/normed/mlpX/oOut/mlpOut)          50 KB
+    //   packed q + q + gate + attn out (2*qDim + 3*qDim)        60 KB
+    //   3 x F MLP intermediates                                102 KB
+    //   gdn qkv + conv (2 x qkvDim) + z/y/out (3 x valueDim)
+    //     + a/b (2 x numVHeads)                                 76 KB
+    private let hidden: MTLBuffer         // [D]
+    private let normed: MTLBuffer         // [D] input_layernorm output
+    private let mlpX: MTLBuffer           // [D] post_attention_layernorm output
+    private let oOut: MTLBuffer           // [D] attention-branch output
+    private let mlpOut: MTLBuffer         // [D] dense MLP output
+    private let qPackedScratch: MTLBuffer // [2 * qDim] packed [query ; gate]
+    private let qScratch: MTLBuffer       // [qDim]
+    private let attnGateScratch: MTLBuffer // [qDim]
+    private let attnOut: MTLBuffer        // [qDim]
+    private let mlpScratchGate: MTLBuffer // [F]
+    private let mlpScratchUp: MTLBuffer   // [F]
+    private let mlpScratchAct: MTLBuffer  // [F]
+    private let gdnQKVRaw: MTLBuffer      // [qkvDim] raw in_proj_qkv output
+    private let gdnConvOut: MTLBuffer     // [qkvDim] conv + SiLU output
+    private let gdnZ: MTLBuffer           // [valueDim]
+    private let gdnA: MTLBuffer           // [numVHeads]
+    private let gdnB: MTLBuffer           // [numVHeads]
+    private let gdnY: MTLBuffer           // [valueDim] delta-rule output
+    private let gdnOut: MTLBuffer         // [valueDim] gated-norm output
+    private let greedyTokenBuf: MTLBuffer // [1] UInt32 fused-head output
+
+    public let maxContext: Int
+    private let useFusedGreedyHead: Bool
+    public private(set) var lastGreedyToken: UInt32 = 0
+    public var usesFusedGreedyHead: Bool { useFusedGreedyHead }
+
+    private static let epsilon: Float = 1e-6
+
+    public init(model: Model, context: MetalContext, maxContext: Int,
+                runtimeConfiguration: RuntimeConfiguration = .production) throws {
+        let cfg = model.config
+        try Self.validate(config: cfg, maxContext: maxContext)
+        self.model = model
+        self.ctx = context
+        self.cfg = cfg
+        self.maxContext = maxContext
+        self.useFusedGreedyHead = runtimeConfiguration.headPath == .fusedRows
+        self.kv = try KVCacheManager(device: context.device,
+                                     config: cfg,
+                                     maxContext: maxContext,
+                                     fp16RingEnabled: runtimeConfiguration.fp16RingEnabled,
+                                     slidingWindow: cfg.slidingWindow,
+                                     maxPrefillChunkTokens: runtimeConfiguration.prefillConfig.chunkTokens)
+        self.gdnState = try GDNStateManager(device: context.device, config: cfg)
+
+        self.embedInt4 = try EmbedLookupInt4(context: context)
+        self.rms = try RMSNorm(context: context)
+        self.int4 = try DequantInt4GEMV(context: context,
+                                        additionalShapes: cfg.decodeInt4GEMVShapes)
+        self.attention = try Attention(context: context)
+        self.elementwise = try Elementwise(context: context)
+        self.rope = try RoPE(context: context)
+        self.gdn = try GDN(context: context, config: cfg.linearAttention,
+                           specializedHiddenSize: cfg.hiddenSize)
+        self.mlp = try SharedExpertRuntime(context: context,
+                                           weightBits: model.sharedExpertWeightBits,
+                                           siluActivation: cfg.hiddenActivation == "silu",
+                                           specializedD: cfg.hiddenSize,
+                                           specializedF: cfg.intermediateSize)
+        self.fusionHead = try LMHeadChainInt4(context: context,
+                                              maxD: cfg.hiddenSize,
+                                              maxVocab: cfg.vocabSize)
+        self.fusedQKVGEMV = try FusedQKVGEMV(context: context)
+
+        let device = context.device
+        func buf(_ elements: Int, _ stride: Int = MemoryLayout<Float16>.stride) throws -> MTLBuffer {
+            guard let made = device.makeBuffer(length: max(elements, 1) * stride,
+                                               options: .storageModeShared) else {
+                throw Qwen38ForwardRunnerError.invalidConfiguration(
+                    "unable to allocate Qwen 3.8 runtime scratch")
+            }
+            return made
+        }
+        let D = cfg.hiddenSize
+        let F = cfg.intermediateSize
+        let qDim = cfg.numHeads * cfg.fullHeadDim
+        let la = cfg.linearAttention
+        self.hidden = try buf(D)
+        self.normed = try buf(D)
+        self.mlpX = try buf(D)
+        self.oOut = try buf(D)
+        self.mlpOut = try buf(D)
+        self.qPackedScratch = try buf(2 * qDim)
+        self.qScratch = try buf(qDim)
+        self.attnGateScratch = try buf(qDim)
+        self.attnOut = try buf(qDim)
+        self.mlpScratchGate = try buf(F)
+        self.mlpScratchUp = try buf(F)
+        self.mlpScratchAct = try buf(F)
+        self.gdnQKVRaw = try buf(la.qkvDim)
+        self.gdnConvOut = try buf(la.qkvDim)
+        self.gdnZ = try buf(la.valueDim)
+        self.gdnA = try buf(la.numVHeads)
+        self.gdnB = try buf(la.numVHeads)
+        self.gdnY = try buf(la.valueDim)
+        self.gdnOut = try buf(la.valueDim)
+        self.greedyTokenBuf = try buf(1, MemoryLayout<UInt32>.stride)
+
+        func projection(_ view: TensorView, rows: Int, cols: Int) -> SharedExpertProjection {
+            SharedExpertProjection(weights: view.buffer,
+                                   scales: view.buffer,
+                                   biases: view.buffer,
+                                   weightsOffset: Int(view.offset),
+                                   scalesOffset: Int(view.scaleOffset),
+                                   biasesOffset: Int(view.biasOffset),
+                                   rows: UInt32(rows),
+                                   cols: UInt32(cols))
+        }
+        self.layers = try (0..<cfg.numLayers).map { L in
+            let isLinear = cfg.layerIsLinear(L)
+            return LayerTensors(
+                inputNorm: try model.inputNorm(layer: L),
+                postAttnNorm: try model.postAttnNorm(layer: L),
+                q: isLinear ? nil : try model.qProj(layer: L),
+                k: isLinear ? nil : try model.kProj(layer: L),
+                v: isLinear ? nil : try model.vProj(layer: L),
+                o: isLinear ? nil : try model.oProj(layer: L),
+                qNorm: isLinear ? nil : try model.qNorm(layer: L),
+                kNorm: isLinear ? nil : try model.kNorm(layer: L),
+                linQKV: isLinear ? try model.linearInProjQKV(layer: L) : nil,
+                linZ: isLinear ? try model.linearInProjZ(layer: L) : nil,
+                linA: isLinear ? try model.linearInProjA(layer: L) : nil,
+                linB: isLinear ? try model.linearInProjB(layer: L) : nil,
+                linOut: isLinear ? try model.linearOutProj(layer: L) : nil,
+                linConv: isLinear ? try model.linearConv1d(layer: L) : nil,
+                linALog: isLinear ? try model.linearALog(layer: L) : nil,
+                linDtBias: isLinear ? try model.linearDtBias(layer: L) : nil,
+                linNorm: isLinear ? try model.linearNorm(layer: L) : nil,
+                mlpGate: projection(try model.sharedExpertGate(layer: L), rows: F, cols: D),
+                mlpUp: projection(try model.sharedExpertUp(layer: L), rows: F, cols: D),
+                mlpDown: projection(try model.sharedExpertDown(layer: L), rows: D, cols: F),
+                isLinear: isLinear)
+        }
+    }
+
+    private static func validate(config: ArchConfig, maxContext: Int) throws {
+        guard config.family == .qwen38 else {
+            throw Qwen38ForwardRunnerError.invalidConfiguration(
+                "Qwen38ForwardRunner requires the qwen38 family")
+        }
+        guard config.numExperts == 0, config.attnOutputGate,
+              config.hasLinearAttentionLayers, config.ropeNeoxSubdim,
+              !config.ffnSandwichNorms, !config.sharedExpertGated,
+              config.intermediateSize > 0 else {
+            throw Qwen38ForwardRunnerError.invalidConfiguration(
+                "model does not match the dense Qwen 3.8 layer graph")
+        }
+        guard maxContext > 0 else {
+            throw Qwen38ForwardRunnerError.invalidConfiguration(
+                "Qwen 3.8 runtime context must be positive")
+        }
+    }
+
+    // MARK: - LogitProducer
+
+    public func reset() {
+        kv.reset()
+        gdnState.reset()
+    }
+
+    public var continuationPosition: Int { kv.position }
+
+    public func prepareForContinuation(expectedPosition: Int) throws {
+        guard expectedPosition > 0, expectedPosition == kv.position else {
+            throw PrefillError.prefillCursorMismatch(
+                "Qwen 3.8 continuation cursor \(expectedPosition) does not match \(kv.position)")
+        }
+    }
+
+    public func produce(token: Int32, position: Int, into logits: MTLBuffer) async throws {
+        try await produceToken(token: token, position: position, into: logits,
+                               emitHead: true, outputMode: .greedyIfAvailable)
+    }
+
+    func produceWithoutLogits(token: Int32, position: Int) async throws {
+        try await produceToken(token: token, position: position, into: nil,
+                               emitHead: false, outputMode: .logits)
+    }
+
+    func produceExactPrefill(token: Int32, position: Int, into logits: MTLBuffer) async throws {
+        try await produceToken(token: token, position: position, into: logits,
+                               emitHead: true, outputMode: .logits)
+    }
+
+    // MARK: - Prefill (v1: sequential decode replay)
+
+    /// Sequential decode-path replay: each prompt token runs the full decode
+    /// step, heads suppressed until the last token. Exact by construction —
+    /// prefill and decode share every kernel and all recurrent state. The
+    /// chunked layer-major path is a follow-up; `config.chunkTokens` only
+    /// affects progress granularity here.
+    func prefillChunked(tokens: ArraySlice<Int32>,
+                        startPosition: Int,
+                        outputMode: PrefillOutputMode,
+                        config: PrefillRuntimeConfig,
+                        into logits: MTLBuffer,
+                        onProgress: (Int) -> Void) async throws -> PrefillResult {
+        guard config.mode == .chunked else {
+            throw PrefillError.chunkedUnsupported(
+                "Qwen 3.8 prefillChunked requires PrefillRuntimeConfig.mode == .chunked")
+        }
+        guard startPosition >= 0, startPosition == kv.position else {
+            throw PrefillError.chunkedUnsupported(
+                "Qwen 3.8 prefill cursor \(kv.position) != startPosition \(startPosition)")
+        }
+        guard tokens.count <= maxContext - startPosition else {
+            throw PrefillError.chunkedUnsupported(
+                "Qwen 3.8 prefill range starting at \(startPosition) with \(tokens.count) tokens exceeds maxContext \(maxContext)")
+        }
+        guard !tokens.isEmpty else {
+            return PrefillResult(newPosition: startPosition, seed: .logitsWritten)
+        }
+
+        var position = startPosition
+        var index = 0
+        for token in tokens {
+            try Task.checkCancellation()
+            let isLast = index == tokens.count - 1
+            try await produceToken(token: token, position: position,
+                                   into: logits,
+                                   emitHead: isLast,
+                                   outputMode: outputMode)
+            position += 1
+            index += 1
+            if index % 16 == 0 { onProgress(index) }
+        }
+        onProgress(tokens.count)
+        if outputMode == .greedyIfAvailable, useFusedGreedyHead {
+            return PrefillResult(newPosition: position, seed: .greedyToken(lastGreedyToken))
+        }
+        return PrefillResult(newPosition: position, seed: .logitsWritten)
+    }
+
+    // MARK: - Decode step
+
+    /// One full decode step, encoded into a single command buffer: no router
+    /// readback exists in this architecture, so nothing forces a mid-layer
+    /// CPU round-trip.
+    private func produceToken(token: Int32,
+                              position: Int,
+                              into logits: MTLBuffer?,
+                              emitHead: Bool,
+                              outputMode: PrefillOutputMode) async throws {
+        try Task.checkCancellation()
+        guard position == kv.position, position >= 0, position < maxContext else {
+            throw Qwen38ForwardRunnerError.invalidInput(
+                "Qwen 3.8 position \(position) does not match its KV cursor \(kv.position)")
+        }
+        guard token >= 0, token < Int32(cfg.vocabSize) else {
+            throw Qwen38ForwardRunnerError.invalidInput(
+                "Qwen 3.8 token is outside the vocabulary")
+        }
+        let emitLogitsHead = emitHead
+            && !(useFusedGreedyHead && outputMode == .greedyIfAvailable)
+        if emitLogitsHead {
+            guard let logits,
+                  logits.length >= cfg.vocabSize * MemoryLayout<Float16>.stride else {
+                throw Qwen38ForwardRunnerError.invalidInput(
+                    "Qwen 3.8 logits buffer is too small")
+            }
+        }
+
+        let D = UInt32(cfg.hiddenSize)
+        let cb = try commandBuffer()
+
+        let emb = model.embedding
+        embedInt4.encode(commandBuffer: cb,
+                         table: emb.buffer, tableOffset: Int(emb.offset),
+                         scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
+                         biases: emb.buffer, biasesOffset: Int(emb.biasOffset),
+                         out: hidden,
+                         tokenId: UInt32(bitPattern: token),
+                         d: D,
+                         outScale: 1.0)
+
+        for (index, layer) in layers.enumerated() {
+            rms.encodeBF16W(commandBuffer: cb,
+                            x: hidden,
+                            weight: layer.inputNorm.buffer,
+                            weightOffset: Int(layer.inputNorm.offset),
+                            out: normed,
+                            d: D, eps: Self.epsilon)
+            if layer.isLinear {
+                encodeLinearAttentionDecode(cb, layer: layer, layerIndex: index)
+            } else {
+                encodeGatedFullAttentionDecode(cb, layer: layer,
+                                               layerIndex: index,
+                                               position: position,
+                                               seqLen: UInt32(position + 1))
+            }
+            elementwise.encodeResidualAdd(commandBuffer: cb,
+                                          hidden: hidden,
+                                          delta: oOut,
+                                          count: cfg.hiddenSize)
+            rms.encodeBF16W(commandBuffer: cb,
+                            x: hidden,
+                            weight: layer.postAttnNorm.buffer,
+                            weightOffset: Int(layer.postAttnNorm.offset),
+                            out: mlpX,
+                            d: D, eps: Self.epsilon)
+            try mlp.encode(commandBuffer: cb,
+                           x: mlpX,
+                           gate: layer.mlpGate,
+                           up: layer.mlpUp,
+                           down: layer.mlpDown,
+                           y: mlpOut,
+                           scratchGate: mlpScratchGate,
+                           scratchUp: mlpScratchUp,
+                           scratchAct: mlpScratchAct)
+            elementwise.encodeResidualAdd(commandBuffer: cb,
+                                          hidden: hidden,
+                                          delta: mlpOut,
+                                          count: cfg.hiddenSize)
+        }
+
+        if emitHead {
+            let fNorm = model.finalNorm
+            let lm = model.lmHead
+            if emitLogitsHead, let logits {
+                rms.encodeBF16W(commandBuffer: cb,
+                                x: hidden,
+                                weight: fNorm.buffer,
+                                weightOffset: Int(fNorm.offset),
+                                out: normed,
+                                d: D, eps: Self.epsilon)
+                int4.encode(commandBuffer: cb,
+                            weights: lm.buffer, weightsOffset: Int(lm.offset),
+                            scales: lm.buffer, scalesOffset: Int(lm.scaleOffset),
+                            biases: lm.buffer, biasesOffset: Int(lm.biasOffset),
+                            x: normed, y: logits,
+                            m: UInt32(cfg.vocabSize), n: D)
+            } else {
+                fusionHead.encodeGreedyDecode(commandBuffer: cb,
+                                              hidden: hidden,
+                                              normWeight: fNorm.buffer,
+                                              normOffset: Int(fNorm.offset),
+                                              weights: lm.buffer,
+                                              weightsOffset: Int(lm.offset),
+                                              scales: lm.buffer,
+                                              scalesOffset: Int(lm.scaleOffset),
+                                              biases: lm.buffer,
+                                              biasesOffset: Int(lm.biasOffset),
+                                              outToken: greedyTokenBuf,
+                                              d: D, vocab: UInt32(cfg.vocabSize),
+                                              rmsEps: Self.epsilon)
+            }
+        }
+
+        try finish(cb)
+        if emitHead, !emitLogitsHead {
+            lastGreedyToken = greedyTokenBuf.contents().load(as: UInt32.self)
+        }
+        kv.advance()
+    }
+
+    /// Gated-DeltaNet linear attention (layer mask 2), one decode step. Reads
+    /// `normed`, updates the layer's recurrent state + conv tail in place,
+    /// and leaves the attention-branch output in `oOut`. Hv 48 != the fused
+    /// `_qwen` kernels' Hv 32, so `encodeDeltaGatedDecode` declines and the
+    /// generic delta step + gated norm run instead.
+    private func encodeLinearAttentionDecode(_ cb: MTLCommandBuffer,
+                                             layer: LayerTensors,
+                                             layerIndex: Int) {
+        guard let qkvW = layer.linQKV, let zW = layer.linZ,
+              let aW = layer.linA, let bW = layer.linB,
+              let outW = layer.linOut, let convW = layer.linConv,
+              let aLog = layer.linALog, let dtBias = layer.linDtBias,
+              let gatedNormW = layer.linNorm else {
+            preconditionFailure("linear-attention layer without GDN tensors")
+        }
+        let la = cfg.linearAttention
+        let D = UInt32(cfg.hiddenSize)
+
+        // One dispatch over the concatenated qkv/z/a/b row space instead of
+        // four separate GEMVs.
+        gdn.encodeInputProjections(commandBuffer: cb,
+                                   x: normed,
+                                   qkv: qkvW, qkvOut: gdnQKVRaw,
+                                   z: zW, zOut: gdnZ,
+                                   a: aW, aOut: gdnA,
+                                   b: bW, bOut: gdnB,
+                                   hiddenSize: cfg.hiddenSize)
+        gdn.encodeConvDecode(commandBuffer: cb,
+                             tail: gdnState.convTailBuffer(layer: layerIndex),
+                             qkv: gdnQKVRaw,
+                             convWeight: convW.buffer,
+                             convWeightOffset: Int(convW.offset),
+                             out: gdnConvOut)
+        gdn.encodeQKNorm(commandBuffer: cb, convOut: gdnConvOut)
+        let usedFusedDeltaNorm = gdn.encodeDeltaGatedDecode(
+            commandBuffer: cb,
+            convOut: gdnConvOut,
+            aProj: gdnA,
+            bProj: gdnB,
+            aLog: aLog.buffer, aLogOffset: Int(aLog.offset),
+            dtBias: dtBias.buffer, dtBiasOffset: Int(dtBias.offset),
+            state: gdnState.stateBuffer(layer: layerIndex),
+            z: gdnZ,
+            weight: gatedNormW.buffer, weightOffset: Int(gatedNormW.offset),
+            out: gdnOut)
+        if !usedFusedDeltaNorm {
+            gdn.encodeDeltaStepDecode(commandBuffer: cb,
+                                      convOut: gdnConvOut,
+                                      aProj: gdnA,
+                                      bProj: gdnB,
+                                      aLog: aLog.buffer, aLogOffset: Int(aLog.offset),
+                                      dtBias: dtBias.buffer, dtBiasOffset: Int(dtBias.offset),
+                                      state: gdnState.stateBuffer(layer: layerIndex),
+                                      y: gdnY)
+            gdn.encodeGatedNorm(commandBuffer: cb,
+                                y: gdnY,
+                                z: gdnZ,
+                                weight: gatedNormW.buffer,
+                                weightOffset: Int(gatedNormW.offset),
+                                out: gdnOut)
+        }
+        int4.encode(commandBuffer: cb,
+                    weights: outW.buffer, weightsOffset: Int(outW.offset),
+                    scales: outW.buffer, scalesOffset: Int(outW.scaleOffset),
+                    biases: outW.buffer, biasesOffset: Int(outW.biasOffset),
+                    x: gdnOut, y: oOut, m: D, n: UInt32(la.valueDim))
+    }
+
+    /// Qwen full attention (attn_output_gate), one decode step: packed
+    /// [query ; gate] q_proj split per head, weighted per-head q/k norms
+    /// (no V norm), NeoX sub-dim RoPE over headDim * partialRotaryFactor
+    /// dims, full attention at the configured scale, sigmoid output gate,
+    /// then o_proj into `oOut`.
+    private func encodeGatedFullAttentionDecode(_ cb: MTLCommandBuffer,
+                                                layer: LayerTensors,
+                                                layerIndex: Int,
+                                                position: Int,
+                                                seqLen: UInt32) {
+        guard let q = layer.q, let k = layer.k, let v = layer.v, let o = layer.o,
+              let qNormW = layer.qNorm, let kNormW = layer.kNorm else {
+            preconditionFailure("full-attention layer without attention tensors")
+        }
+        let D = UInt32(cfg.hiddenSize)
+        let headDim = cfg.fullHeadDim
+        let numKV = cfg.numFullKVHeads
+        let qDim = UInt32(cfg.numHeads * headDim)
+        let kvDim = UInt32(numKV * headDim)
+        let kSlot = kv.kSlot(layer: layerIndex, position: position)
+        let vSlot = kv.vSlot(layer: layerIndex, position: position)
+        let rotaryDim = UInt32(Double(headDim) * cfg.partialRotaryFactor)
+
+        fusedQKVGEMV.encode(commandBuffer: cb,
+                            qWeights: q.buffer, qWeightsOffset: Int(q.offset),
+                            qScales: q.buffer, qScalesOffset: Int(q.scaleOffset),
+                            qBiases: q.buffer, qBiasesOffset: Int(q.biasOffset),
+                            kWeights: k.buffer, kWeightsOffset: Int(k.offset),
+                            kScales: k.buffer, kScalesOffset: Int(k.scaleOffset),
+                            kBiases: k.buffer, kBiasesOffset: Int(k.biasOffset),
+                            vWeights: v.buffer, vWeightsOffset: Int(v.offset),
+                            vScales: v.buffer, vScalesOffset: Int(v.scaleOffset),
+                            vBiases: v.buffer, vBiasesOffset: Int(v.biasOffset),
+                            x: normed,
+                            qOut: qPackedScratch,
+                            kOut: kSlot.buffer, kOutOffset: kSlot.offset,
+                            vOut: vSlot.buffer, vOutOffset: vSlot.offset,
+                            qRows: 2 * qDim,
+                            kvRows: kvDim,
+                            n: D)
+        elementwise.encodeSplitQGate(commandBuffer: cb,
+                                     packed: qPackedScratch,
+                                     q: qScratch,
+                                     gate: attnGateScratch,
+                                     heads: cfg.numHeads,
+                                     dim: headDim)
+        rms.encodeBF16WPerHead(commandBuffer: cb,
+                               x: qScratch,
+                               weight: qNormW.buffer,
+                               weightOffset: Int(qNormW.offset),
+                               out: qScratch,
+                               headDim: UInt32(headDim),
+                               numHeads: cfg.numHeads,
+                               eps: Self.epsilon)
+        rms.encodeBF16WPerHead(commandBuffer: cb,
+                               x: kSlot.buffer, xOffset: kSlot.offset,
+                               weight: kNormW.buffer,
+                               weightOffset: Int(kNormW.offset),
+                               out: kSlot.buffer, outOffset: kSlot.offset,
+                               headDim: UInt32(headDim),
+                               numHeads: numKV,
+                               eps: Self.epsilon)
+        rope.encodeNeoxSubdim(commandBuffer: cb,
+                              data: qScratch,
+                              position: UInt32(position),
+                              headDim: UInt32(headDim),
+                              numHeads: UInt32(cfg.numHeads),
+                              rotaryDim: rotaryDim,
+                              theta: Float(cfg.fullRopeTheta))
+        rope.encodeNeoxSubdim(commandBuffer: cb,
+                              data: kSlot.buffer,
+                              dataOffset: kSlot.offset,
+                              position: UInt32(position),
+                              headDim: UInt32(headDim),
+                              numHeads: UInt32(numKV),
+                              rotaryDim: rotaryDim,
+                              theta: Float(cfg.fullRopeTheta))
+        attention.encodeFull(commandBuffer: cb,
+                             q: qScratch,
+                             k: kSlot.buffer, kOffset: 0,
+                             v: vSlot.buffer, vOffset: 0,
+                             out: attnOut,
+                             headDim: UInt32(headDim),
+                             numQHeads: UInt32(cfg.numHeads),
+                             numKVHeads: UInt32(numKV),
+                             seqLen: seqLen,
+                             scale: Float(cfg.attentionScale))
+        elementwise.encodeSigmoidGateMul(commandBuffer: cb,
+                                         out: attnOut,
+                                         gate: attnGateScratch,
+                                         count: Int(qDim))
+        int4.encode(commandBuffer: cb,
+                    weights: o.buffer, weightsOffset: Int(o.offset),
+                    scales: o.buffer, scalesOffset: Int(o.scaleOffset),
+                    biases: o.buffer, biasesOffset: Int(o.biasOffset),
+                    x: attnOut, y: oOut, m: D, n: qDim)
+    }
+
+    private func commandBuffer() throws -> MTLCommandBuffer {
+        guard let cb = ctx.queue.makeCommandBuffer() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 command buffer")
+        }
+        return cb
+    }
+
+    private func finish(_ cb: MTLCommandBuffer) throws {
+        cb.commit()
+        cb.waitUntilCompleted()
+        guard cb.status == .completed else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                cb.error?.localizedDescription ?? "Qwen 3.8 command buffer did not complete")
+        }
+    }
+}

--- a/Sources/Mference/Runtime/Inference/Qwen38MTPSpeculator.swift
+++ b/Sources/Mference/Runtime/Inference/Qwen38MTPSpeculator.swift
@@ -1,0 +1,1354 @@
+import Foundation
+import Metal
+
+/// Greedy speculative decoding for the Qwen 3.8 dense family using the
+/// checkpoint's native MTP (multi-token-prediction) draft layer.
+///
+/// Per round, with the last committed token `b` at position `P`:
+///
+///  1. **Draft** `k` tokens by iterating the MTP layer (one full-attention
+///     block that consumes `fc(concat(norm_e(embed(tok)), norm_h(hidden)))`,
+///     sharing the target's embedding and lm_head — mlx-vlm
+///     `Qwen3_5MTPDraftModel` semantics).
+///  2. **Verify** all `k+1` tokens `[b, d0..dk-1]` in ONE target pass built
+///     from decode-exact kernels: every weight-consuming projection runs the
+///     multi-token GEMV (`DequantInt4GEMVMultiX`, weights read once,
+///     per-token math bit-identical to the decode GEMV) and every stateful
+///     or reduction-order-sensitive step (attention, RoPE, per-head norms,
+///     the GDN conv/delta recurrence) runs the decode kernels per token.
+///     The per-position greedy head is `LMHeadGreedyMultiX`, bit-identical
+///     to the fused decode head. Emitted tokens are therefore byte-identical
+///     to plain decode for any draft quality.
+///  3. **Accept** the longest draft prefix matching the target argmaxes; the
+///     following token is the target's own argmax (standard bonus token).
+///  4. **Roll back** on partial acceptance: the GDN FP32 states and conv
+///     tails are captured per verified position into an arena during the
+///     verify pass, so rollback is a blit restore of the state after the
+///     last accepted row plus a KV cursor rewind. No replay pass.
+///
+/// The drafter's own KV cache is trimmed to the committed pair count each
+/// round and re-fed with exact (token, target-hidden) pairs, which also
+/// yields the next round's free "seed" draft token (mlx's
+/// `accept_verified_tokens` flow, simplified to always re-feed).
+final class Qwen38MTPSpeculator {
+
+    struct Stats {
+        var rounds = 0
+        var draftedTokens = 0
+        var acceptedTokens = 0
+        var emittedTokens = 0
+        var rollbacks = 0
+        var draftNanos: UInt64 = 0
+        var verifyNanos: UInt64 = 0
+        var acceptNanos: UInt64 = 0
+    }
+
+    /// Resolved MTP tensor views (`mtp.*` names in the resident index).
+    private struct Weights {
+        let fc: TensorView
+        let preFcNormEmbedding: TensorView
+        let preFcNormHidden: TensorView
+        let finalNorm: TensorView
+        let inputNorm: TensorView
+        let postAttnNorm: TensorView
+        let q: TensorView
+        let k: TensorView
+        let v: TensorView
+        let o: TensorView
+        let qNorm: TensorView
+        let kNorm: TensorView
+        let mlpGate: SharedExpertProjection
+        let mlpUp: SharedExpertProjection
+        let mlpDown: SharedExpertProjection
+    }
+
+    private let model: Model
+    private let ctx: MetalContext
+    private let cfg: ArchConfig
+    private let kv: KVCacheManager
+    private let gdnState: GDNStateManager
+    private let layers: [Qwen38ForwardRunner.LayerTensors]
+    private let maxContext: Int
+    private let mlpWeightBits: Int
+    private let weights: Weights
+
+    /// Scratch/arena capacity in draft tokens (`MFERENCE_MTP_K` at init).
+    let draftCapacity: Int
+    /// Number of draft tokens per round; test-adjustable up to the capacity.
+    var draftCount: Int {
+        didSet {
+            precondition(draftCount >= 1 && draftCount <= draftCapacity,
+                         "draftCount outside 1...\(draftCapacity)")
+        }
+    }
+
+    // Kernels (pipeline states are shared through the MetalContext cache).
+    private let embedInt4: EmbedLookupInt4
+    private let prefillEmbed: PrefillEmbedLookupInt4
+    private let rms: RMSNorm
+    private let prefillRMS: PrefillRMSNorm
+    private let int4: DequantInt4GEMV
+    private let multix: DequantInt4GEMVMultiX
+    private let attention: Attention
+    private let mtpAttention: Attention
+    private let elementwise: Elementwise
+    private let rope: RoPE
+    private let gdn: GDN
+    private let mtpMLP: SharedExpertRuntime
+    private let verifyMLPInt8: SharedExpertRuntime?
+    private let siluMulPSO: MTLComputePipelineState
+    private let verifyHead: LMHeadGreedyMultiX
+    private let draftHead: LMHeadChainInt4
+
+    // Verify scratch, `vT = draftCount + 1` rows.
+    private let vT: Int
+    private let vHidden: MTLBuffer      // [T, D]
+    private let vNormed: MTLBuffer      // [T, D]
+    private let vMlpX: MTLBuffer        // [T, D]
+    private let vOut1: MTLBuffer        // [T, D]
+    private let vMlpOut: MTLBuffer      // [T, D]
+    private let vQPacked: MTLBuffer     // [T, 2*qDim]
+    private let vQ: MTLBuffer           // [T, qDim]
+    private let vGate: MTLBuffer        // [T, qDim]
+    private let vAttnOut: MTLBuffer     // [T, qDim]
+    private let vKStage: MTLBuffer      // [T, kvDim]
+    private let vVStage: MTLBuffer      // [T, kvDim]
+    private let vMlpGate: MTLBuffer     // [T, F]
+    private let vMlpUp: MTLBuffer       // [T, F]
+    private let vMlpAct: MTLBuffer      // [T, F]
+    private let vGdnQKV: MTLBuffer      // [T, qkvDim]
+    private let vGdnConv: MTLBuffer     // [T, qkvDim]
+    private let vGdnZ: MTLBuffer        // [T, valueDim]
+    private let vGdnA: MTLBuffer        // [T, Hv]
+    private let vGdnB: MTLBuffer        // [T, Hv]
+    private let vGdnY: MTLBuffer        // [T, valueDim]
+    private let vGdnOut: MTLBuffer      // [T, valueDim]
+    private let normedHidden: MTLBuffer // [T, D] final-norm rows (verify)
+    private let verifyTokensBuf: MTLBuffer // [T] UInt32
+    private let tokenIdsBuf: MTLBuffer  // [max(T, R)] UInt32
+
+    // GDN rollback arena: `vT - 1` capture slots (state after verify rows
+    // 0..vT-2), each holding every linear layer's FP32 state + conv tail.
+    private let linearLayerIndex: [Int?] // layer -> dense linear ordinal
+    private let numLinearLayers: Int
+    private let stateArena: MTLBuffer
+    private let tailArena: MTLBuffer
+    private var arenaRoundBase = -1     // kv position of the last round's row 0
+    private var arenaCaptured = 0
+
+    // MTP layer state.
+    private let mtpKVDim: Int
+    private let mtpK: MTLBuffer         // [maxContext, kvDim]
+    private let mtpV: MTLBuffer         // [maxContext, kvDim]
+    private var mtpLen = 0              // committed pair entries
+    private var basePair = 0            // pair index of slot 0
+    private var started = false
+    private var haveSeed = false
+    private var seedToken: Int32 = 0
+    private let seedHiddenBuf: MTLBuffer // [D] post-mtp-norm hidden of the seed pair
+    let lastHiddenBuf: MTLBuffer         // [D] target final-norm hidden of the last processed position
+
+    // Draft scratch (single token).
+    private let dEmb: MTLBuffer         // [D]
+    private let dFcIn: MTLBuffer        // [2D]
+    private let dH: MTLBuffer           // [D]
+    private let dNormed: MTLBuffer      // [D]
+    private let dQPacked: MTLBuffer     // [2*qDim]
+    private let dQ: MTLBuffer           // [qDim]
+    private let dGate: MTLBuffer        // [qDim]
+    private let dAttnOut: MTLBuffer     // [qDim]
+    private let dOut1: MTLBuffer        // [D]
+    private let dMlpX: MTLBuffer        // [D]
+    private let dMlpGate: MTLBuffer     // [F]
+    private let dMlpUp: MTLBuffer       // [F]
+    private let dMlpAct: MTLBuffer      // [F]
+    private let dMlpOut: MTLBuffer      // [D]
+    private let dHOutA: MTLBuffer       // [D] ping
+    private let dHOutB: MTLBuffer       // [D] pong
+    private let dTokenBuf: MTLBuffer    // [1] UInt32
+
+    // Accept scratch, `aR = draftCount + 2` rows.
+    private let aR: Int
+    private let aEmb: MTLBuffer         // [R, D]
+    private let aEmbNorm: MTLBuffer     // [R, D]
+    private let aHiddenSrc: MTLBuffer   // [R, D]
+    private let aHidNorm: MTLBuffer     // [R, D]
+    private let aFcIn: MTLBuffer        // [R, 2D]
+    private let aH: MTLBuffer           // [R, D]
+    private let aNormed: MTLBuffer      // [R, D]
+    private let aQPacked: MTLBuffer     // [R, 2*qDim]
+    private let aQ: MTLBuffer           // [R, qDim]
+    private let aGate: MTLBuffer        // [R, qDim]
+    private let aAttnOut: MTLBuffer     // [R, qDim]
+    private let aOut1: MTLBuffer        // [R, D]
+    private let aMlpX: MTLBuffer        // [R, D]
+    private let aMlpGate: MTLBuffer     // [R, F]
+    private let aMlpUp: MTLBuffer       // [R, F]
+    private let aMlpAct: MTLBuffer      // [R, F]
+    private let aMlpOut: MTLBuffer      // [R, D]
+
+    // Pending verified tokens: produce(expectInput, position) -> emit.
+    private var pending: [(expectInput: Int32, emit: UInt32)] = []
+    private var pendingPosition = 0
+
+    private(set) var stats = Stats()
+
+    /// Test hook: supplies the draft tokens for a round instead of the MTP
+    /// layer (still `draftCount`-clamped). Byte-identity must hold for any
+    /// value this returns.
+    var draftOverride: ((_ round: Int, _ k: Int) -> [Int32])?
+
+    private static let epsilon: Float = 1e-6
+
+    /// Probe the resident index for MTP tensors; returns nil when the
+    /// install carries none (spec decode silently unavailable).
+    static func probe(model: Model,
+                      context: MetalContext,
+                      config: ArchConfig,
+                      kv: KVCacheManager,
+                      gdnState: GDNStateManager,
+                      layers: [Qwen38ForwardRunner.LayerTensors],
+                      maxContext: Int,
+                      mlpWeightBits: Int) throws -> Qwen38MTPSpeculator? {
+        guard (try? model.resident(name: "mtp.fc.weight")) != nil else { return nil }
+        return try Qwen38MTPSpeculator(model: model, context: context, config: config,
+                                       kv: kv, gdnState: gdnState, layers: layers,
+                                       maxContext: maxContext,
+                                       mlpWeightBits: mlpWeightBits)
+    }
+
+    private init(model: Model,
+                 context: MetalContext,
+                 config: ArchConfig,
+                 kv: KVCacheManager,
+                 gdnState: GDNStateManager,
+                 layers: [Qwen38ForwardRunner.LayerTensors],
+                 maxContext: Int,
+                 mlpWeightBits: Int) throws {
+        self.model = model
+        self.ctx = context
+        self.cfg = config
+        self.kv = kv
+        self.gdnState = gdnState
+        self.layers = layers
+        self.maxContext = maxContext
+        self.mlpWeightBits = mlpWeightBits
+
+        let D = config.hiddenSize
+        let F = config.intermediateSize
+        let qDim = config.numHeads * config.fullHeadDim
+        let kvDim = config.numFullKVHeads * config.fullHeadDim
+        self.mtpKVDim = kvDim
+
+        func view(_ name: String) throws -> TensorView {
+            try model.resident(name: "mtp.\(name)")
+        }
+        func projection(_ view: TensorView, rows: Int, cols: Int) -> SharedExpertProjection {
+            SharedExpertProjection(weights: view.buffer,
+                                   scales: view.buffer,
+                                   biases: view.buffer,
+                                   weightsOffset: Int(view.offset),
+                                   scalesOffset: Int(view.scaleOffset),
+                                   biasesOffset: Int(view.biasOffset),
+                                   rows: UInt32(rows),
+                                   cols: UInt32(cols))
+        }
+        self.weights = Weights(
+            fc: try view("fc.weight"),
+            preFcNormEmbedding: try view("pre_fc_norm_embedding.weight"),
+            preFcNormHidden: try view("pre_fc_norm_hidden.weight"),
+            finalNorm: try view("norm.weight"),
+            inputNorm: try view("layers.0.input_layernorm.weight"),
+            postAttnNorm: try view("layers.0.post_attention_layernorm.weight"),
+            q: try view("layers.0.self_attn.q_proj.weight"),
+            k: try view("layers.0.self_attn.k_proj.weight"),
+            v: try view("layers.0.self_attn.v_proj.weight"),
+            o: try view("layers.0.self_attn.o_proj.weight"),
+            qNorm: try view("layers.0.self_attn.q_norm.weight"),
+            kNorm: try view("layers.0.self_attn.k_norm.weight"),
+            mlpGate: projection(try view("layers.0.mlp.gate_proj.weight"), rows: F, cols: D),
+            mlpUp: projection(try view("layers.0.mlp.up_proj.weight"), rows: F, cols: D),
+            mlpDown: projection(try view("layers.0.mlp.down_proj.weight"), rows: D, cols: F))
+
+        let requestedK = ProcessInfo.processInfo.environment["MFERENCE_MTP_K"].flatMap(Int.init)
+        // Upper bound 6 keeps the GDN capture arena bounded (k slots of every
+        // linear layer's FP32 state) and the verify batch within the multi-x
+        // kernels' 8-token limit.
+        let capacity = min(max(requestedK ?? 3, 1), 6)
+        self.draftCapacity = capacity
+        self.draftCount = capacity
+        let vT = capacity + 1
+        let aR = capacity + 2
+        self.vT = vT
+        self.aR = aR
+
+        self.embedInt4 = try EmbedLookupInt4(context: context)
+        self.prefillEmbed = try PrefillEmbedLookupInt4(context: context)
+        self.rms = try RMSNorm(context: context)
+        self.prefillRMS = try PrefillRMSNorm(context: context)
+        self.int4 = try DequantInt4GEMV(context: context)
+        self.multix = try DequantInt4GEMVMultiX(context: context)
+        self.attention = try Attention(context: context)
+        self.mtpAttention = try Attention(context: context)
+        self.elementwise = try Elementwise(context: context)
+        self.rope = try RoPE(context: context)
+        self.gdn = try GDN(context: context, config: config.linearAttention,
+                           specializedHiddenSize: config.hiddenSize)
+        // MTP projections are always INT4 (the attach step quantizes them);
+        // the target MLP follows the install's attention quant.
+        self.mtpMLP = try SharedExpertRuntime(context: context, weightBits: 4,
+                                              siluActivation: config.hiddenActivation == "silu",
+                                              specializedD: D, specializedF: F)
+        self.verifyMLPInt8 = mlpWeightBits == 8
+            ? try SharedExpertRuntime(context: context, weightBits: 8,
+                                      siluActivation: config.hiddenActivation == "silu")
+            : nil
+        self.siluMulPSO = try context.pipeline(
+            config.hiddenActivation == "silu" ? "silu_mul_fp16" : "gelu_mul_fp16")
+        self.verifyHead = try LMHeadGreedyMultiX(context: context, maxVocab: config.vocabSize)
+        self.draftHead = try LMHeadChainInt4(context: context, maxD: D,
+                                             maxVocab: config.vocabSize)
+
+        let la = config.linearAttention
+        let device = context.device
+        func buf(_ elements: Int, _ label: String,
+                 stride: Int = MemoryLayout<Float16>.stride,
+                 options: MTLResourceOptions = .storageModeShared) throws -> MTLBuffer {
+            guard let made = device.makeBuffer(length: max(elements, 1) * stride,
+                                               options: options) else {
+                throw Qwen38ForwardRunnerError.invalidConfiguration(
+                    "unable to allocate Qwen 3.8 MTP scratch (\(label))")
+            }
+            made.label = "qwen38.mtp.\(label)"
+            return made
+        }
+
+        self.vHidden = try buf(vT * D, "v.hidden")
+        self.vNormed = try buf(vT * D, "v.normed")
+        self.vMlpX = try buf(vT * D, "v.mlpX")
+        self.vOut1 = try buf(vT * D, "v.out1")
+        self.vMlpOut = try buf(vT * D, "v.mlpOut")
+        self.vQPacked = try buf(vT * 2 * qDim, "v.qPacked")
+        self.vQ = try buf(vT * qDim, "v.q")
+        self.vGate = try buf(vT * qDim, "v.gate")
+        self.vAttnOut = try buf(vT * qDim, "v.attnOut")
+        self.vKStage = try buf(vT * kvDim, "v.kStage")
+        self.vVStage = try buf(vT * kvDim, "v.vStage")
+        self.vMlpGate = try buf(vT * F, "v.mlpGate")
+        self.vMlpUp = try buf(vT * F, "v.mlpUp")
+        self.vMlpAct = try buf(vT * F, "v.mlpAct")
+        self.vGdnQKV = try buf(vT * la.qkvDim, "v.gdnQKV")
+        self.vGdnConv = try buf(vT * la.qkvDim, "v.gdnConv")
+        self.vGdnZ = try buf(vT * la.valueDim, "v.gdnZ")
+        self.vGdnA = try buf(vT * la.numVHeads, "v.gdnA")
+        self.vGdnB = try buf(vT * la.numVHeads, "v.gdnB")
+        self.vGdnY = try buf(vT * la.valueDim, "v.gdnY")
+        self.vGdnOut = try buf(vT * la.valueDim, "v.gdnOut")
+        self.normedHidden = try buf(vT * D, "v.normedHidden")
+        self.verifyTokensBuf = try buf(vT, "v.tokens", stride: MemoryLayout<UInt32>.stride)
+        self.tokenIdsBuf = try buf(max(vT, aR), "tokenIds", stride: MemoryLayout<UInt32>.stride)
+
+        var linearIndex: [Int?] = []
+        var linearCount = 0
+        for layer in 0..<config.numLayers {
+            if config.layerIsLinear(layer) {
+                linearIndex.append(linearCount)
+                linearCount += 1
+            } else {
+                linearIndex.append(nil)
+            }
+        }
+        self.linearLayerIndex = linearIndex
+        self.numLinearLayers = linearCount
+        let stateBytes = gdnState.stateBytesPerLayer
+        let tailBytes = gdnState.convTailBytesPerLayer
+        let captureSlots = max(vT - 1, 1)
+        self.stateArena = try buf(captureSlots * linearCount * stateBytes, "gdn.stateArena",
+                                  stride: 1, options: .storageModePrivate)
+        self.tailArena = try buf(captureSlots * linearCount * tailBytes, "gdn.tailArena",
+                                 stride: 1, options: .storageModePrivate)
+
+        self.mtpK = try buf(maxContext * kvDim, "mtp.K")
+        self.mtpV = try buf(maxContext * kvDim, "mtp.V")
+        self.seedHiddenBuf = try buf(D, "mtp.seedHidden")
+        self.lastHiddenBuf = try buf(D, "mtp.lastHidden")
+
+        self.dEmb = try buf(D, "d.emb")
+        self.dFcIn = try buf(2 * D, "d.fcIn")
+        self.dH = try buf(D, "d.h")
+        self.dNormed = try buf(D, "d.normed")
+        self.dQPacked = try buf(2 * qDim, "d.qPacked")
+        self.dQ = try buf(qDim, "d.q")
+        self.dGate = try buf(qDim, "d.gate")
+        self.dAttnOut = try buf(qDim, "d.attnOut")
+        self.dOut1 = try buf(D, "d.out1")
+        self.dMlpX = try buf(D, "d.mlpX")
+        self.dMlpGate = try buf(F, "d.mlpGate")
+        self.dMlpUp = try buf(F, "d.mlpUp")
+        self.dMlpAct = try buf(F, "d.mlpAct")
+        self.dMlpOut = try buf(D, "d.mlpOut")
+        self.dHOutA = try buf(D, "d.hOutA")
+        self.dHOutB = try buf(D, "d.hOutB")
+        self.dTokenBuf = try buf(1, "d.token", stride: MemoryLayout<UInt32>.stride)
+
+        self.aEmb = try buf(aR * D, "a.emb")
+        self.aEmbNorm = try buf(aR * D, "a.embNorm")
+        self.aHiddenSrc = try buf(aR * D, "a.hiddenSrc")
+        self.aHidNorm = try buf(aR * D, "a.hidNorm")
+        self.aFcIn = try buf(aR * 2 * D, "a.fcIn")
+        self.aH = try buf(aR * D, "a.h")
+        self.aNormed = try buf(aR * D, "a.normed")
+        self.aQPacked = try buf(aR * 2 * qDim, "a.qPacked")
+        self.aQ = try buf(aR * qDim, "a.q")
+        self.aGate = try buf(aR * qDim, "a.gate")
+        self.aAttnOut = try buf(aR * qDim, "a.attnOut")
+        self.aOut1 = try buf(aR * D, "a.out1")
+        self.aMlpX = try buf(aR * D, "a.mlpX")
+        self.aMlpGate = try buf(aR * F, "a.mlpGate")
+        self.aMlpUp = try buf(aR * F, "a.mlpUp")
+        self.aMlpAct = try buf(aR * F, "a.mlpAct")
+        self.aMlpOut = try buf(aR * D, "a.mlpOut")
+    }
+
+    // MARK: - Session state
+
+    func reset() {
+        pending.removeAll(keepingCapacity: true)
+        pendingPosition = 0
+        started = false
+        haveSeed = false
+        mtpLen = 0
+        basePair = 0
+        arenaRoundBase = -1
+        arenaCaptured = 0
+    }
+
+    var hasPending: Bool { !pending.isEmpty }
+
+    /// Continuation support after a generation that ended mid-round: the KV
+    /// and GDN state may have run ahead of the tokens the caller consumed.
+    /// When the requested cursor falls inside the last verify span, restore
+    /// the captured GDN state for that position and rewind the KV cursor;
+    /// otherwise (and for an exact match) just clear speculative state.
+    func prepareForContinuation(expectedPosition: Int) throws {
+        defer {
+            pending.removeAll(keepingCapacity: true)
+            started = false
+            haveSeed = false
+        }
+        if expectedPosition == kv.position { return }
+        guard expectedPosition < kv.position else { return } // main guard throws
+        let row = expectedPosition - 1 - arenaRoundBase
+        guard arenaRoundBase >= 0, row >= 0, row < arenaCaptured else {
+            throw PrefillError.prefillCursorMismatch(
+                "Qwen 3.8 continuation cursor \(expectedPosition) is behind the "
+                + "speculative KV cursor \(kv.position) and outside the last verify span")
+        }
+        guard let cb = ctx.queue.makeCommandBuffer() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 MTP continuation command buffer")
+        }
+        try encodeGDNRestore(cb, slot: row)
+        cb.commit()
+        cb.waitUntilCompleted()
+        guard cb.status == .completed else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "Qwen 3.8 MTP continuation restore did not complete")
+        }
+        kv.rewind(to: expectedPosition)
+        arenaRoundBase = -1
+        arenaCaptured = 0
+    }
+
+    // MARK: - Round orchestration
+
+    /// Serve a queued verified token if this call matches the expectation.
+    func consumePending(token: Int32, position: Int) throws -> UInt32? {
+        guard !pending.isEmpty else { return nil }
+        let next = pending.removeFirst()
+        guard position == pendingPosition, token == next.expectInput else {
+            throw Qwen38ForwardRunnerError.invalidInput(
+                "Qwen 3.8 speculative stream desync: produce(\(token), \(position)) "
+                + "does not match the pending verified continuation "
+                + "(\(next.expectInput), \(pendingPosition))")
+        }
+        pendingPosition += 1
+        stats.emittedTokens += 1
+        return next.emit
+    }
+
+    /// A round needs the cursor caught up and room for at least one draft.
+    func canRunRound(position: Int) -> Bool {
+        position == kv.position && position + 2 <= maxContext
+    }
+
+    /// Run one draft/verify/accept round for `produce(bonus, position)`.
+    /// Returns the first verified token; the rest are queued.
+    func runRound(bonus: Int32, position: Int) throws -> UInt32 {
+        precondition(pending.isEmpty, "spec round with pending tokens")
+        let P = position
+        let kRound = min(draftCount, maxContext - P - 1)
+        precondition(kRound >= 1, "runRound caller must guarantee draft room")
+
+        // (Re)initialize the drafter when starting or after a cursor gap
+        // (plain decode steps or a resumed prefill advanced the target).
+        if !started || basePair + mtpLen < P - 1 {
+            started = true
+            basePair = P - 1
+            mtpLen = 0
+            haveSeed = false
+        }
+
+        // 1. Draft.
+        let draftStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+        var drafts: [Int32] = []
+        if let draftOverride {
+            drafts = Array(draftOverride(stats.rounds, kRound).prefix(kRound))
+            precondition(!drafts.isEmpty, "draft override returned no tokens")
+            precondition(drafts.allSatisfy { $0 >= 0 && $0 < Int32(cfg.vocabSize) },
+                         "draft override token outside the vocabulary")
+        } else {
+            var slot = mtpLen
+            var tok: Int32
+            var hPrev: MTLBuffer
+            if haveSeed {
+                drafts.append(seedToken)
+                tok = seedToken
+                hPrev = seedHiddenBuf
+            } else {
+                tok = bonus
+                hPrev = lastHiddenBuf
+            }
+            var useA = true
+            while drafts.count < kRound {
+                let hOut = useA ? dHOutA : dHOutB
+                let next = try runDraftForward(token: tok, hPrev: hPrev,
+                                               hOut: hOut, slot: slot)
+                slot += 1
+                tok = next
+                hPrev = hOut
+                useA.toggle()
+                drafts.append(next)
+            }
+        }
+        stats.draftNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - draftStart
+        stats.draftedTokens += drafts.count
+
+        // 2. Verify.
+        let verifyStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+        let verifyTokens = [bonus] + drafts
+        try runVerifyPass(tokens: verifyTokens, startPosition: P)
+        kv.advance(by: verifyTokens.count)
+        arenaRoundBase = P
+        arenaCaptured = verifyTokens.count - 1
+
+        let targets = verifyTokensBuf.contents()
+            .bindMemory(to: UInt32.self, capacity: verifyTokens.count)
+        var accepted = 0
+        while accepted < drafts.count,
+              targets[accepted] == UInt32(bitPattern: drafts[accepted]) {
+            accepted += 1
+        }
+        let emitted = (0...accepted).map { targets[$0] } // t1..t_{accepted+1}
+        stats.verifyNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - verifyStart
+        stats.rounds += 1
+        stats.acceptedTokens += accepted
+
+        // 3. Accept + rollback.
+        let acceptStart = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+        let rolledBack = accepted < drafts.count
+        if rolledBack {
+            stats.rollbacks += 1
+            kv.rewind(to: P + accepted + 1)
+        }
+        try runAcceptPass(bonus: bonus, emitted: emitted, position: P,
+                          restoreSlot: rolledBack ? accepted : nil)
+        stats.acceptNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - acceptStart
+
+        // 4. Queue.
+        pending = (1..<emitted.count).map {
+            (expectInput: Int32(bitPattern: emitted[$0 - 1]), emit: emitted[$0])
+        }
+        pendingPosition = P + 1
+        stats.emittedTokens += 1
+        return emitted[0]
+    }
+
+    // MARK: - Target verify pass (decode-exact, weights read once)
+
+    private func runVerifyPass(tokens: [Int32], startPosition: Int) throws {
+        let t = tokens.count
+        precondition(t >= 2 && t <= vT, "verify batch \(t) outside 2...\(vT)")
+        let D = cfg.hiddenSize
+        let ids = tokenIdsBuf.contents().bindMemory(to: UInt32.self, capacity: t)
+        for (i, token) in tokens.enumerated() { ids[i] = UInt32(bitPattern: token) }
+
+        let cb = try commandBuffer()
+        let emb = model.embedding
+        prefillEmbed.encode(commandBuffer: cb,
+                            table: emb.buffer, tableOffset: Int(emb.offset),
+                            scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
+                            biases: emb.buffer, biasesOffset: Int(emb.biasOffset),
+                            tokens: tokenIdsBuf,
+                            out: vHidden,
+                            t: UInt32(t), d: UInt32(D),
+                            outScale: 1.0)
+
+        for (index, layer) in layers.enumerated() {
+            prefillRMS.encodeBF16W(commandBuffer: cb,
+                                   x: vHidden,
+                                   weight: layer.inputNorm.buffer,
+                                   weightOffset: Int(layer.inputNorm.offset),
+                                   out: vNormed,
+                                   t: UInt32(t), d: UInt32(D),
+                                   eps: Self.epsilon)
+            if layer.isLinear {
+                try encodeVerifyLinear(cb, layer: layer, layerIndex: index, tokenCount: t)
+            } else {
+                try encodeVerifyFullAttention(cb, layer: layer, layerIndex: index,
+                                              tokenCount: t, startPosition: startPosition)
+            }
+            elementwise.encodeResidualAdd(commandBuffer: cb,
+                                          hidden: vHidden, delta: vOut1,
+                                          count: t * D)
+            prefillRMS.encodeBF16W(commandBuffer: cb,
+                                   x: vHidden,
+                                   weight: layer.postAttnNorm.buffer,
+                                   weightOffset: Int(layer.postAttnNorm.offset),
+                                   out: vMlpX,
+                                   t: UInt32(t), d: UInt32(D),
+                                   eps: Self.epsilon)
+            try encodeVerifyMLP(cb, layer: layer, tokenCount: t)
+            elementwise.encodeResidualAdd(commandBuffer: cb,
+                                          hidden: vHidden, delta: vMlpOut,
+                                          count: t * D)
+        }
+
+        let fNorm = model.finalNorm
+        prefillRMS.encodeBF16W(commandBuffer: cb,
+                               x: vHidden,
+                               weight: fNorm.buffer,
+                               weightOffset: Int(fNorm.offset),
+                               out: normedHidden,
+                               t: UInt32(t), d: UInt32(D),
+                               eps: Self.epsilon)
+        let lm = model.lmHead
+        verifyHead.encode(commandBuffer: cb,
+                          xNormed: normedHidden,
+                          weights: lm.buffer, weightsOffset: Int(lm.offset),
+                          scales: lm.buffer, scalesOffset: Int(lm.scaleOffset),
+                          biases: lm.buffer, biasesOffset: Int(lm.biasOffset),
+                          outTokens: verifyTokensBuf,
+                          d: D, vocab: cfg.vocabSize, tokens: t)
+        try finish(cb)
+    }
+
+    private func encodeVerifyFullAttention(_ cb: MTLCommandBuffer,
+                                           layer: Qwen38ForwardRunner.LayerTensors,
+                                           layerIndex: Int,
+                                           tokenCount t: Int,
+                                           startPosition: Int) throws {
+        guard let q = layer.q, let k = layer.k, let v = layer.v, let o = layer.o,
+              let qNormW = layer.qNorm, let kNormW = layer.kNorm else {
+            preconditionFailure("full-attention layer without attention tensors")
+        }
+        let D = cfg.hiddenSize
+        let headDim = cfg.fullHeadDim
+        let numKV = cfg.numFullKVHeads
+        let qDim = cfg.numHeads * headDim
+        let kvDim = numKV * headDim
+        let rotaryDim = UInt32(Double(headDim) * cfg.partialRotaryFactor)
+        let h = MemoryLayout<Float16>.stride
+
+        func mx(_ w: TensorView, y: MTLBuffer, m: Int, n: Int) {
+            multix.encode(commandBuffer: cb,
+                          weights: w.buffer, weightsOffset: Int(w.offset),
+                          scales: w.buffer, scalesOffset: Int(w.scaleOffset),
+                          biases: w.buffer, biasesOffset: Int(w.biasOffset),
+                          x: vNormed, y: y, m: m, n: n, tokens: t)
+        }
+        mx(q, y: vQPacked, m: 2 * qDim, n: D)
+        mx(k, y: vKStage, m: kvDim, n: D)
+        mx(v, y: vVStage, m: kvDim, n: D)
+        elementwise.encodeSplitQGate(commandBuffer: cb,
+                                     packed: vQPacked, q: vQ, gate: vGate,
+                                     heads: cfg.numHeads, dim: headDim, rows: t)
+
+        // Stage -> cache (contiguous slots for a linear full-attention layer).
+        let kRange = kv.kRange(layer: layerIndex, start: startPosition, count: t)
+        let vRange = kv.vRange(layer: layerIndex, start: startPosition, count: t)
+        guard let blit = cb.makeBlitCommandEncoder() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 MTP verify KV blit encoder")
+        }
+        blit.copy(from: vKStage, sourceOffset: 0,
+                  to: kRange.buffer, destinationOffset: kRange.offset,
+                  size: t * kvDim * h)
+        blit.copy(from: vVStage, sourceOffset: 0,
+                  to: vRange.buffer, destinationOffset: vRange.offset,
+                  size: t * kvDim * h)
+        blit.endEncoding()
+
+        for i in 0..<t {
+            let kSlot = kv.kSlot(layer: layerIndex, position: startPosition + i)
+            rms.encodeBF16WPerHead(commandBuffer: cb,
+                                   x: vQ, xOffset: i * qDim * h,
+                                   weight: qNormW.buffer,
+                                   weightOffset: Int(qNormW.offset),
+                                   out: vQ, outOffset: i * qDim * h,
+                                   headDim: UInt32(headDim),
+                                   numHeads: cfg.numHeads,
+                                   eps: Self.epsilon)
+            rms.encodeBF16WPerHead(commandBuffer: cb,
+                                   x: kSlot.buffer, xOffset: kSlot.offset,
+                                   weight: kNormW.buffer,
+                                   weightOffset: Int(kNormW.offset),
+                                   out: kSlot.buffer, outOffset: kSlot.offset,
+                                   headDim: UInt32(headDim),
+                                   numHeads: numKV,
+                                   eps: Self.epsilon)
+            rope.encodeNeoxSubdim(commandBuffer: cb,
+                                  data: vQ, dataOffset: i * qDim * h,
+                                  position: UInt32(startPosition + i),
+                                  headDim: UInt32(headDim),
+                                  numHeads: UInt32(cfg.numHeads),
+                                  rotaryDim: rotaryDim,
+                                  theta: Float(cfg.fullRopeTheta))
+            rope.encodeNeoxSubdim(commandBuffer: cb,
+                                  data: kSlot.buffer, dataOffset: kSlot.offset,
+                                  position: UInt32(startPosition + i),
+                                  headDim: UInt32(headDim),
+                                  numHeads: UInt32(numKV),
+                                  rotaryDim: rotaryDim,
+                                  theta: Float(cfg.fullRopeTheta))
+        }
+        for i in 0..<t {
+            attention.encodeFull(commandBuffer: cb,
+                                 q: vQ, qOffset: i * qDim * h,
+                                 k: kv.keyBuffer(layer: layerIndex,
+                                                 validTokenCount: startPosition + i + 1),
+                                 v: kv.valueBuffer(layer: layerIndex,
+                                                   validTokenCount: startPosition + i + 1),
+                                 out: vAttnOut, outOffset: i * qDim * h,
+                                 headDim: UInt32(headDim),
+                                 numQHeads: UInt32(cfg.numHeads),
+                                 numKVHeads: UInt32(numKV),
+                                 seqLen: UInt32(startPosition + i + 1),
+                                 scale: Float(cfg.attentionScale))
+        }
+        elementwise.encodeSigmoidGateMul(commandBuffer: cb,
+                                         out: vAttnOut, gate: vGate,
+                                         count: t * qDim)
+        multix.encode(commandBuffer: cb,
+                      weights: o.buffer, weightsOffset: Int(o.offset),
+                      scales: o.buffer, scalesOffset: Int(o.scaleOffset),
+                      biases: o.buffer, biasesOffset: Int(o.biasOffset),
+                      x: vAttnOut, y: vOut1, m: D, n: qDim, tokens: t)
+    }
+
+    private func encodeVerifyLinear(_ cb: MTLCommandBuffer,
+                                    layer: Qwen38ForwardRunner.LayerTensors,
+                                    layerIndex: Int,
+                                    tokenCount t: Int) throws {
+        guard let qkvW = layer.linQKV, let zW = layer.linZ,
+              let aW = layer.linA, let bW = layer.linB,
+              let outW = layer.linOut, let convW = layer.linConv,
+              let aLog = layer.linALog, let dtBias = layer.linDtBias,
+              let gatedNormW = layer.linNorm else {
+            preconditionFailure("linear-attention layer without GDN tensors")
+        }
+        let la = cfg.linearAttention
+        let D = cfg.hiddenSize
+        let h = MemoryLayout<Float16>.stride
+        guard let linearOrdinal = linearLayerIndex[layerIndex] else {
+            preconditionFailure("linear layer without ordinal")
+        }
+
+        func mx(_ w: TensorView, y: MTLBuffer, m: Int) {
+            multix.encode(commandBuffer: cb,
+                          weights: w.buffer, weightsOffset: Int(w.offset),
+                          scales: w.buffer, scalesOffset: Int(w.scaleOffset),
+                          biases: w.buffer, biasesOffset: Int(w.biasOffset),
+                          x: vNormed, y: y, m: m, n: D, tokens: t)
+        }
+        // The decode step fuses these four into one dispatch
+        // (`gdn_in_proj_gemv_simd`), documented bit-identical to the four
+        // separate GEMVs; the multi-x rows match that per-row body.
+        mx(qkvW, y: vGdnQKV, m: la.qkvDim)
+        mx(zW, y: vGdnZ, m: la.valueDim)
+        mx(aW, y: vGdnA, m: la.numVHeads)
+        mx(bW, y: vGdnB, m: la.numVHeads)
+
+        let tail = gdnState.convTailBuffer(layer: layerIndex)
+        let state = gdnState.stateBuffer(layer: layerIndex)
+        let stateBytes = gdnState.stateBytesPerLayer
+        let tailBytes = gdnState.convTailBytesPerLayer
+        for i in 0..<t {
+            gdn.encodeConvDecode(commandBuffer: cb,
+                                 tail: tail,
+                                 qkv: vGdnQKV, qkvOffset: i * la.qkvDim * h,
+                                 convWeight: convW.buffer,
+                                 convWeightOffset: Int(convW.offset),
+                                 out: vGdnConv, outOffset: i * la.qkvDim * h)
+            if i < t - 1 {
+                guard let blit = cb.makeBlitCommandEncoder() else {
+                    throw Qwen38ForwardRunnerError.commandFailed(
+                        "unable to create Qwen 3.8 MTP tail-capture blit encoder")
+                }
+                blit.copy(from: tail, sourceOffset: 0,
+                          to: tailArena,
+                          destinationOffset: (i * numLinearLayers + linearOrdinal) * tailBytes,
+                          size: tailBytes)
+                blit.endEncoding()
+            }
+        }
+        gdn.encodeQKNorm(commandBuffer: cb, convOut: vGdnConv, rows: t)
+        for i in 0..<t {
+            let usedFused = gdn.encodeDeltaGatedDecode(
+                commandBuffer: cb,
+                convOut: vGdnConv, convOutOffset: i * la.qkvDim * h,
+                aProj: vGdnA, aProjOffset: i * la.numVHeads * h,
+                bProj: vGdnB, bProjOffset: i * la.numVHeads * h,
+                aLog: aLog.buffer, aLogOffset: Int(aLog.offset),
+                dtBias: dtBias.buffer, dtBiasOffset: Int(dtBias.offset),
+                state: state,
+                z: vGdnZ, zOffset: i * la.valueDim * h,
+                weight: gatedNormW.buffer, weightOffset: Int(gatedNormW.offset),
+                out: vGdnOut, outOffset: i * la.valueDim * h)
+            if !usedFused {
+                gdn.encodeDeltaStepDecode(commandBuffer: cb,
+                                          convOut: vGdnConv,
+                                          convOutOffset: i * la.qkvDim * h,
+                                          aProj: vGdnA, aProjOffset: i * la.numVHeads * h,
+                                          bProj: vGdnB, bProjOffset: i * la.numVHeads * h,
+                                          aLog: aLog.buffer, aLogOffset: Int(aLog.offset),
+                                          dtBias: dtBias.buffer,
+                                          dtBiasOffset: Int(dtBias.offset),
+                                          state: state,
+                                          y: vGdnY, yOffset: i * la.valueDim * h)
+                gdn.encodeGatedNorm(commandBuffer: cb,
+                                    y: vGdnY, yOffset: i * la.valueDim * h,
+                                    z: vGdnZ, zOffset: i * la.valueDim * h,
+                                    weight: gatedNormW.buffer,
+                                    weightOffset: Int(gatedNormW.offset),
+                                    out: vGdnOut, outOffset: i * la.valueDim * h)
+            }
+            if i < t - 1 {
+                guard let blit = cb.makeBlitCommandEncoder() else {
+                    throw Qwen38ForwardRunnerError.commandFailed(
+                        "unable to create Qwen 3.8 MTP state-capture blit encoder")
+                }
+                blit.copy(from: state, sourceOffset: 0,
+                          to: stateArena,
+                          destinationOffset: (i * numLinearLayers + linearOrdinal) * stateBytes,
+                          size: stateBytes)
+                blit.endEncoding()
+            }
+        }
+        multix.encode(commandBuffer: cb,
+                      weights: outW.buffer, weightsOffset: Int(outW.offset),
+                      scales: outW.buffer, scalesOffset: Int(outW.scaleOffset),
+                      biases: outW.buffer, biasesOffset: Int(outW.biasOffset),
+                      x: vGdnOut, y: vOut1, m: D, n: la.valueDim, tokens: t)
+    }
+
+    private func encodeVerifyMLP(_ cb: MTLCommandBuffer,
+                                 layer: Qwen38ForwardRunner.LayerTensors,
+                                 tokenCount t: Int) throws {
+        let D = cfg.hiddenSize
+        let F = cfg.intermediateSize
+        if let int8Runtime = verifyMLPInt8 {
+            // Toy fixtures carry an INT8 MLP: replay the decode kernel per
+            // row (exact by construction; toy performance is irrelevant).
+            let h = MemoryLayout<Float16>.stride
+            for i in 0..<t {
+                try int8Runtime.encode(commandBuffer: cb,
+                                       x: vMlpX, xOffset: i * D * h,
+                                       gate: layer.mlpGate, up: layer.mlpUp,
+                                       down: layer.mlpDown,
+                                       y: vMlpOut, yOffset: i * D * h,
+                                       scratchGate: vMlpGate,
+                                       scratchUp: vMlpUp,
+                                       scratchAct: vMlpAct)
+            }
+            return
+        }
+        // INT4: the decode step's fused gate/up/act kernel preserves the
+        // exact three-dispatch boundary (gate and up round through FP16, the
+        // activation multiplies in FP32), so multi-x gate/up + the shared
+        // silu-mul + multi-x down reproduce it bit for bit.
+        func mx(_ proj: SharedExpertProjection, x: MTLBuffer, y: MTLBuffer,
+                m: Int, n: Int) {
+            multix.encode(commandBuffer: cb,
+                          weights: proj.weights, weightsOffset: proj.weightsOffset,
+                          scales: proj.scales, scalesOffset: proj.scalesOffset,
+                          biases: proj.biases, biasesOffset: proj.biasesOffset,
+                          x: x, y: y, m: m, n: n, tokens: t)
+        }
+        mx(layer.mlpGate, x: vMlpX, y: vMlpGate, m: F, n: D)
+        mx(layer.mlpUp, x: vMlpX, y: vMlpUp, m: F, n: D)
+        try encodeSiluMul(cb, gate: vMlpGate, up: vMlpUp, out: vMlpAct, count: t * F)
+        mx(layer.mlpDown, x: vMlpAct, y: vMlpOut, m: D, n: F)
+    }
+
+    private func encodeSiluMul(_ cb: MTLCommandBuffer,
+                               gate: MTLBuffer, up: MTLBuffer, out: MTLBuffer,
+                               count: Int) throws {
+        guard let encoder = cb.makeComputeCommandEncoder() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 MTP activation encoder")
+        }
+        encoder.setComputePipelineState(siluMulPSO)
+        encoder.setBuffer(gate, offset: 0, index: 0)
+        encoder.setBuffer(up, offset: 0, index: 1)
+        encoder.setBuffer(out, offset: 0, index: 2)
+        var elementCount = UInt32(count)
+        encoder.setBytes(&elementCount, length: MemoryLayout<UInt32>.size, index: 3)
+        let width = min(siluMulPSO.maxTotalThreadsPerThreadgroup, 256)
+        encoder.dispatchThreads(MTLSize(width: count, height: 1, depth: 1),
+                                threadsPerThreadgroup: MTLSize(width: width, height: 1, depth: 1))
+        encoder.endEncoding()
+    }
+
+    private func encodeGDNRestore(_ cb: MTLCommandBuffer, slot: Int) throws {
+        precondition(slot >= 0 && slot < vT - 1, "GDN restore slot out of range")
+        guard let blit = cb.makeBlitCommandEncoder() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 MTP restore blit encoder")
+        }
+        let stateBytes = gdnState.stateBytesPerLayer
+        let tailBytes = gdnState.convTailBytesPerLayer
+        for layer in 0..<cfg.numLayers {
+            guard let ordinal = linearLayerIndex[layer] else { continue }
+            blit.copy(from: stateArena,
+                      sourceOffset: (slot * numLinearLayers + ordinal) * stateBytes,
+                      to: gdnState.stateBuffer(layer: layer),
+                      destinationOffset: 0,
+                      size: stateBytes)
+            blit.copy(from: tailArena,
+                      sourceOffset: (slot * numLinearLayers + ordinal) * tailBytes,
+                      to: gdnState.convTailBuffer(layer: layer),
+                      destinationOffset: 0,
+                      size: tailBytes)
+        }
+        blit.endEncoding()
+    }
+
+    // MARK: - MTP draft layer
+
+    /// One MTP forward: pair (`token`, `hPrev`) appended at `slot`, argmax of
+    /// the shared lm_head over the drafter's output, and the post-norm hidden
+    /// written to `hOut` for the next chained step.
+    private func runDraftForward(token: Int32, hPrev: MTLBuffer,
+                                 hOut: MTLBuffer, slot: Int) throws -> Int32 {
+        precondition(slot >= 0 && slot < maxContext, "MTP slot out of range")
+        let D = UInt32(cfg.hiddenSize)
+        let cb = try commandBuffer()
+
+        let emb = model.embedding
+        embedInt4.encode(commandBuffer: cb,
+                         table: emb.buffer, tableOffset: Int(emb.offset),
+                         scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
+                         biases: emb.buffer, biasesOffset: Int(emb.biasOffset),
+                         out: dEmb,
+                         tokenId: UInt32(bitPattern: token),
+                         d: D, outScale: 1.0)
+        rms.encodeBF16W(commandBuffer: cb,
+                        x: dEmb,
+                        weight: weights.preFcNormEmbedding.buffer,
+                        weightOffset: Int(weights.preFcNormEmbedding.offset),
+                        out: dFcIn,
+                        d: D, eps: Self.epsilon)
+        rms.encodeBF16W(commandBuffer: cb,
+                        x: hPrev,
+                        weight: weights.preFcNormHidden.buffer,
+                        weightOffset: Int(weights.preFcNormHidden.offset),
+                        out: dFcIn, outOffset: cfg.hiddenSize * MemoryLayout<Float16>.stride,
+                        d: D, eps: Self.epsilon)
+        int4.encode(commandBuffer: cb,
+                    weights: weights.fc.buffer, weightsOffset: Int(weights.fc.offset),
+                    scales: weights.fc.buffer, scalesOffset: Int(weights.fc.scaleOffset),
+                    biases: weights.fc.buffer, biasesOffset: Int(weights.fc.biasOffset),
+                    x: dFcIn, y: dH,
+                    m: D, n: 2 * D)
+        try encodeMTPLayerSingle(cb, slot: slot)
+        rms.encodeBF16W(commandBuffer: cb,
+                        x: dH,
+                        weight: weights.finalNorm.buffer,
+                        weightOffset: Int(weights.finalNorm.offset),
+                        out: hOut,
+                        d: D, eps: Self.epsilon)
+        let lm = model.lmHead
+        draftHead.encodeGreedyDecode(commandBuffer: cb,
+                                     hidden: dH,
+                                     normWeight: weights.finalNorm.buffer,
+                                     normOffset: Int(weights.finalNorm.offset),
+                                     weights: lm.buffer, weightsOffset: Int(lm.offset),
+                                     scales: lm.buffer, scalesOffset: Int(lm.scaleOffset),
+                                     biases: lm.buffer, biasesOffset: Int(lm.biasOffset),
+                                     outToken: dTokenBuf,
+                                     d: D, vocab: UInt32(cfg.vocabSize),
+                                     rmsEps: Self.epsilon)
+        try finish(cb)
+        return Int32(bitPattern: dTokenBuf.contents().load(as: UInt32.self))
+    }
+
+    /// The MTP decoder layer over the single-token scratch: gated full
+    /// attention against the drafter's own KV cache plus the dense SwiGLU
+    /// MLP, with residuals — the target's full-attention block shape.
+    private func encodeMTPLayerSingle(_ cb: MTLCommandBuffer, slot: Int) throws {
+        let D = UInt32(cfg.hiddenSize)
+        let headDim = cfg.fullHeadDim
+        let numKV = cfg.numFullKVHeads
+        let qDim = UInt32(cfg.numHeads * headDim)
+        let rotaryDim = UInt32(Double(headDim) * cfg.partialRotaryFactor)
+        let h = MemoryLayout<Float16>.stride
+        let slotOffset = slot * mtpKVDim * h
+
+        rms.encodeBF16W(commandBuffer: cb,
+                        x: dH,
+                        weight: weights.inputNorm.buffer,
+                        weightOffset: Int(weights.inputNorm.offset),
+                        out: dNormed,
+                        d: D, eps: Self.epsilon)
+        func gemv(_ w: TensorView, x: MTLBuffer, xOffset: Int = 0,
+                  y: MTLBuffer, yOffset: Int = 0, m: UInt32, n: UInt32) {
+            int4.encode(commandBuffer: cb,
+                        weights: w.buffer, weightsOffset: Int(w.offset),
+                        scales: w.buffer, scalesOffset: Int(w.scaleOffset),
+                        biases: w.buffer, biasesOffset: Int(w.biasOffset),
+                        x: x, xOffset: xOffset, y: y, yOffset: yOffset, m: m, n: n)
+        }
+        gemv(weights.q, x: dNormed, y: dQPacked, m: 2 * qDim, n: D)
+        gemv(weights.k, x: dNormed, y: mtpK, yOffset: slotOffset,
+             m: UInt32(mtpKVDim), n: D)
+        gemv(weights.v, x: dNormed, y: mtpV, yOffset: slotOffset,
+             m: UInt32(mtpKVDim), n: D)
+        elementwise.encodeSplitQGate(commandBuffer: cb,
+                                     packed: dQPacked, q: dQ, gate: dGate,
+                                     heads: cfg.numHeads, dim: headDim)
+        rms.encodeBF16WPerHead(commandBuffer: cb,
+                               x: dQ,
+                               weight: weights.qNorm.buffer,
+                               weightOffset: Int(weights.qNorm.offset),
+                               out: dQ,
+                               headDim: UInt32(headDim), numHeads: cfg.numHeads,
+                               eps: Self.epsilon)
+        rms.encodeBF16WPerHead(commandBuffer: cb,
+                               x: mtpK, xOffset: slotOffset,
+                               weight: weights.kNorm.buffer,
+                               weightOffset: Int(weights.kNorm.offset),
+                               out: mtpK, outOffset: slotOffset,
+                               headDim: UInt32(headDim), numHeads: numKV,
+                               eps: Self.epsilon)
+        let ropePosition = UInt32(basePair + slot)
+        rope.encodeNeoxSubdim(commandBuffer: cb,
+                              data: dQ,
+                              position: ropePosition,
+                              headDim: UInt32(headDim),
+                              numHeads: UInt32(cfg.numHeads),
+                              rotaryDim: rotaryDim,
+                              theta: Float(cfg.fullRopeTheta))
+        rope.encodeNeoxSubdim(commandBuffer: cb,
+                              data: mtpK, dataOffset: slotOffset,
+                              position: ropePosition,
+                              headDim: UInt32(headDim),
+                              numHeads: UInt32(numKV),
+                              rotaryDim: rotaryDim,
+                              theta: Float(cfg.fullRopeTheta))
+        mtpAttention.encodeFull(commandBuffer: cb,
+                                q: dQ,
+                                k: mtpK, v: mtpV,
+                                out: dAttnOut,
+                                headDim: UInt32(headDim),
+                                numQHeads: UInt32(cfg.numHeads),
+                                numKVHeads: UInt32(numKV),
+                                seqLen: UInt32(slot + 1),
+                                scale: Float(cfg.attentionScale))
+        elementwise.encodeSigmoidGateMul(commandBuffer: cb,
+                                         out: dAttnOut, gate: dGate,
+                                         count: Int(qDim))
+        gemv(weights.o, x: dAttnOut, y: dOut1, m: D, n: qDim)
+        elementwise.encodeResidualAdd(commandBuffer: cb,
+                                      hidden: dH, delta: dOut1,
+                                      count: cfg.hiddenSize)
+        rms.encodeBF16W(commandBuffer: cb,
+                        x: dH,
+                        weight: weights.postAttnNorm.buffer,
+                        weightOffset: Int(weights.postAttnNorm.offset),
+                        out: dMlpX,
+                        d: D, eps: Self.epsilon)
+        try mtpMLP.encode(commandBuffer: cb,
+                          x: dMlpX,
+                          gate: weights.mlpGate, up: weights.mlpUp,
+                          down: weights.mlpDown,
+                          y: dMlpOut,
+                          scratchGate: dMlpGate, scratchUp: dMlpUp,
+                          scratchAct: dMlpAct)
+        elementwise.encodeResidualAdd(commandBuffer: cb,
+                                      hidden: dH, delta: dMlpOut,
+                                      count: cfg.hiddenSize)
+    }
+
+    // MARK: - MTP accept pass
+
+    /// Trim the drafter cache to the committed pair count and re-feed the
+    /// exact (token, target-hidden) pairs the round committed; the last row
+    /// (the new bonus pair) yields the next round's seed token and hidden.
+    /// Also restores the target's GDN state on partial acceptance and
+    /// persists the accepted position's target hidden for the next round.
+    private func runAcceptPass(bonus: Int32, emitted: [UInt32], position P: Int,
+                               restoreSlot: Int?) throws {
+        let accepted = emitted.count - 1
+        let firstMissingPair = basePair + mtpLen
+        let lastPair = P + accepted
+        precondition(firstMissingPair >= P - 1 && firstMissingPair <= lastPair,
+                     "MTP pair bookkeeping out of range")
+        let R = lastPair - firstMissingPair + 1
+        precondition(R >= 1 && R <= aR, "MTP accept batch \(R) outside 1...\(aR)")
+        let D = cfg.hiddenSize
+        let h = MemoryLayout<Float16>.stride
+
+        // Pair j consumes (token at j+1, target hidden at j).
+        var tokens: [Int32] = []
+        tokens.reserveCapacity(R)
+        for pair in firstMissingPair...lastPair {
+            let tokenPosition = pair + 1
+            if tokenPosition == P {
+                tokens.append(bonus)
+            } else {
+                tokens.append(Int32(bitPattern: emitted[tokenPosition - P - 1]))
+            }
+        }
+        let ids = tokenIdsBuf.contents().bindMemory(to: UInt32.self, capacity: R)
+        for (i, token) in tokens.enumerated() { ids[i] = UInt32(bitPattern: token) }
+
+        let cb = try commandBuffer()
+        if let restoreSlot {
+            try encodeGDNRestore(cb, slot: restoreSlot)
+        }
+
+        // Assemble the hidden rows: lastHiddenBuf for pair P-1, verify
+        // normed-hidden rows for pairs P..P+accepted.
+        guard let gather = cb.makeBlitCommandEncoder() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 MTP accept gather encoder")
+        }
+        for (row, pair) in (firstMissingPair...lastPair).enumerated() {
+            if pair == P - 1 {
+                gather.copy(from: lastHiddenBuf, sourceOffset: 0,
+                            to: aHiddenSrc, destinationOffset: row * D * h,
+                            size: D * h)
+            } else {
+                gather.copy(from: normedHidden, sourceOffset: (pair - P) * D * h,
+                            to: aHiddenSrc, destinationOffset: row * D * h,
+                            size: D * h)
+            }
+        }
+        // Persist the accepted position's hidden for the next round before
+        // the next verify pass overwrites `normedHidden`.
+        gather.copy(from: normedHidden, sourceOffset: accepted * D * h,
+                    to: lastHiddenBuf, destinationOffset: 0, size: D * h)
+        gather.endEncoding()
+
+        let emb = model.embedding
+        prefillEmbed.encode(commandBuffer: cb,
+                            table: emb.buffer, tableOffset: Int(emb.offset),
+                            scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
+                            biases: emb.buffer, biasesOffset: Int(emb.biasOffset),
+                            tokens: tokenIdsBuf,
+                            out: aEmb,
+                            t: UInt32(R), d: UInt32(D),
+                            outScale: 1.0)
+        prefillRMS.encodeBF16W(commandBuffer: cb,
+                               x: aEmb,
+                               weight: weights.preFcNormEmbedding.buffer,
+                               weightOffset: Int(weights.preFcNormEmbedding.offset),
+                               out: aEmbNorm,
+                               t: UInt32(R), d: UInt32(D), eps: Self.epsilon)
+        prefillRMS.encodeBF16W(commandBuffer: cb,
+                               x: aHiddenSrc,
+                               weight: weights.preFcNormHidden.buffer,
+                               weightOffset: Int(weights.preFcNormHidden.offset),
+                               out: aHidNorm,
+                               t: UInt32(R), d: UInt32(D), eps: Self.epsilon)
+        guard let interleave = cb.makeBlitCommandEncoder() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 MTP fc-interleave encoder")
+        }
+        for row in 0..<R {
+            interleave.copy(from: aEmbNorm, sourceOffset: row * D * h,
+                            to: aFcIn, destinationOffset: row * 2 * D * h,
+                            size: D * h)
+            interleave.copy(from: aHidNorm, sourceOffset: row * D * h,
+                            to: aFcIn, destinationOffset: (row * 2 + 1) * D * h,
+                            size: D * h)
+        }
+        interleave.endEncoding()
+
+        multix.encode(commandBuffer: cb,
+                      weights: weights.fc.buffer, weightsOffset: Int(weights.fc.offset),
+                      scales: weights.fc.buffer, scalesOffset: Int(weights.fc.scaleOffset),
+                      biases: weights.fc.buffer, biasesOffset: Int(weights.fc.biasOffset),
+                      x: aFcIn, y: aH, m: D, n: 2 * D, tokens: R)
+        try encodeMTPLayerRows(cb, rows: R, startSlot: mtpLen)
+
+        // Seed for the next round: argmax + post-norm hidden of the last row.
+        rms.encodeBF16W(commandBuffer: cb,
+                        x: aH, xOffset: (R - 1) * D * h,
+                        weight: weights.finalNorm.buffer,
+                        weightOffset: Int(weights.finalNorm.offset),
+                        out: seedHiddenBuf,
+                        d: UInt32(D), eps: Self.epsilon)
+        let lm = model.lmHead
+        draftHead.encodeGreedyDecode(commandBuffer: cb,
+                                     hidden: aH, hiddenOffset: (R - 1) * D * h,
+                                     normWeight: weights.finalNorm.buffer,
+                                     normOffset: Int(weights.finalNorm.offset),
+                                     weights: lm.buffer, weightsOffset: Int(lm.offset),
+                                     scales: lm.buffer, scalesOffset: Int(lm.scaleOffset),
+                                     biases: lm.buffer, biasesOffset: Int(lm.biasOffset),
+                                     outToken: dTokenBuf,
+                                     d: UInt32(D), vocab: UInt32(cfg.vocabSize),
+                                     rmsEps: Self.epsilon)
+        try finish(cb)
+        seedToken = Int32(bitPattern: dTokenBuf.contents().load(as: UInt32.self))
+        haveSeed = true
+        mtpLen += R
+    }
+
+    /// The MTP decoder layer over `rows` accept rows in `aH`. Rows are
+    /// independent up to attention (their fc inputs use exact target
+    /// hiddens), and attend causally over the drafter cache.
+    private func encodeMTPLayerRows(_ cb: MTLCommandBuffer, rows R: Int,
+                                    startSlot: Int) throws {
+        precondition(startSlot + R <= maxContext, "MTP cache overflow")
+        let D = cfg.hiddenSize
+        let F = cfg.intermediateSize
+        let headDim = cfg.fullHeadDim
+        let numKV = cfg.numFullKVHeads
+        let qDim = cfg.numHeads * headDim
+        let rotaryDim = UInt32(Double(headDim) * cfg.partialRotaryFactor)
+        let h = MemoryLayout<Float16>.stride
+
+        prefillRMS.encodeBF16W(commandBuffer: cb,
+                               x: aH,
+                               weight: weights.inputNorm.buffer,
+                               weightOffset: Int(weights.inputNorm.offset),
+                               out: aNormed,
+                               t: UInt32(R), d: UInt32(D), eps: Self.epsilon)
+        func mx(_ w: TensorView, x: MTLBuffer, y: MTLBuffer,
+                yOffset: Int = 0, m: Int, n: Int) {
+            multix.encode(commandBuffer: cb,
+                          weights: w.buffer, weightsOffset: Int(w.offset),
+                          scales: w.buffer, scalesOffset: Int(w.scaleOffset),
+                          biases: w.buffer, biasesOffset: Int(w.biasOffset),
+                          x: x, y: y, yOffset: yOffset, m: m, n: n, tokens: R)
+        }
+        mx(weights.q, x: aNormed, y: aQPacked, m: 2 * qDim, n: D)
+        // K/V rows land directly in the drafter cache: slots are contiguous
+        // and the multi-x output stride equals the slot stride.
+        mx(weights.k, x: aNormed, y: mtpK, yOffset: startSlot * mtpKVDim * h,
+           m: mtpKVDim, n: D)
+        mx(weights.v, x: aNormed, y: mtpV, yOffset: startSlot * mtpKVDim * h,
+           m: mtpKVDim, n: D)
+        elementwise.encodeSplitQGate(commandBuffer: cb,
+                                     packed: aQPacked, q: aQ, gate: aGate,
+                                     heads: cfg.numHeads, dim: headDim, rows: R)
+        for i in 0..<R {
+            let slot = startSlot + i
+            let slotOffset = slot * mtpKVDim * h
+            rms.encodeBF16WPerHead(commandBuffer: cb,
+                                   x: aQ, xOffset: i * qDim * h,
+                                   weight: weights.qNorm.buffer,
+                                   weightOffset: Int(weights.qNorm.offset),
+                                   out: aQ, outOffset: i * qDim * h,
+                                   headDim: UInt32(headDim), numHeads: cfg.numHeads,
+                                   eps: Self.epsilon)
+            rms.encodeBF16WPerHead(commandBuffer: cb,
+                                   x: mtpK, xOffset: slotOffset,
+                                   weight: weights.kNorm.buffer,
+                                   weightOffset: Int(weights.kNorm.offset),
+                                   out: mtpK, outOffset: slotOffset,
+                                   headDim: UInt32(headDim), numHeads: numKV,
+                                   eps: Self.epsilon)
+            rope.encodeNeoxSubdim(commandBuffer: cb,
+                                  data: aQ, dataOffset: i * qDim * h,
+                                  position: UInt32(basePair + slot),
+                                  headDim: UInt32(headDim),
+                                  numHeads: UInt32(cfg.numHeads),
+                                  rotaryDim: rotaryDim,
+                                  theta: Float(cfg.fullRopeTheta))
+            rope.encodeNeoxSubdim(commandBuffer: cb,
+                                  data: mtpK, dataOffset: slotOffset,
+                                  position: UInt32(basePair + slot),
+                                  headDim: UInt32(headDim),
+                                  numHeads: UInt32(numKV),
+                                  rotaryDim: rotaryDim,
+                                  theta: Float(cfg.fullRopeTheta))
+        }
+        for i in 0..<R {
+            mtpAttention.encodeFull(commandBuffer: cb,
+                                    q: aQ, qOffset: i * qDim * h,
+                                    k: mtpK, v: mtpV,
+                                    out: aAttnOut, outOffset: i * qDim * h,
+                                    headDim: UInt32(headDim),
+                                    numQHeads: UInt32(cfg.numHeads),
+                                    numKVHeads: UInt32(numKV),
+                                    seqLen: UInt32(startSlot + i + 1),
+                                    scale: Float(cfg.attentionScale))
+        }
+        elementwise.encodeSigmoidGateMul(commandBuffer: cb,
+                                         out: aAttnOut, gate: aGate,
+                                         count: R * qDim)
+        mx(weights.o, x: aAttnOut, y: aOut1, m: D, n: qDim)
+        elementwise.encodeResidualAdd(commandBuffer: cb,
+                                      hidden: aH, delta: aOut1, count: R * D)
+        prefillRMS.encodeBF16W(commandBuffer: cb,
+                               x: aH,
+                               weight: weights.postAttnNorm.buffer,
+                               weightOffset: Int(weights.postAttnNorm.offset),
+                               out: aMlpX,
+                               t: UInt32(R), d: UInt32(D), eps: Self.epsilon)
+        mx(SharedExpertProjectionView(weights.mlpGate), x: aMlpX, y: aMlpGate, m: F, n: D)
+        mx(SharedExpertProjectionView(weights.mlpUp), x: aMlpX, y: aMlpUp, m: F, n: D)
+        try encodeSiluMul(cb, gate: aMlpGate, up: aMlpUp, out: aMlpAct, count: R * F)
+        mx(SharedExpertProjectionView(weights.mlpDown), x: aMlpAct, y: aMlpOut, m: D, n: F)
+        elementwise.encodeResidualAdd(commandBuffer: cb,
+                                      hidden: aH, delta: aMlpOut, count: R * D)
+    }
+
+    // MARK: - Utilities
+
+    private func commandBuffer() throws -> MTLCommandBuffer {
+        guard let cb = ctx.queue.makeCommandBuffer() else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                "unable to create Qwen 3.8 MTP command buffer")
+        }
+        return cb
+    }
+
+    private func finish(_ cb: MTLCommandBuffer) throws {
+        cb.commit()
+        cb.waitUntilCompleted()
+        guard cb.status == .completed else {
+            throw Qwen38ForwardRunnerError.commandFailed(
+                cb.error?.localizedDescription
+                    ?? "Qwen 3.8 MTP command buffer did not complete")
+        }
+    }
+}
+
+/// Adapter: a `SharedExpertProjection` viewed as a plain tensor for the
+/// multi-x GEMV (weights + companions share the projection's buffer).
+private func SharedExpertProjectionView(_ p: SharedExpertProjection) -> TensorView {
+    TensorView(buffer: p.weights,
+               offset: UInt64(p.weightsOffset),
+               length: 0,
+               scaleOffset: UInt64(p.scalesOffset),
+               scaleLength: 0,
+               biasOffset: UInt64(p.biasesOffset),
+               biasLength: 0,
+               shape: (p.rows, p.cols, 0, 0),
+               dtype: 0)
+}

--- a/Sources/Mference/Runtime/KVCache/KVCacheManager.swift
+++ b/Sources/Mference/Runtime/KVCache/KVCacheManager.swift
@@ -247,6 +247,17 @@ public final class KVCacheManager {
         position += count
     }
 
+    /// Rewind the position cursor to `position` after a partially accepted
+    /// speculative-verify span. Storage is untouched — attention reads only
+    /// `[0, validTokenCount)`, so rows past the cursor are dead until the
+    /// next writer overwrites their slots.
+    public func rewind(to position: Int) {
+        precondition(position >= 0, "rewind position must be non-negative")
+        precondition(position <= self.position,
+                     "rewind \(position) is ahead of cursor \(self.position)")
+        self.position = position
+    }
+
     /// Drop all cached positions and return physical pages to the OS.
     ///
     /// No buffer zeroing — the attention kernels read only `[0, validTokenCount]`,

--- a/Sources/Mference/Tokenization/Tokenizer.swift
+++ b/Sources/Mference/Tokenization/Tokenizer.swift
@@ -69,9 +69,10 @@ public struct MFTokenizer: @unchecked Sendable {
     public let stopTokenIDs: Set<Int32>
     public let vocabSize: Int
 
-    /// Maple's pinned prompt opens a live `<think>` block. The initializer
-    /// resolves this EOS relationship only when the caller supplies the Maple
-    /// manifest family; direct and non-Maple loads retain their old behavior.
+    /// Maple's and Qwen 3.8's pinned prompts open a live `<think>` block. The
+    /// initializer resolves this EOS relationship only when the caller
+    /// supplies one of those manifest families; direct loads and other
+    /// families retain their old behavior.
     public var generationPromptStartsInThinking: Bool {
         dialect == .chatml && eosID == endOfTurnID
     }
@@ -165,7 +166,7 @@ public struct MFTokenizer: @unchecked Sendable {
         }
         let resolved = switch dialect {
         case .gemma: try Self.resolveGemmaTokens(tokenizer)
-        case .chatml: try Self.resolveChatMLTokens(tokenizer, maple: family == .maple)
+        case .chatml: try Self.resolveChatMLTokens(tokenizer, family: family)
         case .deepseek: try Self.resolveDeepseekTokens(tokenizer)
         case .inkling: try Self.resolveInklingTokens(tokenizer)
         }
@@ -259,7 +260,7 @@ public struct MFTokenizer: @unchecked Sendable {
 
     private static func resolveChatMLTokens(
         _ tokenizer: any Tokenizer,
-        maple: Bool
+        family: ModelFamily?
     ) throws -> ResolvedSpecialTokens {
         func id(_ token: String) throws -> Int32 {
             guard let value = specialTokenID(tokenizer, token) else {
@@ -278,10 +279,15 @@ public struct MFTokenizer: @unchecked Sendable {
         let toolResponseEnd = try id("</tool_response>")
         let thinkStart = try id("<think>")
         let thinkEnd = try id("</think>")
+        // Maple and Qwen 3.8 chat templates end the generation prompt inside
+        // a live `<think>` block and stop on `<|im_end|>`; the eos ==
+        // end-of-turn identity is what `generationPromptStartsInThinking`
+        // keys off. A nil family keeps the Qwen 3.6 (non-thinking) behavior.
+        let startsInThinking = family == .maple || family == .qwen38
         return ResolvedSpecialTokens(
             bosID: endOfText,
             bosPrefixID: nil,
-            eosID: maple ? imEnd : endOfText,
+            eosID: startsInThinking ? imEnd : endOfText,
             padID: endOfText,
             endOfTurnID: imEnd,
             toolCallStartID: toolCallStart,
@@ -293,7 +299,7 @@ public struct MFTokenizer: @unchecked Sendable {
             thinkStartID: thinkStart,
             thinkEndID: thinkEnd,
             stopTokenIDs: [imEnd, endOfText],
-            vocabSize: maple ? 151_936 : 248_320)
+            vocabSize: family == .maple ? 151_936 : 248_320)
     }
 
     /// Sentinel for token roles a dialect frames as plain text rather than a
@@ -426,7 +432,7 @@ public struct MFTokenizer: @unchecked Sendable {
     /// `add_generation_prompt` + `enable_thinking=false` branch.
     private static let chatMLGenerationSuffix =
         "<|im_start|>assistant\n<think>\n\n</think>\n\n"
-    private static let mapleChatMLGenerationSuffix =
+    private static let thinkingChatMLGenerationSuffix =
         "<|im_start|>assistant\n<think>\n"
     /// DeepSeek-V4 special-token text; note the fullwidth vertical bars
     /// (U+FF5C) and the U+2581 fillers in the sentence markers.
@@ -574,7 +580,7 @@ public struct MFTokenizer: @unchecked Sendable {
             s += Self.imStartMark + message.role.rawValue + "\n" + content + Self.imEndMark + "\n"
         }
         s += generationPromptStartsInThinking
-            ? Self.mapleChatMLGenerationSuffix
+            ? Self.thinkingChatMLGenerationSuffix
             : Self.chatMLGenerationSuffix
         return s
     }
@@ -836,7 +842,7 @@ public struct MFTokenizer: @unchecked Sendable {
         case .chatml:
             let content = generationPromptStartsInThinking ? userContent : trimmedContent
             let suffix = generationPromptStartsInThinking
-                ? Self.mapleChatMLGenerationSuffix
+                ? Self.thinkingChatMLGenerationSuffix
                 : Self.chatMLGenerationSuffix
             return [endOfTurnID] + encode(
                 "\n\(Self.imStartMark)user\n\(content)\(Self.imEndMark)\n"

--- a/Sources/MferenceApp/Core/Installation/AppModelInstallDescriptor.swift
+++ b/Sources/MferenceApp/Core/Installation/AppModelInstallDescriptor.swift
@@ -110,6 +110,7 @@ public struct AppModelInstallDescriptor: Equatable, Sendable {
         switch family {
         case .gemma4: return .default
         case .qwen36: return .qwen36
+        case .qwen38: return nil   // no shipped app descriptor yet
         case .deepseekV4Flash: return .deepseekV4Flash
         case .inklingSmall: return .inklingSmall
         case .maple: return .maple
@@ -121,6 +122,7 @@ public struct AppModelInstallDescriptor: Equatable, Sendable {
         switch family {
         case .gemma4: return "gemma4.gturbo"
         case .qwen36: return "qwen36.gturbo"
+        case .qwen38: return "qwen38.gturbo"
         case .deepseekV4Flash: return "deepseekv4flash.gturbo"
         case .inklingSmall: return "inklingsmall.gturbo"
         case .maple: return "maple.gturbo"

--- a/Sources/MferenceCLI/Run.swift
+++ b/Sources/MferenceCLI/Run.swift
@@ -189,6 +189,21 @@ public func run(args: Args,
             lines += String(format: "%.1f", total - accounted) + " ms\n"
             stderr.write(Data(lines.utf8))
         }
+        if ProcessInfo.processInfo.environment["MFERENCE_PHASES"] == "1",
+           let q38 = runner as? Qwen38ForwardRunner,
+           let spec = q38.mtpSpecStats, spec.rounds > 0 {
+            let ms = { (n: UInt64) in String(format: "%.1f", Double(n) / 1e6) }
+            let acceptRate = spec.draftedTokens > 0
+                ? Double(spec.acceptedTokens) / Double(spec.draftedTokens) : 0
+            var lines = "\n[mtp spec over \(spec.rounds) rounds]\n"
+            lines += "  drafted \(spec.draftedTokens), accepted \(spec.acceptedTokens)"
+            lines += String(format: " (accept rate %.1f%%)", acceptRate * 100)
+            lines += ", emitted \(spec.emittedTokens), rollbacks \(spec.rollbacks)\n"
+            lines += "  draft: " + ms(spec.draftNanos) + " ms, verify: "
+            lines += ms(spec.verifyNanos) + " ms, accept: "
+            lines += ms(spec.acceptNanos) + " ms\n"
+            stderr.write(Data(lines.utf8))
+        }
         if !args.quiet {
             let tokensPerSecond = stats.decodeSeconds > 0
                 ? Double(stats.newTokens) / stats.decodeSeconds

--- a/Sources/MferenceRepack/Command/main.swift
+++ b/Sources/MferenceRepack/Command/main.swift
@@ -3,7 +3,7 @@ import MferenceRepackCore
 
 private let usage = """
 Usage:
-  MferenceRepack [--dry-run] [--model <gemma4|qwen36|deepseekv4flash|inklingsmall|maple>] --output <model.gturbo> [--overwrite] [--resume] [--base-url <url>]
+  MferenceRepack [--dry-run] [--model <gemma4|qwen36|qwen38|deepseekv4flash|inklingsmall|maple>] --output <model.gturbo> [--overwrite] [--resume] [--base-url <url>]
   MferenceRepack --discard-partial --output <model.gturbo>
   MferenceRepack --verify-install --input-gturbo <model.gturbo>
   MferenceRepack --help

--- a/Sources/MferenceRepack/Command/main.swift
+++ b/Sources/MferenceRepack/Command/main.swift
@@ -4,9 +4,14 @@ import MferenceRepackCore
 private let usage = """
 Usage:
   MferenceRepack [--dry-run] [--model <gemma4|qwen36|qwen38|deepseekv4flash|inklingsmall|maple>] --output <model.gturbo> [--overwrite] [--resume] [--base-url <url>]
+  MferenceRepack --attach-mtp <mtp-shard.safetensors> --output <model.gturbo>
   MferenceRepack --discard-partial --output <model.gturbo>
   MferenceRepack --verify-install --input-gturbo <model.gturbo>
   MferenceRepack --help
+
+--attach-mtp appends the Qwen 3.8 MTP draft-layer tensors from a local BF16
+safetensors shard to an existing install (projections quantized to INT4
+affine group-64), enabling speculative decoding.
 
 The installer streams the selected checkpoint (default: the supported Gemma 4
 checkpoint) from Hugging Face and repackages it without materializing the
@@ -22,6 +27,7 @@ private struct Arguments {
     var resume = false
     var discardPartial = false
     var verifyInstall = false
+    var attachMTP: String?
     var inputGTurbo: String?
     var baseURL: URL?
     var dryRun = false
@@ -49,6 +55,12 @@ private struct Arguments {
             case "--verify-install":
                 parsed.verifyInstall = true
                 index += 1
+            case "--attach-mtp":
+                guard index + 1 < values.count else {
+                    throw ParseError.missingValue(flag)
+                }
+                parsed.attachMTP = values[index + 1]
+                index += 2
             case "--model":
                 guard index + 1 < values.count else {
                     throw ParseError.missingValue(flag)
@@ -95,6 +107,16 @@ private struct Arguments {
             }
             guard parsed.inputGTurbo == nil, !parsed.overwrite, !parsed.verifyInstall else {
                 throw ParseError.invalidMode("--discard-partial only accepts --output")
+            }
+            return parsed
+        }
+        if parsed.attachMTP != nil {
+            guard parsed.output != nil else {
+                throw ParseError.missingRequired("--output")
+            }
+            guard parsed.inputGTurbo == nil, !parsed.overwrite, !parsed.resume,
+                  !parsed.verifyInstall, !parsed.dryRun else {
+                throw ParseError.invalidMode("--attach-mtp only accepts --output")
             }
             return parsed
         }
@@ -158,6 +180,21 @@ private func run(_ values: [String]) async -> Int32 {
             return 0
         } catch {
             printError("discard failed: \(error)")
+            return 1
+        }
+    }
+
+    if let shard = arguments.attachMTP, let output = arguments.output {
+        do {
+            let result = try MTPAttachTool.run(gturboDirectory: output,
+                                               shardPath: shard)
+            print("Attached \(result.tensorCount) MTP tensors to \(output)")
+            print("Appended bytes: \(result.appendedBytes)")
+            print("model_weights.bin: \(result.weightsFileBytes) bytes"
+                + (result.rewroteWeightsFile ? " (rewritten with grown index)" : " (in-place)"))
+            return 0
+        } catch {
+            printError("attach-mtp failed: \(error)")
             return 1
         }
     }

--- a/Sources/MferenceRepack/Core/Format/ArchInfo.swift
+++ b/Sources/MferenceRepack/Core/Format/ArchInfo.swift
@@ -7,6 +7,7 @@ import Foundation
 enum RepackModelFamily: String, Sendable, Equatable {
     case gemma4 = "gemma4"
     case qwen36 = "qwen36"
+    case qwen38 = "qwen38"
     case deepseekV4Flash = "deepseekV4Flash"
     case inklingSmall = "inklingSmall"
     case maple = "maple"
@@ -268,6 +269,9 @@ struct ArchInfo: Sendable, Equatable {
         }
         if (root["model_type"] as? String) == "qwen3_5_moe" {
             return try loadQwen36(configPath: configPath, tc: tc)
+        }
+        if (root["model_type"] as? String) == "qwen3_5" {
+            return try loadQwen38(configPath: configPath, tc: tc)
         }
         if (root["model_type"] as? String) == "inkling_mm_model" {
             return try loadInklingSmall(configPath: configPath, tc: tc)
@@ -803,6 +807,151 @@ struct ArchInfo: Sendable, Equatable {
                 path: configPath,
                 detail: "qwen3_5_moe config does not match the pinned "
                     + "Qwen3.6-35B-A3B architecture baseline")
+        }
+    }
+
+    // MARK: - Qwen 3.8 dense (`model_type == "qwen3_5"`)
+
+    /// Text stack of the multimodal Qwen3.8 checkpoint (the vision tower is
+    /// excluded by the planner). Same hybrid linear/full attention schedule as
+    /// Qwen 3.6, but dense: one SwiGLU MLP per layer, no router, no shared
+    /// expert, no routed experts — so the MoE slots are zeroed and every layer
+    /// counts as dense (`numDenseLayers == numLayers`).
+    private static func loadQwen38(configPath: String,
+                                   tc: [String: Any]) throws -> ArchInfo {
+        func i(_ k: String) throws -> Int {
+            guard let n = (tc[k] as? Int) ?? (tc[k] as? NSNumber)?.intValue else {
+                throw RepackError.configJsonInvalid(path: configPath, detail: "missing \(k)")
+            }
+            return n
+        }
+        guard let layerTypes = tc["layer_types"] as? [String] else {
+            throw RepackError.configJsonInvalid(path: configPath, detail: "missing layer_types")
+        }
+        var mask: [UInt8] = []
+        mask.reserveCapacity(layerTypes.count)
+        for t in layerTypes {
+            switch t {
+            case "linear_attention": mask.append(2)
+            case "full_attention":   mask.append(1)
+            default:
+                throw RepackError.configJsonInvalid(
+                    path: configPath, detail: "unknown layer_types entry \"\(t)\"")
+            }
+        }
+        let rope = (tc["rope_parameters"] as? [String: Any]) ?? [:]
+        guard let theta = (rope["rope_theta"] as? Double)
+            ?? (rope["rope_theta"] as? NSNumber)?.doubleValue else {
+            throw RepackError.configJsonInvalid(
+                path: configPath, detail: "missing rope_parameters.rope_theta")
+        }
+        guard let prf = (rope["partial_rotary_factor"] as? Double)
+            ?? (rope["partial_rotary_factor"] as? NSNumber)?.doubleValue else {
+            throw RepackError.configJsonInvalid(
+                path: configPath, detail: "missing rope_parameters.partial_rotary_factor")
+        }
+        let tie = (tc["tie_word_embeddings"] as? Bool) ?? false
+        let gate = (tc["attn_output_gate"] as? Bool) ?? false
+        let act = (tc["hidden_act"] as? String) ?? "silu"
+        let headDim = try i("head_dim")
+        let intermediate = try i("intermediate_size")
+        let numLayers = try i("num_hidden_layers")
+
+        let arch = ArchInfo(
+            hiddenSize: try i("hidden_size"),
+            intermediateSize: intermediate,
+            moeIntermediateSize: 0,
+            numHeads: try i("num_attention_heads"),
+            numKVHeads: try i("num_key_value_heads"),
+            numFullKVHeads: try i("num_key_value_heads"),
+            headDim: headDim,
+            fullHeadDim: headDim,
+            vocabSize: try i("vocab_size"),
+            slidingWindow: 0,
+            finalLogitSoftcap: 0.0,
+            ropeTheta: theta,
+            fullRopeTheta: theta,
+            partialRotaryFactor: prf,
+            numLayers: numLayers,
+            numExperts: 0,
+            topKExperts: 0,
+            tieWordEmbeddings: tie,
+            attentionKEqV: false,
+            fullAttentionLayerMask: mask,
+            hiddenActivation: act,
+            family: .qwen38,
+            attnOutputGate: gate,
+            attentionScale: 1.0 / Double(headDim).squareRoot(),
+            embeddingScaledBySqrtHidden: false,
+            routerScaled: false,
+            ffnSandwichNorms: false,
+            sharedExpertGated: false,
+            ropeNeoxSubdim: true,
+            linearNumKHeads: try i("linear_num_key_heads"),
+            linearNumVHeads: try i("linear_num_value_heads"),
+            linearKeyHeadDim: try i("linear_key_head_dim"),
+            linearValueHeadDim: try i("linear_value_head_dim"),
+            linearConvKernelSize: try i("linear_conv_kernel_dim"),
+            numSharedExperts: 0,
+            numDenseLayers: numLayers,
+            denseIntermediateSize: intermediate)
+        try crossCheckProductionQwen38(arch, configPath: configPath)
+        return arch
+    }
+
+    /// Production Qwen3.8-27B baseline (mirrors the runtime's
+    /// `ArchConfig.qwen38_27B`; the repack target has no dependency on the
+    /// runtime module). A config that matches the production shape
+    /// (hidden 5120, 64 layers) must agree on every field; toy/synthetic
+    /// configs are exempt.
+    private static func crossCheckProductionQwen38(_ a: ArchInfo,
+                                                   configPath: String) throws {
+        guard a.hiddenSize == 5120, a.numLayers == 64 else { return }
+        var expectedMask = [UInt8](repeating: 2, count: 64)
+        for i in stride(from: 3, to: 64, by: 4) { expectedMask[i] = 1 }
+        let expected = ArchInfo(
+            hiddenSize: 5120,
+            intermediateSize: 17_408,
+            moeIntermediateSize: 0,
+            numHeads: 24,
+            numKVHeads: 4,
+            numFullKVHeads: 4,
+            headDim: 256,
+            fullHeadDim: 256,
+            vocabSize: 248_320,
+            slidingWindow: 0,
+            finalLogitSoftcap: 0.0,
+            ropeTheta: 10_000_000.0,
+            fullRopeTheta: 10_000_000.0,
+            partialRotaryFactor: 0.25,
+            numLayers: 64,
+            numExperts: 0,
+            topKExperts: 0,
+            tieWordEmbeddings: false,
+            attentionKEqV: false,
+            fullAttentionLayerMask: expectedMask,
+            hiddenActivation: "silu",
+            family: .qwen38,
+            attnOutputGate: true,
+            attentionScale: 0.0625,
+            embeddingScaledBySqrtHidden: false,
+            routerScaled: false,
+            ffnSandwichNorms: false,
+            sharedExpertGated: false,
+            ropeNeoxSubdim: true,
+            linearNumKHeads: 16,
+            linearNumVHeads: 48,
+            linearKeyHeadDim: 128,
+            linearValueHeadDim: 128,
+            linearConvKernelSize: 4,
+            numSharedExperts: 0,
+            numDenseLayers: 64,
+            denseIntermediateSize: 17_408)
+        guard a == expected else {
+            throw RepackError.configJsonInvalid(
+                path: configPath,
+                detail: "qwen3_5 config does not match the pinned "
+                    + "Qwen3.8-27B architecture baseline")
         }
     }
 

--- a/Sources/MferenceRepack/Core/Format/GTurboJSON.swift
+++ b/Sources/MferenceRepack/Core/Format/GTurboJSON.swift
@@ -122,6 +122,14 @@ enum GTurboJSON {
             archDict["routerGlobalScale"] = arch.routerGlobalScale
             archDict["unpaddedVocabSize"] = arch.unpaddedVocabSize
         }
+        // Qwen 3.8 is dense: the reader validates numSharedExperts against 0
+        // (absence would default to 1) and numDenseLayers/denseIntermediateSize
+        // against the full-depth dense FFN, so all three must be written.
+        if arch.family == .qwen38 {
+            archDict["numSharedExperts"] = arch.numSharedExperts
+            archDict["numDenseLayers"] = arch.numDenseLayers
+            archDict["denseIntermediateSize"] = arch.denseIntermediateSize
+        }
         if arch.family == .maple {
             archDict["routerScoringFunc"] = arch.routerScoringFunc
             archDict["routedScalingFactor"] = arch.routedScalingFactor
@@ -146,6 +154,21 @@ enum GTurboJSON {
                 "biasType": "BF16",
                 "groupSize": plan.baseGroupSize
             ]
+        }
+        // Dense family: there is no router, shared expert or routed expert to
+        // quantize. Mark the slots absent (Maple's sharedExpert convention);
+        // embedding/attention keep the affine INT4 entries from the loop.
+        if arch.family == .qwen38 {
+            let absent: [String: Any] = [
+                "weightBits": 0,
+                "scheme": "none",
+                "scaleType": "none",
+                "biasType": "none",
+                "groupSize": 0,
+            ]
+            quantDict["router"] = absent
+            quantDict["sharedExpert"] = absent
+            quantDict["routedExpert"] = absent
         }
         if arch.family == .maple {
             let affineInt4: [String: Any] = [

--- a/Sources/MferenceRepack/Core/Planning/RepackPlanner.swift
+++ b/Sources/MferenceRepack/Core/Planning/RepackPlanner.swift
@@ -185,7 +185,7 @@ enum RepackPlanner {
     private static func hasResidentPrefix(_ name: String,
                                           family: RepackModelFamily) -> Bool {
         switch family {
-        case .gemma4, .qwen36:
+        case .gemma4, .qwen36, .qwen38:
             return name.hasPrefix("language_model.")
         case .deepseekV4Flash, .maple:
             return name.hasPrefix("model.") || name.hasPrefix("lm_head.")
@@ -203,6 +203,8 @@ enum RepackPlanner {
         switch family {
         case .gemma4:          routedContainer = ".experts.switch_glu."
         case .qwen36:          routedContainer = ".mlp.switch_mlp."
+        // Dense family: every `.mlp.*_proj` is the layer's own FFN, resident.
+        case .qwen38:          return nil
         case .deepseekV4Flash: routedContainer = ".ffn.switch_mlp."
         case .maple:           routedContainer = ".mlp.switch_mlp."
         // `.mlp.experts.` does not match the shared experts, which sit under
@@ -907,7 +909,7 @@ enum RepackPlanner {
         // norm (DeepSeek V4's `model.hc_head.*` stream collapse lands there).
         func key(_ n: String) -> (Int, Int, Int, String) {
             switch family {
-            case .gemma4, .qwen36:
+            case .gemma4, .qwen36, .qwen38:
                 if n == "language_model.model.embed_tokens.weight" { return (0, 0, 0, n) }
                 if n == "language_model.model.norm.weight"          { return (3, 0, 0, n) }
                 if n == "language_model.lm_head.weight"             { return (4, 0, 0, n) }
@@ -930,6 +932,7 @@ enum RepackPlanner {
                 switch family {
                 case .gemma4:          slot = slotRank(in: n)
                 case .qwen36:          slot = qwenSlotRank(in: n)
+                case .qwen38:          slot = qwen38SlotRank(in: n)
                 case .deepseekV4Flash: slot = deepseekV4SlotRank(in: n)
                 case .inklingSmall:    slot = inklingSlotRank(in: n)
                 case .maple:           slot = mapleSlotRank(in: n)
@@ -1022,6 +1025,34 @@ enum RepackPlanner {
         if n.contains(".mlp.shared_expert.down_proj.weight") { return 19 }
         if n.hasSuffix(".input_layernorm.weight")        { return 20 }
         if n.hasSuffix(".post_attention_layernorm.weight") { return 21 }
+        return 100
+    }
+
+    /// Within-layer slot order for the dense Qwen 3.8 family: the Qwen 3.6
+    /// attention and gated-DeltaNet ranks unchanged, then the layer's own
+    /// SwiGLU MLP where the router/shared-expert bundle would sit, then the
+    /// two layer norms.
+    private static func qwen38SlotRank(in n: String) -> Int {
+        if n.contains(".self_attn.q_proj.weight")   { return 0 }
+        if n.contains(".self_attn.k_proj.weight")   { return 1 }
+        if n.contains(".self_attn.v_proj.weight")   { return 2 }
+        if n.contains(".self_attn.o_proj.weight")   { return 3 }
+        if n.contains(".self_attn.q_norm.weight")   { return 4 }
+        if n.contains(".self_attn.k_norm.weight")   { return 5 }
+        if n.contains(".linear_attn.in_proj_qkv.weight") { return 6 }
+        if n.contains(".linear_attn.in_proj_z.weight")   { return 7 }
+        if n.contains(".linear_attn.in_proj_a.weight")   { return 8 }
+        if n.contains(".linear_attn.in_proj_b.weight")   { return 9 }
+        if n.contains(".linear_attn.conv1d.weight")      { return 10 }
+        if n.hasSuffix(".linear_attn.A_log")             { return 11 }
+        if n.hasSuffix(".linear_attn.dt_bias")           { return 12 }
+        if n.contains(".linear_attn.norm.weight")        { return 13 }
+        if n.contains(".linear_attn.out_proj.weight")    { return 14 }
+        if n.contains(".mlp.gate_proj.weight")           { return 15 }
+        if n.contains(".mlp.up_proj.weight")             { return 16 }
+        if n.contains(".mlp.down_proj.weight")           { return 17 }
+        if n.hasSuffix(".input_layernorm.weight")        { return 18 }
+        if n.hasSuffix(".post_attention_layernorm.weight") { return 19 }
         return 100
     }
 

--- a/Sources/MferenceRepack/Core/Quantization/Int4AffineEncoder.swift
+++ b/Sources/MferenceRepack/Core/Quantization/Int4AffineEncoder.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Production INT4 group-64 affine quantizer for the streaming repacker.
+///
+/// The algorithm is deliberately a bit-exact twin of the runtime module's
+/// `Quantization.quantizeInt4Affine` reference (min/max per group, scale
+/// and bias rounded through BF16 *before* index quantization, low nibble =
+/// even index): `Int4AffineEncoderParityTests` locks the two together, so
+/// weights quantized here are indistinguishable from the fixture semantics
+/// every runtime decode kernel was verified against. The duplication is the
+/// price of `MferenceRepackCore` staying free of the runtime module.
+public enum Int4AffineEncoder {
+    public static let groupSize = 64
+
+    public struct EncodedRows: Equatable, Sendable {
+        public let packed: [UInt8]   // N/2 bytes per row; low nibble = even index
+        public let scales: [UInt16]  // N/64 BF16 bit patterns per row
+        public let biases: [UInt16]  // N/64 BF16 bit patterns per row
+    }
+
+    @inline(__always)
+    static func bf16Bits(_ x: Float) -> UInt16 {
+        let bits = x.bitPattern
+        let lsb = (bits >> 16) & 1
+        let roundingBias: UInt32 = 0x7FFF &+ lsb
+        return UInt16(truncatingIfNeeded: (bits &+ roundingBias) >> 16)
+    }
+
+    @inline(__always)
+    static func bf16ToFloat(_ bits: UInt16) -> Float {
+        Float(bitPattern: UInt32(bits) << 16)
+    }
+
+    public static func encodeRow(_ row: [Float]) -> EncodedRows {
+        row.withUnsafeBufferPointer { encodeTensor($0, rowLength: row.count) }
+    }
+
+    /// Quantize `values` as consecutive rows of `rowLength` floats. Layout
+    /// matches the gturbo companion arrangement: packed nibbles for all
+    /// rows, then per-group scales, then per-group biases, row-major.
+    public static func encodeTensor(_ values: UnsafeBufferPointer<Float>,
+                                    rowLength: Int) -> EncodedRows {
+        precondition(rowLength % groupSize == 0,
+                     "row length \(rowLength) is not a multiple of \(groupSize)")
+        precondition(values.count % rowLength == 0,
+                     "value count is not a multiple of the row length")
+        let rows = values.count / rowLength
+        let groupsPerRow = rowLength / groupSize
+        var packed = [UInt8](repeating: 0, count: values.count / 2)
+        var scales = [UInt16](repeating: 0, count: rows * groupsPerRow)
+        var biases = [UInt16](repeating: 0, count: rows * groupsPerRow)
+
+        for r in 0..<rows {
+            let rowBase = r * rowLength
+            for g in 0..<groupsPerRow {
+                var wmin: Float = .infinity
+                var wmax: Float = -.infinity
+                for k in 0..<groupSize {
+                    let w = values[rowBase + g * groupSize + k]
+                    if w < wmin { wmin = w }
+                    if w > wmax { wmax = w }
+                }
+                let scaleF: Float
+                let biasF: Float
+                if wmax == wmin {
+                    // Constant group: scale=1, bias=value reconstructs exactly.
+                    scaleF = 1
+                    biasF = wmin
+                } else {
+                    scaleF = (wmax - wmin) / 15.0
+                    biasF = wmin
+                }
+                let sBits = bf16Bits(scaleF)
+                let bBits = bf16Bits(biasF)
+                scales[r * groupsPerRow + g] = sBits
+                biases[r * groupsPerRow + g] = bBits
+                // Quantize against the BF16-rounded values so the runtime
+                // decode (which reads BF16) reproduces the stored q.
+                let scale = bf16ToFloat(sBits)
+                let bias = bf16ToFloat(bBits)
+                let invScale = scale == 0 ? Float(0) : 1.0 / scale
+                for k in 0..<groupSize {
+                    let w = values[rowBase + g * groupSize + k]
+                    var q = Int(((w - bias) * invScale).rounded())
+                    q = max(0, min(15, q))
+                    let nibble = UInt8(q) & 0x0F
+                    let byteIdx = (rowBase + g * groupSize) / 2 + k / 2
+                    if (k & 1) == 0 {
+                        packed[byteIdx] = (packed[byteIdx] & 0xF0) | nibble
+                    } else {
+                        packed[byteIdx] = (packed[byteIdx] & 0x0F) | (nibble << 4)
+                    }
+                }
+            }
+        }
+        return EncodedRows(packed: packed, scales: scales, biases: biases)
+    }
+}

--- a/Sources/MferenceRepack/Core/Remote/RemoteStreamingRepacker.swift
+++ b/Sources/MferenceRepack/Core/Remote/RemoteStreamingRepacker.swift
@@ -624,6 +624,13 @@ public final class RemoteStreamingRepacker {
            let routedBits = layer.subTensors.first?.bitsForWeights {
             bits.routedExpert = routedBits
         }
+        // The dense Qwen 3.8 family has no router, shared expert or routed
+        // experts; report the slots absent rather than the 8-bit defaults.
+        if plan.arch.family == .qwen38 {
+            bits.router = 0
+            bits.sharedExpert = 0
+            bits.routedExpert = 0
+        }
         let files = audit.outputFiles.map {
             ($0.relativePath, GTurboJSON.FileEntry(size: $0.size, sha256: $0.sha256))
         }

--- a/Sources/MferenceRepack/Core/Remote/SupportedModelSource.swift
+++ b/Sources/MferenceRepack/Core/Remote/SupportedModelSource.swift
@@ -85,6 +85,23 @@ public struct SupportedModelSource: Sendable, Equatable {
         installedBytes: 19_546_491_213,
         reserveBytes: 1_073_741_824)
 
+    /// Text stack of the multimodal Qwen3.8 checkpoint; the vision tower is
+    /// excluded by the planner, so the download estimate is the repo total
+    /// (16.05 GB) minus the ~0.9 GB tower. Installed bytes add the resident
+    /// index plus layout/manifest sidecars — dense, so there are no
+    /// packed-expert blobs or page rounding.
+    public static let qwen38 = SupportedModelSource(
+        name: "qwen38",
+        displayName: "Qwen3.8 27B 4-bit",
+        repoID: "mlx-community/Qwen3.8-27B-4bit",
+        revision: "3e6447f082e89cc7f0bc6e5441afd38dfce760ff",
+        sourceIndexSHA256:
+            "13b840162b4cb35c66fef7df072f7dbb4717908204364f5e5d9f9655a2758fa8",
+        modelID: "qwen3.8-27b-4bit",
+        approximateDownloadBytes: 15_200_000_000,
+        installedBytes: 15_400_000_000,
+        reserveBytes: 1_073_741_824)
+
     /// Revision and index hash are not yet pinned (the upload has not been
     /// fingerprinted); the installer resolves HEAD and prints the computed
     /// index SHA-256 to record here. Byte estimates follow
@@ -135,7 +152,7 @@ public struct SupportedModelSource: Sendable, Equatable {
     public static let `default` = gemma4
 
     public static let all: [SupportedModelSource] = [
-        gemma4, qwen36, deepseekV4Flash, inklingSmall, maple,
+        gemma4, qwen36, qwen38, deepseekV4Flash, inklingSmall, maple,
     ]
 
     public static func named(_ name: String) -> SupportedModelSource? {

--- a/Sources/MferenceRepack/Core/Workflow/MTPAttachTool.swift
+++ b/Sources/MferenceRepack/Core/Workflow/MTPAttachTool.swift
@@ -1,0 +1,471 @@
+import Foundation
+
+/// Attaches a checkpoint's native MTP (multi-token-prediction) draft layer to
+/// an existing Qwen 3.8 `.gturbo` install.
+///
+/// The BF16 `mtp.*` tensors from the HF shard are appended to
+/// `model_weights.bin` as resident tensors: projections are quantized to
+/// INT4 affine group-64 in the MLX layout (`Int4AffineEncoder`, bit-exact
+/// with the runtime's reference quantizer) so the existing INT4 GEMV
+/// kernels consume them; norm vectors stay BF16 with the HF checkpoint's
+/// zero-centered convention converted to full form (`w + 1`, mirroring
+/// mlx-vlm's `Qwen3_5MTPDraftModel.sanitize`). Tensor names keep the source
+/// `mtp.` prefix, which the runtime probes at load; installs without them
+/// are unaffected.
+///
+/// The resident index is rewritten in place when the new entry table still
+/// fits the existing page-padded index region (the common case); otherwise
+/// the whole weights file is rebuilt with a grown index. `manifest.json`'s
+/// size/sha256 entry is refreshed, and any stale verified-install receipt is
+/// removed so it cannot bind to the old manifest.
+public enum MTPAttachTool {
+
+    public struct Result: Sendable {
+        public let tensorCount: Int
+        public let appendedBytes: UInt64
+        public let weightsFileBytes: UInt64
+        public let rewroteWeightsFile: Bool
+    }
+
+    private static let headerBytes = 24
+    private static let entryBytes = 72
+    private static let pageBytes: UInt64 = 16_384
+
+    private struct RawIndexEntry {
+        var name: String
+        var dtype: UInt8
+        var fileOffset: UInt64
+        var sizeBytes: UInt64
+        var shape: (UInt32, UInt32, UInt32, UInt32)
+        var scaleOffset: UInt64
+        var scaleSize: UInt64
+        var biasOffset: UInt64
+        var biasSize: UInt64
+    }
+
+    private struct ExpectedTensor {
+        let name: String            // without the "mtp." prefix
+        let rows: Int
+        let cols: Int?              // nil => BF16 norm vector of `rows` elements
+        let addOne: Bool            // zero-centered norm -> full form
+    }
+
+    public static func run(gturboDirectory: String, shardPath: String) throws -> Result {
+        let weightsPath = (gturboDirectory as NSString)
+            .appendingPathComponent("model_weights.bin")
+        let manifestPath = (gturboDirectory as NSString)
+            .appendingPathComponent("manifest.json")
+
+        // -- Manifest arch dims drive shape validation.
+        let manifestData = try Posix.readBoundedData(manifestPath, maximumBytes: 8 << 20)
+        guard var manifestRoot = try JSONSerialization
+                .jsonObject(with: manifestData) as? [String: Any],
+              let arch = manifestRoot["arch"] as? [String: Any],
+              let family = arch["family"] as? String, family == "qwen38",
+              let d = arch["hiddenSize"] as? Int,
+              let f = arch["ffnIntermediate"] as? Int,
+              let numHeads = arch["numHeads"] as? Int,
+              let numKVHeads = arch["numFullKVHeads"] as? Int,
+              let headDim = arch["fullHeadDim"] as? Int else {
+            throw RepackError.configurationInvalid(
+                detail: "\(manifestPath) is not a Qwen 3.8 manifest")
+        }
+        let qDim = numHeads * headDim
+        let kvDim = numKVHeads * headDim
+        let expected: [ExpectedTensor] = [
+            ExpectedTensor(name: "fc.weight", rows: d, cols: 2 * d, addOne: false),
+            ExpectedTensor(name: "pre_fc_norm_embedding.weight", rows: d, cols: nil, addOne: true),
+            ExpectedTensor(name: "pre_fc_norm_hidden.weight", rows: d, cols: nil, addOne: true),
+            ExpectedTensor(name: "norm.weight", rows: d, cols: nil, addOne: true),
+            ExpectedTensor(name: "layers.0.input_layernorm.weight", rows: d, cols: nil, addOne: true),
+            ExpectedTensor(name: "layers.0.post_attention_layernorm.weight", rows: d, cols: nil, addOne: true),
+            ExpectedTensor(name: "layers.0.self_attn.q_proj.weight", rows: 2 * qDim, cols: d, addOne: false),
+            ExpectedTensor(name: "layers.0.self_attn.k_proj.weight", rows: kvDim, cols: d, addOne: false),
+            ExpectedTensor(name: "layers.0.self_attn.v_proj.weight", rows: kvDim, cols: d, addOne: false),
+            ExpectedTensor(name: "layers.0.self_attn.o_proj.weight", rows: d, cols: qDim, addOne: false),
+            ExpectedTensor(name: "layers.0.self_attn.q_norm.weight", rows: headDim, cols: nil, addOne: true),
+            ExpectedTensor(name: "layers.0.self_attn.k_norm.weight", rows: headDim, cols: nil, addOne: true),
+            ExpectedTensor(name: "layers.0.mlp.gate_proj.weight", rows: f, cols: d, addOne: false),
+            ExpectedTensor(name: "layers.0.mlp.up_proj.weight", rows: f, cols: d, addOne: false),
+            ExpectedTensor(name: "layers.0.mlp.down_proj.weight", rows: d, cols: f, addOne: false),
+        ]
+
+        // -- Existing resident index.
+        let weightsFd = try Posix.openExistingRW(weightsPath)
+        defer { close(weightsFd) }
+        let oldFileSize = try Posix.fileSize(fd: weightsFd, path: weightsPath)
+        var (oldIndexSize, oldResidentSize, oldEntries) =
+            try readIndex(fd: weightsFd, path: weightsPath)
+        guard oldIndexSize + oldResidentSize == oldFileSize else {
+            throw RepackError.configurationInvalid(detail:
+                "\(weightsPath) size \(oldFileSize) != index \(oldIndexSize) + resident \(oldResidentSize)")
+        }
+        guard !oldEntries.contains(where: { $0.name.hasPrefix("mtp.") }) else {
+            throw RepackError.configurationInvalid(
+                detail: "\(gturboDirectory) already carries mtp.* tensors")
+        }
+
+        // -- Source shard.
+        let shardFd = try Posix.openRead(shardPath)
+        defer { close(shardFd) }
+        let shardSize = try Posix.fileSize(fd: shardFd, path: shardPath)
+        var headerLenBytes = [UInt8](repeating: 0, count: 8)
+        try headerLenBytes.withUnsafeMutableBytes {
+            try Posix.preadAll(fd: shardFd, path: shardPath,
+                               buf: $0.baseAddress!, count: 8, offset: 0)
+        }
+        let headerLen = headerLenBytes.withUnsafeBytes {
+            $0.load(as: UInt64.self).littleEndian
+        }
+        guard headerLen > 0, headerLen < Safetensors.maxHeaderBytes else {
+            throw RepackError.safetensorsHeaderTooLarge(path: shardPath, size: headerLen)
+        }
+        var headerData = Data(count: Int(headerLen))
+        try headerData.withUnsafeMutableBytes {
+            try Posix.preadAll(fd: shardFd, path: shardPath,
+                               buf: $0.baseAddress!, count: Int(headerLen), offset: 8)
+        }
+        let header = try Safetensors.parseHeaderBytes(path: shardPath,
+                                                      fileSize: shardSize,
+                                                      headerBytes: headerData)
+        var byName: [String: SourceTensor] = [:]
+        for t in header.tensors where t.name.hasPrefix("mtp.") {
+            byName[t.name] = t
+        }
+
+        // -- Quantize / convert into an appended-payload staging file plan.
+        // Payload is written straight after the current file end; entries are
+        // built against absolute offsets in the (possibly shifted) new file.
+        var appended = Data()
+        appended.reserveCapacity(1 << 20)
+        var newEntries: [RawIndexEntry] = []
+        let payloadBase = oldFileSize
+
+        for spec in expected {
+            let fullName = "mtp.\(spec.name)"
+            guard let tensor = byName[fullName] else {
+                throw RepackError.missingTensor(name: fullName)
+            }
+            guard tensor.dtype == .bf16 else {
+                throw RepackError.dtypeMismatch(name: fullName,
+                    detail: "expected BF16, got \(tensor.dtype)")
+            }
+            if let cols = spec.cols {
+                guard tensor.shape == [UInt64(spec.rows), UInt64(cols)] else {
+                    throw RepackError.shapeMismatch(name: fullName,
+                        detail: "expected [\(spec.rows), \(cols)], got \(tensor.shape)")
+                }
+                guard cols % Int4AffineEncoder.groupSize == 0 else {
+                    throw RepackError.shapeMismatch(name: fullName,
+                        detail: "cols \(cols) not a multiple of \(Int4AffineEncoder.groupSize)")
+                }
+                let weightOffset = payloadBase + UInt64(appended.count)
+                var scales = [UInt16]()
+                var biases = [UInt16]()
+                let groups = cols / Int4AffineEncoder.groupSize
+                scales.reserveCapacity(spec.rows * groups)
+                biases.reserveCapacity(spec.rows * groups)
+                // Row-batched: read BF16 rows, widen, quantize, append.
+                let batchRows = max(1, (8 << 20) / (cols * 2))
+                var floats = [Float](repeating: 0, count: batchRows * cols)
+                var raw = [UInt16](repeating: 0, count: batchRows * cols)
+                var row = 0
+                while row < spec.rows {
+                    let take = min(batchRows, spec.rows - row)
+                    let byteCount = take * cols * 2
+                    try raw.withUnsafeMutableBytes {
+                        try Posix.preadAll(fd: shardFd, path: shardPath,
+                                           buf: $0.baseAddress!, count: byteCount,
+                                           offset: tensor.absoluteOffset
+                                               + UInt64(row * cols * 2))
+                    }
+                    for i in 0..<(take * cols) {
+                        floats[i] = Float(bitPattern: UInt32(raw[i]) << 16)
+                    }
+                    let encoded = floats.withUnsafeBufferPointer {
+                        Int4AffineEncoder.encodeTensor(
+                            UnsafeBufferPointer(rebasing: $0.prefix(take * cols)),
+                            rowLength: cols)
+                    }
+                    appended.append(contentsOf: encoded.packed)
+                    scales.append(contentsOf: encoded.scales)
+                    biases.append(contentsOf: encoded.biases)
+                    row += take
+                }
+                let scaleOffset = payloadBase + UInt64(appended.count)
+                scales.withUnsafeBufferPointer {
+                    appended.append(UnsafeRawBufferPointer($0).bindMemory(to: UInt8.self))
+                }
+                let biasOffset = payloadBase + UInt64(appended.count)
+                biases.withUnsafeBufferPointer {
+                    appended.append(UnsafeRawBufferPointer($0).bindMemory(to: UInt8.self))
+                }
+                newEntries.append(RawIndexEntry(
+                    name: fullName, dtype: 0,
+                    fileOffset: weightOffset,
+                    sizeBytes: UInt64(spec.rows * cols / 2),
+                    shape: (UInt32(spec.rows), UInt32(cols), 0, 0),
+                    scaleOffset: scaleOffset,
+                    scaleSize: UInt64(spec.rows * groups * 2),
+                    biasOffset: biasOffset,
+                    biasSize: UInt64(spec.rows * groups * 2)))
+            } else {
+                guard tensor.shape == [UInt64(spec.rows)] else {
+                    throw RepackError.shapeMismatch(name: fullName,
+                        detail: "expected [\(spec.rows)], got \(tensor.shape)")
+                }
+                var raw = [UInt16](repeating: 0, count: spec.rows)
+                try raw.withUnsafeMutableBytes {
+                    try Posix.preadAll(fd: shardFd, path: shardPath,
+                                       buf: $0.baseAddress!, count: spec.rows * 2,
+                                       offset: tensor.absoluteOffset)
+                }
+                if spec.addOne {
+                    for i in 0..<raw.count {
+                        let value = Float(bitPattern: UInt32(raw[i]) << 16) + 1.0
+                        raw[i] = Int4AffineEncoder.bf16Bits(value)
+                    }
+                }
+                let offset = payloadBase + UInt64(appended.count)
+                raw.withUnsafeBufferPointer {
+                    appended.append(UnsafeRawBufferPointer($0).bindMemory(to: UInt8.self))
+                }
+                newEntries.append(RawIndexEntry(
+                    name: fullName, dtype: 1,
+                    fileOffset: offset,
+                    sizeBytes: UInt64(spec.rows * 2),
+                    shape: (UInt32(spec.rows), 0, 0, 0),
+                    scaleOffset: 0, scaleSize: 0,
+                    biasOffset: 0, biasSize: 0))
+            }
+        }
+
+        // -- New index image.
+        let allEntries = oldEntries + newEntries
+        let rawIndexBytes = headerBytes + allEntries.count * entryBytes
+            + allEntries.reduce(0) { $0 + $1.name.utf8.count }
+        let fitsInPlace = UInt64(rawIndexBytes) <= oldIndexSize
+        let newIndexSize = fitsInPlace
+            ? oldIndexSize
+            : ((UInt64(rawIndexBytes) + pageBytes - 1) / pageBytes) * pageBytes
+        let shift = newIndexSize - oldIndexSize
+        let newResidentSize = oldResidentSize + UInt64(appended.count)
+
+        var shifted = allEntries
+        if shift > 0 {
+            for i in 0..<shifted.count {
+                shifted[i].fileOffset += shift
+                if shifted[i].scaleSize > 0 { shifted[i].scaleOffset += shift }
+                if shifted[i].biasSize > 0 { shifted[i].biasOffset += shift }
+            }
+        }
+        let indexImage = encodeIndex(entries: shifted,
+                                     indexSize: newIndexSize,
+                                     residentSize: newResidentSize)
+
+        let rewrote = !fitsInPlace
+        if fitsInPlace {
+            try appended.withUnsafeBytes {
+                try Posix.pwriteAll(fd: weightsFd, path: weightsPath,
+                                    buf: $0.baseAddress!, count: appended.count,
+                                    offset: oldFileSize)
+            }
+            try indexImage.withUnsafeBytes {
+                try Posix.pwriteAll(fd: weightsFd, path: weightsPath,
+                                    buf: $0.baseAddress!, count: indexImage.count,
+                                    offset: 0)
+            }
+            try Posix.fsync(weightsFd, path: weightsPath)
+        } else {
+            // Grown index: rebuild the file with every payload byte shifted.
+            let tmpPath = weightsPath + ".mtp-attach.tmp"
+            let outFd = try Posix.openCreateRW(tmpPath)
+            defer { close(outFd) }
+            try indexImage.withUnsafeBytes {
+                try Posix.pwriteAll(fd: outFd, path: tmpPath,
+                                    buf: $0.baseAddress!, count: indexImage.count,
+                                    offset: 0)
+            }
+            let tile = 8 << 20
+            let buf = UnsafeMutableRawBufferPointer.allocate(byteCount: tile, alignment: 16_384)
+            defer { buf.deallocate() }
+            var copied: UInt64 = 0
+            while copied < oldResidentSize {
+                let take = Int(min(UInt64(tile), oldResidentSize - copied))
+                try Posix.preadAll(fd: weightsFd, path: weightsPath,
+                                   buf: buf.baseAddress!, count: take,
+                                   offset: oldIndexSize + copied)
+                try Posix.pwriteAll(fd: outFd, path: tmpPath,
+                                    buf: buf.baseAddress!, count: take,
+                                    offset: newIndexSize + copied)
+                copied += UInt64(take)
+            }
+            try appended.withUnsafeBytes {
+                try Posix.pwriteAll(fd: outFd, path: tmpPath,
+                                    buf: $0.baseAddress!, count: appended.count,
+                                    offset: newIndexSize + oldResidentSize)
+            }
+            try Posix.fsync(outFd, path: tmpPath)
+            try Posix.rename(from: tmpPath, to: weightsPath)
+        }
+
+        // -- Manifest refresh.
+        let newSize = newIndexSize + newResidentSize
+        let sha = try Sha256Stream.hashFile(path: weightsPath, tileBytes: 8 << 20)
+        guard var files = manifestRoot["files"] as? [String: Any] else {
+            throw RepackError.configurationInvalid(detail: "manifest.json has no files map")
+        }
+        files["model_weights.bin"] = ["size": Int(newSize), "sha256": sha]
+        manifestRoot["files"] = files
+        let newManifest = try JSONSerialization.data(
+            withJSONObject: manifestRoot,
+            options: [.sortedKeys, .withoutEscapingSlashes])
+        try Posix.atomicWrite(newManifest, to: manifestPath,
+                              durableIn: gturboDirectory)
+        let receiptPath = (gturboDirectory as NSString)
+            .appendingPathComponent("verified-install.json")
+        try? FileManager.default.removeItem(atPath: receiptPath)
+
+        return Result(tensorCount: newEntries.count,
+                      appendedBytes: UInt64(appended.count),
+                      weightsFileBytes: newSize,
+                      rewroteWeightsFile: rewrote)
+    }
+
+    // MARK: - Index encode/decode
+
+    private static func readIndex(fd: Int32, path: String)
+        throws -> (indexSize: UInt64, residentSize: UInt64, entries: [RawIndexEntry]) {
+        var header = [UInt8](repeating: 0, count: headerBytes)
+        try header.withUnsafeMutableBytes {
+            try Posix.preadAll(fd: fd, path: path, buf: $0.baseAddress!,
+                               count: headerBytes, offset: 0)
+        }
+        func u64(_ bytes: [UInt8], _ off: Int) -> UInt64 {
+            var v: UInt64 = 0
+            for i in (0..<8).reversed() { v = (v << 8) | UInt64(bytes[off + i]) }
+            return v
+        }
+        let indexSize = u64(header, 0)
+        let residentSize = u64(header, 8)
+        let entryCount = Int(u64(header, 16))
+        guard indexSize >= UInt64(headerBytes + entryCount * entryBytes) else {
+            throw RepackError.configurationInvalid(detail: "\(path): corrupt index header")
+        }
+        var region = [UInt8](repeating: 0, count: Int(indexSize))
+        try region.withUnsafeMutableBytes {
+            try Posix.preadAll(fd: fd, path: path, buf: $0.baseAddress!,
+                               count: Int(indexSize), offset: 0)
+        }
+        var entries: [RawIndexEntry] = []
+        entries.reserveCapacity(entryCount)
+        try region.withUnsafeBytes { raw in
+            let base = raw.baseAddress!
+            func u64p(_ p: UnsafeRawPointer, _ off: Int) -> UInt64 {
+                var v: UInt64 = 0
+                let bytes = p.advanced(by: off).assumingMemoryBound(to: UInt8.self)
+                for i in (0..<8).reversed() { v = (v << 8) | UInt64(bytes[i]) }
+                return v
+            }
+            func u32p(_ p: UnsafeRawPointer, _ off: Int) -> UInt32 {
+                var v: UInt32 = 0
+                let bytes = p.advanced(by: off).assumingMemoryBound(to: UInt8.self)
+                for i in (0..<4).reversed() { v = (v << 8) | UInt32(bytes[i]) }
+                return v
+            }
+            for i in 0..<entryCount {
+                let p = base.advanced(by: headerBytes + i * entryBytes)
+                let nameOffset = Int(u32p(p, 0))
+                let nameLength = Int(UInt16(p.advanced(by: 4)
+                    .assumingMemoryBound(to: UInt8.self)[0])
+                    | (UInt16(p.advanced(by: 5).assumingMemoryBound(to: UInt8.self)[0]) << 8))
+                guard nameOffset >= headerBytes,
+                      nameOffset + nameLength <= Int(indexSize) else {
+                    throw RepackError.configurationInvalid(
+                        detail: "\(path): entry \(i) name out of range")
+                }
+                let name = String(decoding: UnsafeRawBufferPointer(
+                    start: base.advanced(by: nameOffset), count: nameLength), as: UTF8.self)
+                entries.append(RawIndexEntry(
+                    name: name,
+                    dtype: p.advanced(by: 6).assumingMemoryBound(to: UInt8.self)[0],
+                    fileOffset: u64p(p, 8),
+                    sizeBytes: u64p(p, 16),
+                    shape: (u32p(p, 24), u32p(p, 28), u32p(p, 32), u32p(p, 36)),
+                    scaleOffset: u64p(p, 40),
+                    scaleSize: u64p(p, 48),
+                    biasOffset: u64p(p, 56),
+                    biasSize: u64p(p, 64)))
+            }
+        }
+        return (indexSize, residentSize, entries)
+    }
+
+    private static func encodeIndex(entries: [RawIndexEntry],
+                                    indexSize: UInt64,
+                                    residentSize: UInt64) -> Data {
+        var image = Data(count: Int(indexSize))
+        image.withUnsafeMutableBytes { raw in
+            let base = raw.baseAddress!
+            GTurboBinary.writeIndexHeader(into: base,
+                                          indexSize: indexSize,
+                                          residentSize: residentSize,
+                                          entryCount: UInt64(entries.count))
+            let stringTableBase = headerBytes + entries.count * entryBytes
+            var nameCursor = 0
+            for (i, entry) in entries.enumerated() {
+                let nameOffset = UInt32(stringTableBase + nameCursor)
+                let nameBytes = Array(entry.name.utf8)
+                memcpy(base.advanced(by: stringTableBase + nameCursor),
+                       nameBytes, nameBytes.count)
+                nameCursor += nameBytes.count
+                let dst = base.advanced(by: headerBytes + i * entryBytes)
+                var off = 0
+                writeU32LE(dst, &off, nameOffset)
+                writeU16LE(dst, &off, UInt16(entry.name.utf8.count))
+                writeU8(dst, &off, entry.dtype)
+                writeU8(dst, &off, 0)
+                writeU64LE(dst, &off, entry.fileOffset)
+                writeU64LE(dst, &off, entry.sizeBytes)
+                writeU32LE(dst, &off, entry.shape.0)
+                writeU32LE(dst, &off, entry.shape.1)
+                writeU32LE(dst, &off, entry.shape.2)
+                writeU32LE(dst, &off, entry.shape.3)
+                writeU64LE(dst, &off, entry.scaleOffset)
+                writeU64LE(dst, &off, entry.scaleSize)
+                writeU64LE(dst, &off, entry.biasOffset)
+                writeU64LE(dst, &off, entry.biasSize)
+            }
+        }
+        return image
+    }
+
+    private static func writeU64LE(_ buf: UnsafeMutableRawPointer, _ off: inout Int, _ v: UInt64) {
+        var x = v.littleEndian
+        withUnsafeBytes(of: &x) { src in
+            memcpy(buf.advanced(by: off), src.baseAddress!, 8)
+        }
+        off += 8
+    }
+
+    private static func writeU32LE(_ buf: UnsafeMutableRawPointer, _ off: inout Int, _ v: UInt32) {
+        var x = v.littleEndian
+        withUnsafeBytes(of: &x) { src in
+            memcpy(buf.advanced(by: off), src.baseAddress!, 4)
+        }
+        off += 4
+    }
+
+    private static func writeU16LE(_ buf: UnsafeMutableRawPointer, _ off: inout Int, _ v: UInt16) {
+        var x = v.littleEndian
+        withUnsafeBytes(of: &x) { src in
+            memcpy(buf.advanced(by: off), src.baseAddress!, 2)
+        }
+        off += 2
+    }
+
+    private static func writeU8(_ buf: UnsafeMutableRawPointer, _ off: inout Int, _ v: UInt8) {
+        buf.advanced(by: off).assumingMemoryBound(to: UInt8.self)[0] = v
+        off += 1
+    }
+}

--- a/Sources/MferenceServer/Core/ServerInference.swift
+++ b/Sources/MferenceServer/Core/ServerInference.swift
@@ -173,6 +173,7 @@ public actor ServerModelSession: ServerInferenceBackend {
         switch modelFamily {
         case .gemma4: return "gemma-4-26b-a4b-it"
         case .qwen36: return "qwen3.6-35b-a3b"
+        case .qwen38: return "qwen3.8-27b-4bit"
         case .deepseekV4Flash: return "deepseek-v4-flash-2bit-dq"
         case .inklingSmall: return "inkling-small-4bit"
         case .maple: return "maple-preview-2bit-mlx"

--- a/Tests/Mference/Core/Infrastructure/ModelIO/Int4AffineEncoderParityTests.swift
+++ b/Tests/Mference/Core/Infrastructure/ModelIO/Int4AffineEncoderParityTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import MferenceRepackCore
+@testable import Mference
+
+/// Phase A W2a gate: the repacker's production quantizer must match the
+/// runtime module's reference (`Quantization.quantizeInt4Affine`) bit for
+/// bit — packed nibbles, BF16 scale bits, BF16 bias bits — so weights we
+/// quantize ourselves are indistinguishable from the fixture semantics the
+/// runtime decode was verified against.
+@Suite struct Int4AffineEncoderParityTests {
+
+    private static func assertParity(_ row: [Float],
+                                     _ note: Comment,
+                                     sourceLocation: SourceLocation = #_sourceLocation) {
+        let reference = Quantization.quantizeInt4Affine(row)
+        let encoded = Int4AffineEncoder.encodeRow(row)
+        #expect(encoded.packed == reference.packed, note,
+                sourceLocation: sourceLocation)
+        #expect(encoded.scales == reference.scales, note,
+                sourceLocation: sourceLocation)
+        #expect(encoded.biases == reference.biases, note,
+                sourceLocation: sourceLocation)
+    }
+
+    @Test("Random rows match the reference bit for bit",
+          arguments: [64, 128, 2048, 4096])
+    func randomRowsMatch(length: Int) {
+        var state: UInt64 = 0x9E3779B97F4A7C15 &* UInt64(length)
+        func nextFloat() -> Float {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            let u = Float(state >> 40) / Float(1 << 24)
+            return (u - 0.5) * 4.0
+        }
+        for trial in 0..<8 {
+            let row = (0..<length).map { _ in nextFloat() }
+            Self.assertParity(row, "length \(length) trial \(trial)")
+        }
+    }
+
+    @Test("Edge cases match: constant, zero, extreme, sign-skewed groups")
+    func edgeCasesMatch() {
+        Self.assertParity([Float](repeating: 0, count: 64), "all zero")
+        Self.assertParity([Float](repeating: 3.25, count: 128), "constant nonzero")
+        Self.assertParity((0..<64).map { Float($0) * 1e-30 }, "denormal-scale group")
+        Self.assertParity((0..<64).map { $0 == 0 ? -1e4 : 1e4 }, "extreme spread")
+        Self.assertParity((0..<64).map { -Float($0) - 1 }, "all negative")
+        // One constant group followed by a spread group in the same row.
+        Self.assertParity([Float](repeating: -2, count: 64)
+                     + (0..<64).map { Float($0) / 7 }, "mixed groups")
+    }
+
+    @Test("Tensor encode equals row-by-row encode")
+    func tensorMatchesRows() {
+        var state: UInt64 = 0xC0FFEE
+        func nextFloat() -> Float {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return (Float(state >> 40) / Float(1 << 24) - 0.5) * 2
+        }
+        let rows = 6
+        let cols = 192
+        let values = (0..<rows * cols).map { _ in nextFloat() }
+        let tensor = values.withUnsafeBufferPointer {
+            Int4AffineEncoder.encodeTensor($0, rowLength: cols)
+        }
+        var packed = [UInt8]()
+        var scales = [UInt16]()
+        var biases = [UInt16]()
+        for r in 0..<rows {
+            let row = Array(values[r * cols ..< (r + 1) * cols])
+            let e = Int4AffineEncoder.encodeRow(row)
+            packed += e.packed
+            scales += e.scales
+            biases += e.biases
+        }
+        #expect(tensor.packed == packed)
+        #expect(tensor.scales == scales)
+        #expect(tensor.biases == biases)
+    }
+}

--- a/Tests/Mference/Core/Kernels/GDN/GDNKernelTests.swift
+++ b/Tests/Mference/Core/Kernels/GDN/GDNKernelTests.swift
@@ -613,17 +613,18 @@ import MferenceValidationSupport
         }
     }
 
-    @Test func qwenFusedDeltaGatedNormMatchesSeparateDispatches() throws {
-        let cfg = LinearAttentionConfig(
-            numKHeads: 16, numVHeads: 32,
-            keyHeadDim: 128, valueHeadDim: 128,
-            convKernelSize: 4)
+    /// The fused decode recurrence + gated norm must match the generic
+    /// two-dispatch path bit-for-bit, including the carried FP32 state.
+    private static func expectFusedDeltaGatedNormMatchesSeparateDispatches(
+        cfg: LinearAttentionConfig,
+        seed: UInt64
+    ) throws {
         let ctx = try MetalContext()
         let reference = try GDN(context: ctx, config: cfg,
                                 useQwenDecodeSpecialization: false)
         let fused = try GDN(context: ctx, config: cfg,
                             useQwenDecodeSpecialization: true)
-        var rng = SplitMix64(seed: 0x6D_3602)
+        var rng = SplitMix64(seed: seed)
         let stateCount = cfg.numVHeads * cfg.valueHeadDim * cfg.keyHeadDim
         let initialState = (0..<stateCount).map { _ in rng.uniform(-0.02, 0.02) }
         let aLogValues = (0..<cfg.numVHeads).map { _ in
@@ -703,6 +704,24 @@ import MferenceValidationSupport
             #expect(referenceState[index].bitPattern == fusedState[index].bitPattern,
                     "state differs at \(index)")
         }
+    }
+
+    @Test func qwenFusedDeltaGatedNormMatchesSeparateDispatches() throws {
+        try Self.expectFusedDeltaGatedNormMatchesSeparateDispatches(
+            cfg: LinearAttentionConfig(
+                numKHeads: 16, numVHeads: 32,
+                keyHeadDim: 128, valueHeadDim: 128,
+                convKernelSize: 4),
+            seed: 0x6D_3602)
+    }
+
+    @Test func qwen38FusedDeltaGatedNormMatchesSeparateDispatches() throws {
+        try Self.expectFusedDeltaGatedNormMatchesSeparateDispatches(
+            cfg: LinearAttentionConfig(
+                numKHeads: 16, numVHeads: 48,
+                keyHeadDim: 128, valueHeadDim: 128,
+                convKernelSize: 4),
+            seed: 0x6D_3803)
     }
 
     @Test func shortChunkTailCarry() throws {

--- a/Tests/Mference/Core/Runtime/MultiXKernelParityTests.swift
+++ b/Tests/Mference/Core/Runtime/MultiXKernelParityTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Metal
+import Testing
+@testable import Mference
+
+/// Byte-identity locks for the MTP speculative-verify kernels: the
+/// multi-token INT4 GEMV and the multi-token fused greedy head must be
+/// bit-identical, per token, to the single-token decode kernels they stand
+/// in for. This is the property that makes speculative decode's emitted
+/// tokens equal plain decode's for any draft quality.
+@Suite struct MultiXKernelParityTests {
+
+    private struct Fixture {
+        let ctx: MetalContext
+        let w: MTLBuffer
+        let s: MTLBuffer
+        let b: MTLBuffer
+        let x: MTLBuffer
+        let k: Int
+        let n: Int
+        let t: Int
+    }
+
+    private func makeFixture(k: Int, n: Int, t: Int, seed: UInt64) throws -> Fixture {
+        let ctx = try MetalContext()
+        let device = ctx.device
+        var rng = seed
+        func nextByte() -> UInt8 {
+            rng = rng &* 6364136223846793005 &+ 1442695040888963407
+            return UInt8(truncatingIfNeeded: rng >> 33)
+        }
+        let groups = k / 64
+        let w = device.makeBuffer(length: n * k / 2, options: .storageModeShared)!
+        let wp = w.contents().assumingMemoryBound(to: UInt8.self)
+        for i in 0..<(n * k / 2) { wp[i] = nextByte() }
+        let s = device.makeBuffer(length: n * groups * 2, options: .storageModeShared)!
+        let b = device.makeBuffer(length: n * groups * 2, options: .storageModeShared)!
+        let sp = s.contents().assumingMemoryBound(to: UInt16.self)
+        let bp = b.contents().assumingMemoryBound(to: UInt16.self)
+        for i in 0..<(n * groups) {
+            sp[i] = Quantization.bf16Bits(0.001 + 0.0007 * Float(i % 13))
+            bp[i] = Quantization.bf16Bits(-0.03 + 0.006 * Float(i % 9))
+        }
+        let x = device.makeBuffer(length: t * k * 2, options: .storageModeShared)!
+        let xp = x.contents().assumingMemoryBound(to: Float16.self)
+        for i in 0..<(t * k) { xp[i] = Float16(Float(nextByte()) / 64.0 - 2.0) }
+        return Fixture(ctx: ctx, w: w, s: s, b: b, x: x, k: k, n: n, t: t)
+    }
+
+    @Test("multi-x GEMV rows equal per-token decode GEMV bit for bit",
+          arguments: [(64, 64, 2), (5120, 1024, 4), (1024, 5120, 7)])
+    func multixMatchesGEMV(k: Int, n: Int, t: Int) throws {
+        let f = try makeFixture(k: k, n: n, t: t, seed: 0xFEED_0000 &+ UInt64(k &* n))
+        let ctx = f.ctx
+        let yMulti = ctx.device.makeBuffer(length: t * n * 2, options: .storageModeShared)!
+        let ySingle = ctx.device.makeBuffer(length: t * n * 2, options: .storageModeShared)!
+        let gemv = try DequantInt4GEMV(context: ctx)
+        let multix = try DequantInt4GEMVMultiX(context: ctx)
+
+        let cb = ctx.queue.makeCommandBuffer()!
+        multix.encode(commandBuffer: cb, weights: f.w, scales: f.s, biases: f.b,
+                      x: f.x, y: yMulti, m: n, n: k, tokens: t)
+        for row in 0..<t {
+            gemv.encode(commandBuffer: cb,
+                        weights: f.w, scales: f.s, biases: f.b,
+                        x: f.x, xOffset: row * k * 2,
+                        y: ySingle, yOffset: row * n * 2,
+                        m: UInt32(n), n: UInt32(k))
+        }
+        cb.commit(); cb.waitUntilCompleted()
+
+        let a = yMulti.contents().bindMemory(to: UInt16.self, capacity: t * n)
+        let c = ySingle.contents().bindMemory(to: UInt16.self, capacity: t * n)
+        var mismatches = 0
+        for i in 0..<(t * n) where a[i] != c[i] { mismatches += 1 }
+        #expect(mismatches == 0, "k=\(k) n=\(n) t=\(t): \(mismatches) mismatched outputs")
+    }
+
+    @Test("multi-x greedy head equals per-token fused head",
+          arguments: [(64, 1024, 3), (256, 1000, 5)])
+    func multixHeadMatchesFusedHead(d: Int, vocab: Int, t: Int) throws {
+        let f = try makeFixture(k: d, n: vocab, t: t, seed: 0xABCD_1234 &+ UInt64(d))
+        let ctx = f.ctx
+        // The fused head normalizes internally; feed it a unit norm weight so
+        // both paths consume the same normalized rows.
+        let unitNorm = ctx.device.makeBuffer(length: d * 2, options: .storageModeShared)!
+        let np = unitNorm.contents().assumingMemoryBound(to: UInt16.self)
+        for i in 0..<d { np[i] = Quantization.bf16Bits(1.0 + 0.05 * Float(i % 3)) }
+
+        let rms = try RMSNorm(context: ctx)
+        let normedRows = ctx.device.makeBuffer(length: t * d * 2, options: .storageModeShared)!
+        let outMulti = ctx.device.makeBuffer(length: t * 4, options: .storageModeShared)!
+        let outSingle = ctx.device.makeBuffer(length: 4, options: .storageModeShared)!
+        let fused = try LMHeadChainInt4(context: ctx, maxD: d, maxVocab: vocab)
+        let multi = try LMHeadGreedyMultiX(context: ctx, maxVocab: vocab)
+
+        // Multi-x path: explicit per-row rms (the decode kernel) + one pass.
+        let cb = ctx.queue.makeCommandBuffer()!
+        for row in 0..<t {
+            rms.encodeBF16W(commandBuffer: cb,
+                            x: f.x, xOffset: row * d * 2,
+                            weight: unitNorm,
+                            out: normedRows, outOffset: row * d * 2,
+                            d: UInt32(d), eps: 1e-6)
+        }
+        multi.encode(commandBuffer: cb,
+                     xNormed: normedRows,
+                     weights: f.w, scales: f.s, biases: f.b,
+                     outTokens: outMulti,
+                     d: d, vocab: vocab, tokens: t)
+        cb.commit(); cb.waitUntilCompleted()
+
+        // Reference: the decode fused head once per row.
+        var reference: [UInt32] = []
+        for row in 0..<t {
+            let cb2 = ctx.queue.makeCommandBuffer()!
+            fused.encodeGreedyDecode(commandBuffer: cb2,
+                                     hidden: f.x, hiddenOffset: row * d * 2,
+                                     normWeight: unitNorm,
+                                     weights: f.w, scales: f.s, biases: f.b,
+                                     outToken: outSingle,
+                                     d: UInt32(d), vocab: UInt32(vocab))
+            cb2.commit(); cb2.waitUntilCompleted()
+            reference.append(outSingle.contents().load(as: UInt32.self))
+        }
+        let got = Array(UnsafeBufferPointer(
+            start: outMulti.contents().bindMemory(to: UInt32.self, capacity: t),
+            count: t))
+        #expect(got == reference, "d=\(d) vocab=\(vocab) t=\(t)")
+    }
+}

--- a/Tests/Mference/Core/Runtime/Qwen38ForwardRunnerTests.swift
+++ b/Tests/Mference/Core/Runtime/Qwen38ForwardRunnerTests.swift
@@ -37,6 +37,10 @@ import Testing
             count: Self.vocab))
     }
 
+    private static func prompt(_ count: Int) -> [Int32] {
+        (0..<count).map { Int32(($0 * 37 + 11) % vocab) }
+    }
+
     /// Factory dispatch: a qwen38 model selects the dense runner with FP16
     /// KV storage, and the qwen36 selection is unchanged (mirrors
     /// `qwenFactory_preservesChunkedFusedRunnerSelection`).
@@ -149,6 +153,101 @@ import Testing
 
         try await runner.produce(token: 9, position: prompt.count, into: logits)
         #expect(runner.lastGreedyToken == reference)
+    }
+
+    /// The chunked-prefill correctness gate (mirrors the Maple
+    /// `mapleChunkedPrefill_matchesSequentialLogitsAndContinuation` pattern):
+    /// the final prompt-token logits and every continuation-decode logits row
+    /// after a chunked prefill must be identical to sequential decode from a
+    /// fresh state. Shapes cover a prompt shorter than one chunk (5/32), a
+    /// prompt that is not a chunk multiple (40/32), a multi-chunk prompt
+    /// (70/32), and exactly one full chunk (64/64).
+    @Test("chunked prefill equals sequential decode",
+          arguments: [(5, 32), (40, 32), (70, 32), (64, 64)])
+    func chunkedPrefill_matchesSequentialDecodeLogits(promptLength: Int,
+                                                      chunkTokens: Int) async throws {
+        let (dir, ctx, runner) = try makeRunner(maxContext: 96)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx)
+        let prompt = Self.prompt(promptLength)
+        let continuation: [Int32] = [5, 91, 200]
+
+        // Sequential-decode reference: every prompt and continuation token
+        // through the decode path with the exact logits head.
+        var reference: [[UInt16]] = []
+        for (position, token) in prompt.enumerated() {
+            try await runner.produceExactPrefill(token: token, position: position,
+                                                 into: logits)
+        }
+        reference.append(bits(logits))
+        for (index, token) in continuation.enumerated() {
+            try await runner.produceExactPrefill(token: token,
+                                                 position: prompt.count + index,
+                                                 into: logits)
+            reference.append(bits(logits))
+        }
+
+        runner.reset()
+        var progress: [Int] = []
+        let result = try await runner.prefillChunked(
+            tokens: prompt[...],
+            startPosition: 0,
+            outputMode: .logits,
+            config: .production(chunkTokens: chunkTokens),
+            into: logits,
+            onProgress: { progress.append($0) })
+        #expect(result == PrefillResult(newPosition: prompt.count, seed: .logitsWritten))
+        #expect(progress.last == prompt.count)
+        #expect(runner.continuationPosition == prompt.count)
+        var chunked: [[UInt16]] = [bits(logits)]
+        for (index, token) in continuation.enumerated() {
+            try await runner.produceExactPrefill(token: token,
+                                                 position: prompt.count + index,
+                                                 into: logits)
+            chunked.append(bits(logits))
+        }
+
+        #expect(reference.count == chunked.count)
+        for (step, (want, got)) in zip(reference, chunked).enumerated() {
+            let mismatches = zip(want, got).filter { $0 != $1 }.count
+            #expect(mismatches == 0,
+                    "prompt \(promptLength) chunk \(chunkTokens) step \(step): \(mismatches) mismatched logits")
+        }
+    }
+
+    /// Fused-greedy continuation across a chunk boundary: a multi-chunk
+    /// prefill must seed the same greedy token as pure decode and continue
+    /// decoding identically (KV rows, GDN state, and conv tails all carry
+    /// across chunks).
+    @Test func chunkedPrefill_multiChunkGreedyContinuation_matchesPureDecode() async throws {
+        let (dir, ctx, runner) = try makeRunner(maxContext: 96)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx)
+        let prompt = Self.prompt(40)
+
+        for (position, token) in prompt.enumerated() {
+            try await runner.produce(token: token, position: position, into: logits)
+        }
+        let referenceSeed = runner.lastGreedyToken
+        try await runner.produce(token: 9, position: prompt.count, into: logits)
+        let referenceNext = runner.lastGreedyToken
+
+        runner.reset()
+        let result = try await runner.prefillChunked(
+            tokens: prompt[...],
+            startPosition: 0,
+            outputMode: .greedyIfAvailable,
+            config: .production(chunkTokens: 32),
+            into: logits,
+            onProgress: { _ in })
+        #expect(result.newPosition == prompt.count)
+        if case .greedyToken(let seed) = result.seed {
+            #expect(seed == referenceSeed)
+        } else {
+            Issue.record("expected a greedy seed token from the fused head")
+        }
+        try await runner.produce(token: 9, position: prompt.count, into: logits)
+        #expect(runner.lastGreedyToken == referenceNext)
     }
 
     /// Headless and exact-prefill paths: produceWithoutLogits advances state

--- a/Tests/Mference/Core/Runtime/Qwen38ForwardRunnerTests.swift
+++ b/Tests/Mference/Core/Runtime/Qwen38ForwardRunnerTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Metal
+import Testing
+@testable import Mference
+
+/// Qwen 3.8 dense runtime integration against the qwen38 toy fixture:
+/// factory dispatch, deterministic decode replay across runner instances,
+/// KV + GDN state reset correctness, and the sequential-replay prefill v1
+/// matching pure decode.
+@Suite struct Qwen38ForwardRunnerTests {
+    private static let vocab = 1024
+
+    private func makeRunner(maxContext: Int = 64) throws -> (URL, MetalContext, Qwen38ForwardRunner) {
+        let dir = try Qwen38ToySynthetic.write()
+        let ctx = try MetalContext()
+        let model = try Model.load(directoryURL: dir,
+                                   device: ctx.device,
+                                   expecting: .qwen38Toy())
+        let runner = try Qwen38ForwardRunner(model: model,
+                                             context: ctx,
+                                             maxContext: maxContext)
+        return (dir, ctx, runner)
+    }
+
+    private func makeLogits(_ ctx: MetalContext) throws -> MTLBuffer {
+        guard let buf = ctx.device.makeBuffer(
+            length: Self.vocab * MemoryLayout<Float16>.stride,
+            options: .storageModeShared) else {
+            throw ModelError.residentBufferWrapFailed
+        }
+        return buf
+    }
+
+    private func bits(_ logits: MTLBuffer) -> [UInt16] {
+        Array(UnsafeBufferPointer(
+            start: logits.contents().bindMemory(to: UInt16.self, capacity: Self.vocab),
+            count: Self.vocab))
+    }
+
+    /// Factory dispatch: a qwen38 model selects the dense runner with FP16
+    /// KV storage, and the qwen36 selection is unchanged (mirrors
+    /// `qwenFactory_preservesChunkedFusedRunnerSelection`).
+    @Test func qwen38Factory_selectsDenseRunnerAndPreservesQwen36() throws {
+        let dir = try Qwen38ToySynthetic.write()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let ctx = try MetalContext()
+        let model = try Model.load(directoryURL: dir, device: ctx.device,
+                                   expecting: .qwen38Toy())
+        let requested = RuntimeConfiguration(prefillEnabled: true, forceLogitsHead: false)
+        let runtime = try ForwardRunnerFactory.make(model: model, context: ctx,
+                                                    maxContext: 64,
+                                                    runtimeConfiguration: requested)
+        #expect(runtime.producer is Qwen38ForwardRunner)
+        #expect(runtime.producer is any ChunkedPrefillRunner)
+        #expect(runtime.producer is any HeadlessSequentialPrefillRunner)
+        #expect(runtime.producer is any ExactPrefillLogitProducer)
+        #expect(runtime.prefillConfig == requested.prefillConfig)
+        #expect(runtime.executedPrefillMode == .chunked)
+        #expect(runtime.kvStorageMode == .fp16)
+        #expect((runtime.producer as? any FusedHeadLogitProducer)?.usesFusedGreedyHead == true)
+
+        let qwen36Dir = try QwenToySynthetic.write()
+        defer { try? FileManager.default.removeItem(at: qwen36Dir) }
+        let qwen36Model = try Model.load(directoryURL: qwen36Dir, device: ctx.device,
+                                         expecting: .qwen36Toy())
+        let qwen36Runtime = try ForwardRunnerFactory.make(model: qwen36Model, context: ctx,
+                                                          maxContext: 64,
+                                                          runtimeConfiguration: requested)
+        #expect(qwen36Runtime.producer is RealForwardRunner)
+        #expect(qwen36Runtime.kvStorageMode == .fp16)
+    }
+
+    /// Deterministic decode replay: two fresh runner instances fed the same
+    /// tokens must produce identical greedy tokens at every step.
+    @Test func decodeReplay_isDeterministicAcrossInstances() async throws {
+        let (dirA, ctxA, runnerA) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dirA) }
+        let (dirB, ctxB, runnerB) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dirB) }
+        let logitsA = try makeLogits(ctxA)
+        let logitsB = try makeLogits(ctxB)
+
+        let tokens: [Int32] = [1, 17, 300, 5]
+        var greedyA: [UInt32] = []
+        var greedyB: [UInt32] = []
+        for (position, token) in tokens.enumerated() {
+            try await runnerA.produce(token: token, position: position, into: logitsA)
+            try await runnerB.produce(token: token, position: position, into: logitsB)
+            greedyA.append(runnerA.lastGreedyToken)
+            greedyB.append(runnerB.lastGreedyToken)
+        }
+        #expect(greedyA == greedyB)
+        #expect(greedyA.allSatisfy { $0 < UInt32(Self.vocab) })
+        #expect(runnerA.continuationPosition == tokens.count)
+    }
+
+    /// Sequential-vs-restart reset correctness: the same input from the empty
+    /// state must reproduce the same argmax after reset() — this fails if
+    /// reset() leaves stale KV rows, GDN recurrent state, or conv tail.
+    @Test func reset_restoresEmptyContextState() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx)
+
+        try await runner.produce(token: 1, position: 0, into: logits)
+        let first = runner.lastGreedyToken
+        try await runner.produce(token: Int32(first), position: 1, into: logits)
+        #expect(runner.continuationPosition == 2)
+
+        runner.reset()
+        #expect(runner.continuationPosition == 0)
+        try await runner.produce(token: 1, position: 0, into: logits)
+        #expect(runner.lastGreedyToken == first)
+    }
+
+    /// Prefill v1 is a sequential decode replay, so prefilling a prompt then
+    /// decoding must match pure decode from a fresh state exactly (shared
+    /// KV + GDN recurrent state + conv tail).
+    @Test func prefillChunked_matchesPureDecode() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx)
+
+        // Pure decode reference over a mixed linear/full-layer state history.
+        let prompt: [Int32] = [11, 42, 7]
+        for (position, token) in prompt.enumerated() {
+            try await runner.produce(token: token, position: position, into: logits)
+        }
+        try await runner.produce(token: 9, position: prompt.count, into: logits)
+        let reference = runner.lastGreedyToken
+
+        runner.reset()
+        var progress: [Int] = []
+        let result = try await runner.prefillChunked(
+            tokens: prompt[...],
+            startPosition: 0,
+            outputMode: .greedyIfAvailable,
+            config: .production(chunkTokens: 32),
+            into: logits,
+            onProgress: { progress.append($0) })
+        #expect(result.newPosition == prompt.count)
+        if case .greedyToken(let seed) = result.seed {
+            #expect(seed < UInt32(Self.vocab))
+        } else {
+            Issue.record("expected a greedy seed token from the fused head")
+        }
+        #expect(progress.last == prompt.count)
+        #expect(runner.continuationPosition == prompt.count)
+
+        try await runner.produce(token: 9, position: prompt.count, into: logits)
+        #expect(runner.lastGreedyToken == reference)
+    }
+
+    /// Headless and exact-prefill paths: produceWithoutLogits advances state
+    /// without touching the logits buffer; produceExactPrefill then writes a
+    /// full logits row identical to the plain logits-head decode.
+    @Test func headlessAndExactPrefillPaths() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx)
+        let sentinel: UInt16 = 0x7BFF
+        let values = logits.contents().bindMemory(to: UInt16.self, capacity: Self.vocab)
+        for index in 0..<Self.vocab { values[index] = sentinel }
+
+        let headless: any HeadlessSequentialPrefillRunner = runner
+        try await headless.produceWithoutLogits(token: 3, position: 0)
+        #expect(bits(logits).allSatisfy { $0 == sentinel })
+        #expect(runner.continuationPosition == 1)
+
+        let exact: any ExactPrefillLogitProducer = runner
+        try await exact.produceExactPrefill(token: 4, position: 1, into: logits)
+        let exactBits = bits(logits)
+        #expect(exactBits != Array(repeating: sentinel, count: Self.vocab))
+        #expect(runner.continuationPosition == 2)
+
+        // The exact head must be reproducible from a replayed state.
+        runner.reset()
+        try await headless.produceWithoutLogits(token: 3, position: 0)
+        try await exact.produceExactPrefill(token: 4, position: 1, into: logits)
+        #expect(bits(logits) == exactBits)
+    }
+
+    /// Cursor discipline mirrors the other runners: produce at the wrong
+    /// position and stale continuation cursors are rejected.
+    @Test func cursorMismatch_isRejected() async throws {
+        let (dir, ctx, runner) = try makeRunner()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let logits = try makeLogits(ctx)
+
+        try await runner.produce(token: 1, position: 0, into: logits)
+        await #expect(throws: Qwen38ForwardRunnerError.self) {
+            try await runner.produce(token: 1, position: 0, into: logits)
+        }
+        try runner.prepareForContinuation(expectedPosition: 1)
+        #expect(throws: PrefillError.self) {
+            try runner.prepareForContinuation(expectedPosition: 2)
+        }
+    }
+}

--- a/Tests/Mference/Core/Runtime/Qwen38MTPSpecTests.swift
+++ b/Tests/Mference/Core/Runtime/Qwen38MTPSpecTests.swift
@@ -1,0 +1,262 @@
+import Foundation
+import Metal
+import Testing
+@testable import Mference
+@testable import MferenceRepackCore
+
+/// Qwen 3.8 MTP speculative decoding against the toy fixture with the
+/// draft layer attached by the real `MTPAttachTool`:
+///
+///  - the attach step produces a loadable install whose `mtp.*` tensors
+///    resolve at runtime,
+///  - speculative greedy decode is byte-identical to plain decode for
+///    organic drafts (near-zero acceptance: the rollback path), injected
+///    always-correct drafts (full acceptance: no rollback), injected
+///    partially-correct drafts (mixed acceptance), and several draft depths,
+///  - the `MFERENCE_MTP=0` kill switch disables the speculator.
+///
+/// Serialized: two cases mutate process environment before runner creation.
+@Suite(.serialized) struct Qwen38MTPSpecTests {
+    private static let vocab = 1024
+
+    /// One attached toy install shared by the suite (attach is idempotent
+    /// per directory; each call builds a fresh toy).
+    private static func makeAttachedDirectory() throws -> URL {
+        let dir = try Qwen38ToySynthetic.write()
+        let shard = try Qwen38ToySynthetic.writeMTPShard()
+        defer { try? FileManager.default.removeItem(at: shard) }
+        let result = try MTPAttachTool.run(gturboDirectory: dir.path,
+                                           shardPath: shard.path)
+        #expect(result.tensorCount == 15)
+        return dir
+    }
+
+    private func makeRunner(_ dir: URL, maxContext: Int = 96) throws
+        -> (MetalContext, Qwen38ForwardRunner) {
+        let ctx = try MetalContext()
+        let model = try Model.load(directoryURL: dir,
+                                   device: ctx.device,
+                                   expecting: .qwen38Toy())
+        let runner = try Qwen38ForwardRunner(model: model,
+                                             context: ctx,
+                                             maxContext: maxContext)
+        return (ctx, runner)
+    }
+
+    private func makeLogits(_ ctx: MetalContext) throws -> MTLBuffer {
+        guard let buf = ctx.device.makeBuffer(
+            length: Self.vocab * MemoryLayout<Float16>.stride,
+            options: .storageModeShared) else {
+            throw ModelError.residentBufferWrapFailed
+        }
+        return buf
+    }
+
+    /// Greedy generation mirroring `runRawCompletion`'s fused-greedy loop:
+    /// chunked prefill seeds the first token, then one `produce` per token.
+    private func generate(_ runner: Qwen38ForwardRunner,
+                          logits: MTLBuffer,
+                          prompt: [Int32],
+                          newTokens: Int) async throws -> [Int32] {
+        runner.reset()
+        let result = try await runner.prefillChunked(
+            tokens: prompt[...],
+            startPosition: 0,
+            outputMode: .greedyIfAvailable,
+            config: .production(chunkTokens: 32),
+            into: logits,
+            onProgress: { _ in })
+        guard case .greedyToken(let seed) = result.seed else {
+            Issue.record("expected a greedy prefill seed")
+            return []
+        }
+        var out: [Int32] = [Int32(bitPattern: seed)]
+        var position = prompt.count
+        while out.count < newTokens {
+            try await runner.produce(token: out.last!, position: position, into: logits)
+            position += 1
+            out.append(Int32(bitPattern: runner.lastGreedyToken))
+        }
+        return out
+    }
+
+    private static func prompt(_ count: Int) -> [Int32] {
+        (0..<count).map { Int32(($0 * 37 + 11) % vocab) }
+    }
+
+    @Test func attachProducesLoadableInstall() throws {
+        let dir = try Self.makeAttachedDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let ctx = try MetalContext()
+        // Model.load re-verifies the manifest sha256 of the rewritten
+        // weights file, so a load success also validates the attach output.
+        let model = try Model.load(directoryURL: dir, device: ctx.device,
+                                   expecting: .qwen38Toy())
+        let fc = try model.resident(name: "mtp.fc.weight")
+        #expect(fc.dtype == 0)
+        #expect(fc.shape.0 == 64 && fc.shape.1 == 128)
+        #expect(fc.scaleLength > 0 && fc.biasLength > 0)
+        let norm = try model.resident(name: "mtp.norm.weight")
+        #expect(norm.dtype == 1)
+        // Zero-centered source values became full form: all near 1.0.
+        let values = norm.buffer.contents().advanced(by: Int(norm.offset))
+            .bindMemory(to: UInt16.self, capacity: 64)
+        for i in 0..<64 {
+            let value = Float(bitPattern: UInt32(values[i]) << 16)
+            #expect(abs(value - 1.0) < 0.5, "norm[\(i)] = \(value)")
+        }
+        // Attaching twice must be rejected.
+        let shard = try Qwen38ToySynthetic.writeMTPShard()
+        defer { try? FileManager.default.removeItem(at: shard) }
+        #expect(throws: (any Error).self) {
+            _ = try MTPAttachTool.run(gturboDirectory: dir.path, shardPath: shard.path)
+        }
+    }
+
+    @Test("speculative decode is byte-identical to plain decode",
+          arguments: [1, 2, 3])
+    func specMatchesPlain_organicDrafts(k: Int) async throws {
+        let dir = try Self.makeAttachedDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (ctxPlain, plainRunner) = try makeRunner(dir)
+        plainRunner.mtp = nil
+        let (ctxSpec, specRunner) = try makeRunner(dir)
+        let mtp = try #require(specRunner.mtp)
+        #expect(k <= mtp.draftCapacity)
+        mtp.draftCount = k
+
+        let logitsPlain = try makeLogits(ctxPlain)
+        let logitsSpec = try makeLogits(ctxSpec)
+        for promptLength in [3, 40] {
+            let prompt = Self.prompt(promptLength)
+            let want = try await generate(plainRunner, logits: logitsPlain,
+                                          prompt: prompt, newTokens: 40)
+            let got = try await generate(specRunner, logits: logitsSpec,
+                                         prompt: prompt, newTokens: 40)
+            #expect(want == got, "k=\(k) prompt=\(promptLength)")
+        }
+        #expect(mtp.stats.rounds > 0)
+    }
+
+    @Test("byte identity under forced full and partial acceptance")
+    func specMatchesPlain_injectedDrafts() async throws {
+        let dir = try Self.makeAttachedDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (ctxPlain, plainRunner) = try makeRunner(dir)
+        plainRunner.mtp = nil
+        let logitsPlain = try makeLogits(ctxPlain)
+        let prompt = Self.prompt(9)
+        let newTokens = 48
+        let want = try await generate(plainRunner, logits: logitsPlain,
+                                      prompt: prompt, newTokens: newTokens)
+
+        // The injector needs the position of each round inside the expected
+        // stream; the produce loop below keeps the box current.
+        final class Cursor { var produced = 0 }
+        let cursor = Cursor()
+
+        // scenario: given the correct continuation for the round, the drafts
+        // to inject (correct prefix length varies -> full/partial/none).
+        let scenarios: [(String, (_ correct: [Int32], _ round: Int) -> [Int32])] = [
+            ("full", { correct, _ in correct }),
+            ("none", { correct, _ in correct.map { ($0 &+ 1) % Int32(Self.vocab) } }),
+            ("mixed", { correct, round in
+                var drafts = correct
+                let keep = round % (drafts.count + 1)
+                for i in keep..<drafts.count {
+                    drafts[i] = (drafts[i] &+ 1) % Int32(Self.vocab)
+                }
+                return drafts
+            }),
+        ]
+
+        for (name, scenario) in scenarios {
+            let (ctxSpec, specRunner) = try makeRunner(dir)
+            let mtp = try #require(specRunner.mtp)
+            mtp.draftOverride = { round, k in
+                // The round's bonus token is want[cursor.produced - 1]; its
+                // verified continuation is the next k expected tokens.
+                let start = cursor.produced
+                let correct = (0..<k).map { offset -> Int32 in
+                    let index = start + offset
+                    return index < want.count ? want[index] : 7
+                }
+                return scenario(correct, round)
+            }
+            let logitsSpec = try makeLogits(ctxSpec)
+
+            specRunner.reset()
+            let result = try await specRunner.prefillChunked(
+                tokens: prompt[...], startPosition: 0,
+                outputMode: .greedyIfAvailable,
+                config: .production(chunkTokens: 32),
+                into: logitsSpec, onProgress: { _ in })
+            guard case .greedyToken(let seed) = result.seed else {
+                Issue.record("expected a greedy prefill seed")
+                return
+            }
+            var got: [Int32] = [Int32(bitPattern: seed)]
+            var position = prompt.count
+            while got.count < newTokens {
+                cursor.produced = got.count
+                try await specRunner.produce(token: got.last!, position: position,
+                                             into: logitsSpec)
+                position += 1
+                got.append(Int32(bitPattern: specRunner.lastGreedyToken))
+            }
+            #expect(got == want, "scenario \(name)")
+            if name == "full" {
+                #expect(mtp.stats.rollbacks == 0, "full acceptance must not roll back")
+                #expect(mtp.stats.acceptedTokens == mtp.stats.draftedTokens)
+            }
+            if name == "none" {
+                #expect(mtp.stats.acceptedTokens == 0)
+                #expect(mtp.stats.rollbacks == mtp.stats.rounds)
+            }
+        }
+    }
+
+    @Test("deeper draft depth via MFERENCE_MTP_K")
+    func specMatchesPlain_k4() async throws {
+        setenv("MFERENCE_MTP_K", "4", 1)
+        defer { unsetenv("MFERENCE_MTP_K") }
+        let dir = try Self.makeAttachedDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (ctxPlain, plainRunner) = try makeRunner(dir)
+        plainRunner.mtp = nil
+        let (ctxSpec, specRunner) = try makeRunner(dir)
+        let mtp = try #require(specRunner.mtp)
+        #expect(mtp.draftCapacity == 4)
+
+        let logitsPlain = try makeLogits(ctxPlain)
+        let logitsSpec = try makeLogits(ctxSpec)
+        let prompt = Self.prompt(12)
+        let want = try await generate(plainRunner, logits: logitsPlain,
+                                      prompt: prompt, newTokens: 40)
+        let got = try await generate(specRunner, logits: logitsSpec,
+                                     prompt: prompt, newTokens: 40)
+        #expect(want == got)
+    }
+
+    @Test("MFERENCE_MTP=0 disables the speculator")
+    func killSwitch() async throws {
+        setenv("MFERENCE_MTP", "0", 1)
+        defer { unsetenv("MFERENCE_MTP") }
+        let dir = try Self.makeAttachedDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (_, runner) = try makeRunner(dir)
+        #expect(runner.mtp == nil)
+    }
+
+    @Test("plain qwen38 installs without MTP tensors stay unaffected")
+    func noMTPTensorsMeansNoSpeculator() async throws {
+        let dir = try Qwen38ToySynthetic.write()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (ctx, runner) = try makeRunner(dir)
+        #expect(runner.mtp == nil)
+        let logits = try makeLogits(ctx)
+        let tokens = try await generate(runner, logits: logits,
+                                        prompt: Self.prompt(5), newTokens: 8)
+        #expect(tokens.count == 8)
+    }
+}

--- a/Tests/Mference/Core/Runtime/Qwen38ToySynthetic.swift
+++ b/Tests/Mference/Core/Runtime/Qwen38ToySynthetic.swift
@@ -1,0 +1,341 @@
+import Foundation
+@testable import Mference
+@testable import MferenceRepackCore
+
+/// Synthetic Qwen 3.8 toy fixture: a tiny runnable `.gturbo/` directory with
+/// the qwen38 tensor-name contract (linear_attn.* on mask-2 layers,
+/// self_attn.* with packed [query ; gate] q_proj on mask-1 layers, a dense
+/// mlp.{gate,up,down}_proj per layer, untied lm_head, NO router, NO experts,
+/// NO shared-expert tensors). Mirrors `QwenToySynthetic` for the qwen36 toy.
+enum Qwen38ToySynthetic {
+
+    /// Build the toy directory in a temp dir and return its URL.
+    static func write() throws -> URL {
+        let toy = ArchConfig.qwen38Toy()
+        let la = toy.linearAttention
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gturbo-qwen38-toy-\(UUID().uuidString)")
+        let exp = dir.appendingPathComponent("packed_experts")
+        try FileManager.default.createDirectory(at: exp, withIntermediateDirectories: true)
+
+        struct ResidentSpec {
+            let name: String
+            let dtype: UInt8
+            let shape: [UInt32]
+            let weightBytes: UInt64
+            let scaleBytes: UInt64
+            let biasBytes: UInt64
+        }
+
+        let d = toy.hiddenSize
+        let u16 = MemoryLayout<UInt16>.stride
+
+        func int4AffineSpec(_ name: String, rows: Int, cols: Int) -> ResidentSpec {
+            let groups = cols / Quantization.groupSize
+            let auxBytes = UInt64(rows * groups * u16)
+            return ResidentSpec(name: name,
+                                dtype: 0,
+                                shape: [UInt32(rows), UInt32(cols), 0, 0],
+                                weightBytes: UInt64(rows * cols / 2),
+                                scaleBytes: auxBytes,
+                                biasBytes: auxBytes)
+        }
+
+        func int8AffineSpec(_ name: String, rows: Int, cols: Int) -> ResidentSpec {
+            let groups = cols / Quantization.groupSize
+            let auxBytes = UInt64(rows * groups * u16)
+            return ResidentSpec(name: name,
+                                dtype: 0,
+                                shape: [UInt32(rows), UInt32(cols), 0, 0],
+                                weightBytes: UInt64(rows * cols),
+                                scaleBytes: auxBytes,
+                                biasBytes: auxBytes)
+        }
+
+        func bf16Spec(_ name: String, shape: [UInt32], count: Int) -> ResidentSpec {
+            ResidentSpec(name: name,
+                         dtype: 1,
+                         shape: shape,
+                         weightBytes: UInt64(count * u16),
+                         scaleBytes: 0,
+                         biasBytes: 0)
+        }
+
+        // 1. Resident specs. The dense MLP goes through the shared-expert
+        // runtime, whose weight bits default to 8 when the manifest carries
+        // no quant block (toy manifests may omit it), so the MLP tensors are
+        // int8 affine here — exactly like the qwen36 toy's shared expert.
+        var specs: [ResidentSpec] = [
+            int4AffineSpec("language_model.model.embed_tokens.weight",
+                           rows: toy.vocabSize, cols: d),
+            int4AffineSpec("language_model.lm_head.weight",
+                           rows: toy.vocabSize, cols: d),
+            bf16Spec("language_model.model.norm.weight",
+                     shape: [UInt32(d), 0, 0, 0], count: d),
+        ]
+        for L in 0..<toy.numLayers {
+            let prefix = "language_model.model.layers.\(L)"
+            specs.append(bf16Spec("\(prefix).input_layernorm.weight",
+                                  shape: [UInt32(d), 0, 0, 0], count: d))
+            specs.append(bf16Spec("\(prefix).post_attention_layernorm.weight",
+                                  shape: [UInt32(d), 0, 0, 0], count: d))
+            specs.append(int8AffineSpec("\(prefix).mlp.gate_proj.weight",
+                                        rows: toy.intermediateSize, cols: d))
+            specs.append(int8AffineSpec("\(prefix).mlp.up_proj.weight",
+                                        rows: toy.intermediateSize, cols: d))
+            specs.append(int8AffineSpec("\(prefix).mlp.down_proj.weight",
+                                        rows: d, cols: toy.intermediateSize))
+            if toy.layerIsLinear(L) {
+                specs.append(int4AffineSpec("\(prefix).linear_attn.in_proj_qkv.weight",
+                                            rows: la.qkvDim, cols: d))
+                specs.append(int4AffineSpec("\(prefix).linear_attn.in_proj_z.weight",
+                                            rows: la.valueDim, cols: d))
+                specs.append(int4AffineSpec("\(prefix).linear_attn.in_proj_a.weight",
+                                            rows: la.numVHeads, cols: d))
+                specs.append(int4AffineSpec("\(prefix).linear_attn.in_proj_b.weight",
+                                            rows: la.numVHeads, cols: d))
+                specs.append(int4AffineSpec("\(prefix).linear_attn.out_proj.weight",
+                                            rows: d, cols: la.valueDim))
+                specs.append(bf16Spec("\(prefix).linear_attn.conv1d.weight",
+                                      shape: [UInt32(la.qkvDim), UInt32(la.convKernelSize), 1, 0],
+                                      count: la.qkvDim * la.convKernelSize))
+                specs.append(bf16Spec("\(prefix).linear_attn.A_log",
+                                      shape: [UInt32(la.numVHeads), 0, 0, 0],
+                                      count: la.numVHeads))
+                specs.append(bf16Spec("\(prefix).linear_attn.dt_bias",
+                                      shape: [UInt32(la.numVHeads), 0, 0, 0],
+                                      count: la.numVHeads))
+                specs.append(bf16Spec("\(prefix).linear_attn.norm.weight",
+                                      shape: [UInt32(la.valueHeadDim), 0, 0, 0],
+                                      count: la.valueHeadDim))
+            } else {
+                let qDim = toy.numHeads * toy.fullHeadDim
+                let kvDim = toy.numFullKVHeads * toy.fullHeadDim
+                specs.append(int4AffineSpec("\(prefix).self_attn.q_proj.weight",
+                                            rows: 2 * qDim, cols: d))
+                specs.append(int4AffineSpec("\(prefix).self_attn.k_proj.weight",
+                                            rows: kvDim, cols: d))
+                specs.append(int4AffineSpec("\(prefix).self_attn.v_proj.weight",
+                                            rows: kvDim, cols: d))
+                specs.append(int4AffineSpec("\(prefix).self_attn.o_proj.weight",
+                                            rows: d, cols: qDim))
+                specs.append(bf16Spec("\(prefix).self_attn.q_norm.weight",
+                                      shape: [UInt32(toy.fullHeadDim), 0, 0, 0],
+                                      count: toy.fullHeadDim))
+                specs.append(bf16Spec("\(prefix).self_attn.k_norm.weight",
+                                      shape: [UInt32(toy.fullHeadDim), 0, 0, 0],
+                                      count: toy.fullHeadDim))
+            }
+        }
+
+        // 2. Serialize the resident index + payload.
+        let names = specs.map(\.name)
+        let stringTable = names.joined().data(using: .utf8)!
+        let headerBytes = GTurboBinary.indexHeaderBytes
+        let entryBytes  = GTurboBinary.indexEntryBytes
+        let entriesBase = headerBytes
+        let stringTableBase = entriesBase + names.count * entryBytes
+        var nameAbsOffsets: [UInt32] = []
+        var cursor = 0
+        for n in names {
+            nameAbsOffsets.append(UInt32(stringTableBase + cursor))
+            cursor += n.utf8.count
+        }
+        let indexBytes = UInt64(stringTableBase + stringTable.count)
+
+        var entries: [ResidentEntry] = []
+        entries.reserveCapacity(specs.count)
+        var payloadCursor = indexBytes
+        for spec in specs {
+            let weightOffset = payloadCursor
+            let scaleOffset = spec.scaleBytes > 0 ? weightOffset + spec.weightBytes : 0
+            let biasOffset = spec.biasBytes > 0 ? scaleOffset + spec.scaleBytes : 0
+            entries.append(ResidentEntry(
+                name: spec.name,
+                dtype: spec.dtype,
+                logicalShape4: spec.shape,
+                fileOffset: weightOffset,
+                sizeBytes: spec.weightBytes,
+                scaleOffset: scaleOffset,
+                scaleSize: spec.scaleBytes,
+                biasOffset: biasOffset,
+                biasSize: spec.biasBytes,
+                quantSpec: nil,
+                sourceWeight: ModelLoaderTests.dummySource(spec.name),
+                sourceScales: nil,
+                sourceBiases: nil))
+            payloadCursor += spec.weightBytes + spec.scaleBytes + spec.biasBytes
+        }
+        let residentSize = payloadCursor - indexBytes
+
+        let totalBytes = Int(indexBytes + residentSize)
+        var fileBuf = [UInt8](repeating: 0, count: totalBytes)
+        fileBuf.withUnsafeMutableBytes { raw in
+            let base = raw.baseAddress!
+            GTurboBinary.writeIndexHeader(into: base,
+                                          indexSize: indexBytes,
+                                          residentSize: residentSize,
+                                          entryCount: UInt64(entries.count))
+            for (i, e) in entries.enumerated() {
+                let dst = base.advanced(by: entriesBase + i * entryBytes)
+                GTurboBinary.writeIndexEntry(into: dst, entry: e,
+                                             nameOffset: nameAbsOffsets[i])
+            }
+            _ = stringTable.withUnsafeBytes { sb in
+                memcpy(base.advanced(by: stringTableBase), sb.baseAddress!, stringTable.count)
+            }
+            // Quantized tensors: weight bytes 0x11 (nibbles/bytes of small
+            // positive codes), scales 0.01, biases zero. BF16 tensors: 1.0.
+            for entry in entries where entry.dtype == 0 {
+                memset(base.advanced(by: Int(entry.fileOffset)), 0x11, Int(entry.sizeBytes))
+                if entry.scaleSize > 0 {
+                    let scales = base.advanced(by: Int(entry.scaleOffset))
+                        .assumingMemoryBound(to: UInt16.self)
+                    for i in 0..<(Int(entry.scaleSize) / u16) {
+                        scales[i] = Quantization.bf16Bits(0.01)
+                    }
+                }
+            }
+            for entry in entries where entry.dtype == 1 {
+                let dst = base.advanced(by: Int(entry.fileOffset))
+                    .assumingMemoryBound(to: UInt16.self)
+                for i in 0..<(Int(entry.sizeBytes) / u16) {
+                    dst[i] = Quantization.bf16Bits(1.0)
+                }
+            }
+        }
+        let weightsURL = dir.appendingPathComponent("model_weights.bin")
+        try Data(fileBuf).write(to: weightsURL)
+        let weightsSha = try Sha256Verifier.hashFile(at: weightsURL)
+
+        // 3. layout.json: zero experts per layer, so every layer entry is
+        // empty and no blob file is written (the dense-layer contract the
+        // Inkling toys already exercise).
+        let expertStride: UInt64 = 16384
+        var layersArr: [[String: Any]] = []
+        for L in 0..<toy.numLayers {
+            layersArr.append([
+                "layer": L,
+                "file": String(format: "layer_%02d.bin", L),
+                "experts": [[String: Any]](),
+            ])
+        }
+        let layoutRoot: [String: Any] = [
+            "expertStride": expertStride,
+            "numLayers": toy.numLayers,
+            "expertsPerLayer": toy.numExperts,
+            "layers": layersArr,
+        ]
+        let layoutData = try JSONSerialization.data(
+            withJSONObject: layoutRoot, options: [.sortedKeys])
+        let layoutURL = exp.appendingPathComponent("layout.json")
+        try layoutData.write(to: layoutURL)
+        let layoutSha = try Sha256Verifier.hashFile(at: layoutURL)
+
+        // 4. manifest.json (arch v2 with the qwen38 family fields).
+        let files: [String: [String: Any]] = [
+            "model_weights.bin": ["size": Int(totalBytes), "sha256": weightsSha],
+            "packed_experts/layout.json": ["size": layoutData.count, "sha256": layoutSha],
+        ]
+
+        let archDict: [String: Any] = [
+            "hiddenSize": toy.hiddenSize, "ffnIntermediate": toy.intermediateSize,
+            "moeIntermediateSize": toy.moeIntermediateSize,
+            "numHeads": toy.numHeads, "numKVHeads": toy.numKVHeads,
+            "numFullKVHeads": toy.numFullKVHeads,
+            "headDim": toy.headDim, "fullHeadDim": toy.fullHeadDim,
+            "vocabSize": toy.vocabSize, "slidingWindow": toy.slidingWindow,
+            "finalLogitSoftcap": toy.finalLogitSoftcap,
+            "ropeTheta": toy.ropeTheta, "fullRopeTheta": toy.fullRopeTheta,
+            "partialRotaryFactor": toy.partialRotaryFactor,
+            "numLayers": toy.numLayers, "numExperts": toy.numExperts,
+            "topKExperts": toy.topKExperts,
+            "tieWordEmbeddings": toy.tieWordEmbeddings,
+            "attentionKEqV": toy.attentionKEqV,
+            "hiddenActivation": toy.hiddenActivation,
+            "fullAttentionLayerMask": toy.fullAttentionLayerMask.map { Int($0) },
+            "family": toy.family.rawValue,
+            "attnOutputGate": toy.attnOutputGate,
+            "attentionScale": toy.attentionScale,
+            "embeddingScaledBySqrtHidden": toy.embeddingScaledBySqrtHidden,
+            "routerScaled": toy.routerScaled,
+            "ffnSandwichNorms": toy.ffnSandwichNorms,
+            "sharedExpertGated": toy.sharedExpertGated,
+            "ropeNeoxSubdim": toy.ropeNeoxSubdim,
+            "linearNumKHeads": la.numKHeads,
+            "linearNumVHeads": la.numVHeads,
+            "linearKeyHeadDim": la.keyHeadDim,
+            "linearValueHeadDim": la.valueHeadDim,
+            "linearConvKernelSize": la.convKernelSize,
+            "numSharedExperts": toy.numSharedExperts,
+            "numDenseLayers": toy.numDenseLayers,
+            "denseIntermediateSize": toy.denseIntermediateSize,
+        ]
+        let manifestRoot: [String: Any] = [
+            "magic": "GTURBO",
+            "versionMajor": 1,
+            "versionMinor": 0,
+            "flags": ["streamingPresent": true, "turboQuantKV": false, "aneSharedExpert": false],
+            "modelID": "qwen38-toy",
+            "arch": archDict,
+            "files": files,
+            "expertsPerLayer": toy.numExperts,
+            "numLayers": toy.numLayers,
+            "expertStride": expertStride,
+        ]
+        let manifestData = try JSONSerialization.data(withJSONObject: manifestRoot,
+            options: [.sortedKeys, .withoutEscapingSlashes])
+        try manifestData.write(to: dir.appendingPathComponent("manifest.json"))
+        return dir
+    }
+}
+
+extension ArchConfig {
+    /// Tiny Qwen 3.8 baseline: 4 dense layers with the production 3:1 mask
+    /// shape (linear, linear, linear, full), an attn-gated full layer, GDN
+    /// with Hv/Hk ratio 3 (Hv 6, Hk 2 — off the fused Hv-32 kernels, like
+    /// production's 48/16), one dense SwiGLU MLP per layer, untied lm_head,
+    /// no experts. Numbers are intentionally toy but respect every kernel
+    /// divisibility constraint (D % 64, keyHeadDim % 32, even rotaryDim,
+    /// Hv % Hk == 0).
+    static func qwen38Toy() -> ArchConfig {
+        ArchConfig(
+            hiddenSize: 64,
+            intermediateSize: 128,
+            moeIntermediateSize: 0,
+            numHeads: 4,
+            numKVHeads: 2,
+            numFullKVHeads: 2,
+            headDim: 32,
+            fullHeadDim: 32,
+            vocabSize: 1024,
+            slidingWindow: 0,
+            finalLogitSoftcap: 0.0,
+            ropeTheta: 10_000_000.0,
+            fullRopeTheta: 10_000_000.0,
+            partialRotaryFactor: 0.25,
+            numLayers: 4,
+            numExperts: 0,
+            topKExperts: 0,
+            tieWordEmbeddings: false,
+            attentionKEqV: false,
+            fullAttentionLayerMask: [2, 2, 2, 1],
+            hiddenActivation: "silu",
+            family: .qwen38,
+            attnOutputGate: true,
+            attentionScale: 0.125,
+            embeddingScaledBySqrtHidden: false,
+            routerScaled: false,
+            ffnSandwichNorms: false,
+            sharedExpertGated: false,
+            ropeNeoxSubdim: true,
+            linearAttention: LinearAttentionConfig(
+                numKHeads: 2, numVHeads: 6,
+                keyHeadDim: 32, valueHeadDim: 32,
+                convKernelSize: 4),
+            numSharedExperts: 0,
+            numDenseLayers: 4,
+            denseIntermediateSize: 128
+        )
+    }
+}

--- a/Tests/Mference/Core/Runtime/Qwen38ToySynthetic.swift
+++ b/Tests/Mference/Core/Runtime/Qwen38ToySynthetic.swift
@@ -184,15 +184,33 @@ enum Qwen38ToySynthetic {
             _ = stringTable.withUnsafeBytes { sb in
                 memcpy(base.advanced(by: stringTableBase), sb.baseAddress!, stringTable.count)
             }
-            // Quantized tensors: weight bytes 0x11 (nibbles/bytes of small
-            // positive codes), scales 0.01, biases zero. BF16 tensors: 1.0.
+            // Quantized tensors: deterministic varied nibbles (splitmix-style
+            // LCG over the byte index) with varied small scales and biases, so
+            // dot products exercise real, order-sensitive FP accumulation
+            // (uniform fills would make every reduction order agree by
+            // construction and mask parity bugs). BF16 tensors: 1.0 plus a
+            // small deterministic ripple.
+            var lcg: UInt64 = 0x9E3779B97F4A7C15
+            func nextByte() -> UInt8 {
+                lcg = lcg &* 6364136223846793005 &+ 1442695040888963407
+                return UInt8(truncatingIfNeeded: lcg >> 33)
+            }
             for entry in entries where entry.dtype == 0 {
-                memset(base.advanced(by: Int(entry.fileOffset)), 0x11, Int(entry.sizeBytes))
+                let weights = base.advanced(by: Int(entry.fileOffset))
+                    .assumingMemoryBound(to: UInt8.self)
+                for i in 0..<Int(entry.sizeBytes) { weights[i] = nextByte() }
                 if entry.scaleSize > 0 {
                     let scales = base.advanced(by: Int(entry.scaleOffset))
                         .assumingMemoryBound(to: UInt16.self)
                     for i in 0..<(Int(entry.scaleSize) / u16) {
-                        scales[i] = Quantization.bf16Bits(0.01)
+                        scales[i] = Quantization.bf16Bits(0.004 + 0.002 * Float(i % 7))
+                    }
+                }
+                if entry.biasSize > 0 {
+                    let biases = base.advanced(by: Int(entry.biasOffset))
+                        .assumingMemoryBound(to: UInt16.self)
+                    for i in 0..<(Int(entry.biasSize) / u16) {
+                        biases[i] = Quantization.bf16Bits(-0.05 + 0.01 * Float(i % 11))
                     }
                 }
             }
@@ -200,7 +218,7 @@ enum Qwen38ToySynthetic {
                 let dst = base.advanced(by: Int(entry.fileOffset))
                     .assumingMemoryBound(to: UInt16.self)
                 for i in 0..<(Int(entry.sizeBytes) / u16) {
-                    dst[i] = Quantization.bf16Bits(1.0)
+                    dst[i] = Quantization.bf16Bits(1.0 + 0.03 * Float(i % 5) - 0.06)
                 }
             }
         }
@@ -287,6 +305,75 @@ enum Qwen38ToySynthetic {
             options: [.sortedKeys, .withoutEscapingSlashes])
         try manifestData.write(to: dir.appendingPathComponent("manifest.json"))
         return dir
+    }
+}
+
+extension Qwen38ToySynthetic {
+
+    /// Write a toy BF16 MTP shard (the 15 `mtp.*` tensors of the HF layout,
+    /// sized for `ArchConfig.qwen38Toy`) for `MTPAttachTool`. Norm vectors
+    /// are written zero-centered, matching the HF convention the attach
+    /// step's `+1` conversion expects. Values are deterministic and varied.
+    static func writeMTPShard() throws -> URL {
+        let toy = ArchConfig.qwen38Toy()
+        let d = toy.hiddenSize
+        let f = toy.intermediateSize
+        let qDim = toy.numHeads * toy.fullHeadDim
+        let kvDim = toy.numFullKVHeads * toy.fullHeadDim
+
+        // (name, shape, zeroCenteredNorm)
+        let tensors: [(String, [Int], Bool)] = [
+            ("mtp.fc.weight", [d, 2 * d], false),
+            ("mtp.pre_fc_norm_embedding.weight", [d], true),
+            ("mtp.pre_fc_norm_hidden.weight", [d], true),
+            ("mtp.norm.weight", [d], true),
+            ("mtp.layers.0.input_layernorm.weight", [d], true),
+            ("mtp.layers.0.post_attention_layernorm.weight", [d], true),
+            ("mtp.layers.0.self_attn.q_proj.weight", [2 * qDim, d], false),
+            ("mtp.layers.0.self_attn.k_proj.weight", [kvDim, d], false),
+            ("mtp.layers.0.self_attn.v_proj.weight", [kvDim, d], false),
+            ("mtp.layers.0.self_attn.o_proj.weight", [d, qDim], false),
+            ("mtp.layers.0.self_attn.q_norm.weight", [toy.fullHeadDim], true),
+            ("mtp.layers.0.self_attn.k_norm.weight", [toy.fullHeadDim], true),
+            ("mtp.layers.0.mlp.gate_proj.weight", [f, d], false),
+            ("mtp.layers.0.mlp.up_proj.weight", [f, d], false),
+            ("mtp.layers.0.mlp.down_proj.weight", [d, f], false),
+        ]
+
+        var headerEntries: [String] = []
+        var payload = Data()
+        var lcg: UInt64 = 0x5DEECE66D
+        func nextFloat() -> Float {
+            lcg = lcg &* 6364136223846793005 &+ 1442695040888963407
+            return Float(lcg >> 40) / Float(1 << 24) - 0.5
+        }
+        for (name, shape, isNorm) in tensors {
+            let count = shape.reduce(1, *)
+            let begin = payload.count
+            var bits = [UInt16](repeating: 0, count: count)
+            for i in 0..<count {
+                let value = isNorm ? 0.3 * nextFloat() : 0.25 * nextFloat()
+                bits[i] = Quantization.bf16Bits(value)
+            }
+            bits.withUnsafeBufferPointer {
+                payload.append(UnsafeRawBufferPointer($0).bindMemory(to: UInt8.self))
+            }
+            let dims = shape.map(String.init).joined(separator: ",")
+            headerEntries.append(
+                "\"\(name)\":{\"dtype\":\"BF16\",\"shape\":[\(dims)],"
+                + "\"data_offsets\":[\(begin),\(payload.count)]}")
+        }
+        let headerJSON = "{" + headerEntries.joined(separator: ",") + "}"
+        let headerBytes = Data(headerJSON.utf8)
+        var file = Data()
+        var headerLen = UInt64(headerBytes.count).littleEndian
+        withUnsafeBytes(of: &headerLen) { file.append(contentsOf: $0) }
+        file.append(headerBytes)
+        file.append(payload)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("qwen38-toy-mtp-\(UUID().uuidString).safetensors")
+        try file.write(to: url)
+        return url
     }
 }
 

--- a/Tests/Mference/Core/Tokenization/ChatMLTemplateTests.swift
+++ b/Tests/Mference/Core/Tokenization/ChatMLTemplateTests.swift
@@ -50,6 +50,24 @@ struct ChatMLTemplateTests {
         #expect(tok.vocabSize == 248_320)
     }
 
+    @Test("qwen38 family starts the generation prompt inside a live think block")
+    func qwen38StartsInThinking() async throws {
+        let tokenizer = try await MFTokenizer.load(from: Self.fixtureFolder(),
+                                                   family: .qwen38)
+        #expect(tokenizer.dialect == .chatml)
+        #expect(tokenizer.generationPromptStartsInThinking)
+        #expect(tokenizer.eosID == tokenizer.endOfTurnID)
+        #expect(tokenizer.stopTokenIDs == [tokenizer.endOfTurnID, 248044])
+        #expect(tokenizer.vocabSize == 248_320)
+        let prompt = try tokenizer.applyChatTemplate([
+            Message(role: .user, content: "Hi"),
+        ])
+        #expect(prompt == "<|im_start|>user\nHi<|im_end|>\n"
+            + "<|im_start|>assistant\n<think>\n")
+        // A family-neutral load of the same fixture keeps Qwen 3.6 behavior.
+        #expect(!tok.generationPromptStartsInThinking)
+    }
+
     @Test("Encode never prepends a BOS")
     func noBOS() {
         let with = tok.encode("hi", addBOS: true)

--- a/Tests/MferenceRepack/Core/Command/RepackCLITests.swift
+++ b/Tests/MferenceRepack/Core/Command/RepackCLITests.swift
@@ -68,6 +68,19 @@ struct RepackCLITests {
         #expect(result.stderr.contains("no resumable install state exists"))
     }
 
+    @Test func qwen38ModelSelectorIsAccepted() throws {
+        let output = temporaryOutput("qwen38-model")
+        defer { clean(output) }
+        let result = try run([
+            "--model", "qwen38",
+            "--output", output,
+            "--resume",
+        ])
+
+        #expect(result.status == 1)
+        #expect(result.stderr.contains("no resumable install state exists"))
+    }
+
     @Test func mapleModelSelectorIsAccepted() throws {
         let output = temporaryOutput("maple-model")
         defer { clean(output) }

--- a/Tests/MferenceRepack/Core/Planning/Qwen38RepackPlannerTests.swift
+++ b/Tests/MferenceRepack/Core/Planning/Qwen38RepackPlannerTests.swift
@@ -1,0 +1,342 @@
+import Darwin
+import Foundation
+import Testing
+@testable import MferenceRepackCore
+
+@Suite
+struct Qwen38RepackPlannerTests {
+
+    @Test func qwen38ArchInfoLoadsFromSyntheticConfig() throws {
+        let snapshotDir = temporaryRoot("qwen38-arch")
+        defer { try? FileManager.default.removeItem(atPath: snapshotDir) }
+        _ = try SyntheticSnapshot.buildQwen38(at: snapshotDir)
+
+        let arch = try ArchInfo.load(
+            configPath: (snapshotDir as NSString).appendingPathComponent("config.json"))
+
+        #expect(arch.family == .qwen38)
+        #expect(arch.hiddenSize == 128)
+        #expect(arch.numLayers == 4)
+        #expect(arch.fullAttentionLayerMask == [2, 2, 2, 1])
+        #expect(arch.numExperts == 0)
+        #expect(arch.topKExperts == 0)
+        #expect(arch.moeIntermediateSize == 0)
+        #expect(arch.intermediateSize == 64)
+        #expect(arch.numSharedExperts == 0)
+        #expect(arch.numDenseLayers == 4)
+        #expect(arch.denseIntermediateSize == 64)
+        #expect(arch.tieWordEmbeddings == false)
+        #expect(arch.attentionKEqV == false)
+        #expect(arch.hiddenActivation == "silu")
+        #expect(arch.ropeTheta == 10_000_000.0)
+        #expect(arch.fullRopeTheta == 10_000_000.0)
+        #expect(arch.partialRotaryFactor == 0.25)
+        #expect(arch.finalLogitSoftcap == 0.0)
+        #expect(arch.attnOutputGate == true)
+        #expect(arch.attentionScale == 0.125)   // 64^-0.5
+        #expect(arch.embeddingScaledBySqrtHidden == false)
+        #expect(arch.routerScaled == false)
+        #expect(arch.ffnSandwichNorms == false)
+        #expect(arch.sharedExpertGated == false)
+        #expect(arch.ropeNeoxSubdim == true)
+        #expect(arch.linearNumKHeads == 2)
+        #expect(arch.linearNumVHeads == 4)
+        #expect(arch.linearKeyHeadDim == 32)
+        #expect(arch.linearValueHeadDim == 32)
+        #expect(arch.linearConvKernelSize == 4)
+    }
+
+    @Test func productionQwen38ConfigParsesAndCrossChecks() throws {
+        let root = temporaryRoot("qwen38-prod")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let configPath = (root as NSString).appendingPathComponent("config.json")
+        try writeProductionConfig(to: configPath, mutate: { _ in })
+
+        let arch = try ArchInfo.load(configPath: configPath)
+        #expect(arch.family == .qwen38)
+        #expect(arch.hiddenSize == 5120)
+        #expect(arch.numLayers == 64)
+        #expect(arch.vocabSize == 248_320)
+        #expect(arch.numExperts == 0)
+        #expect(arch.topKExperts == 0)
+        #expect(arch.intermediateSize == 17_408)
+        #expect(arch.denseIntermediateSize == 17_408)
+        #expect(arch.numDenseLayers == 64)
+        #expect(arch.attentionScale == 0.0625) // 256^-0.5
+        #expect(arch.linearNumKHeads == 16)
+        #expect(arch.linearNumVHeads == 48)
+        #expect(arch.linearKeyHeadDim == 128)
+        #expect(arch.linearValueHeadDim == 128)
+        #expect(arch.linearConvKernelSize == 4)
+        #expect(arch.fullAttentionLayerMask.count == 64)
+        #expect(arch.fullAttentionLayerMask.filter { $0 == 1 }.count == 16)
+        for (i, v) in arch.fullAttentionLayerMask.enumerated() {
+            #expect(v == ((i + 1) % 4 == 0 ? 1 : 2))
+        }
+    }
+
+    @Test func productionQwen38ConfigMismatchIsRejected() throws {
+        let root = temporaryRoot("qwen38-prod-bad")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let configPath = (root as NSString).appendingPathComponent("config.json")
+        try writeProductionConfig(to: configPath, mutate: { tc in
+            tc["num_attention_heads"] = 8
+        })
+
+        #expect(throws: RepackError.self) {
+            _ = try ArchInfo.load(configPath: configPath)
+        }
+    }
+
+    @Test func qwen38SourceFingerprintIsKnown() {
+        #expect(SourceFingerprint.modelID(forIndexSha256:
+            "13b840162b4cb35c66fef7df072f7dbb4717908204364f5e5d9f9655a2758fa8")
+            == "qwen3.8-27b-4bit")
+    }
+
+    @Test func qwen38ClassificationBucketsNames() {
+        let f = RepackModelFamily.qwen38
+        // Dense: the layer's own MLP is resident, never a routed expert.
+        #expect(RepackPlanner.classify(
+            "language_model.model.layers.1.mlp.gate_proj.weight",
+            numLayers: 4, family: f) == .lmResident)
+        #expect(RepackPlanner.classify(
+            "language_model.model.layers.2.mlp.down_proj.weight",
+            numLayers: 4, family: f) == .lmResident)
+        // Untied head and the DeltaNet bundle are resident.
+        #expect(RepackPlanner.classify(
+            "language_model.lm_head.weight", numLayers: 4, family: f) == .lmResident)
+        #expect(RepackPlanner.classify(
+            "language_model.model.layers.0.linear_attn.conv1d.weight",
+            numLayers: 4, family: f) == .lmResident)
+        // Vision is excluded; unknown prefixes stay unknown.
+        #expect(RepackPlanner.classify(
+            "vision_tower.blocks.0.norm1.weight", numLayers: 4, family: f)
+            == .excludedMultimodal)
+        #expect(RepackPlanner.classify(
+            "model.layers.0.mlp.gate_proj.weight",
+            numLayers: 4, family: f) == .unknown)
+    }
+
+    @Test func qwen38PlanOrdersResidentsWithZeroExpertLayers() throws {
+        let snapshotDir = temporaryRoot("qwen38-plan")
+        let outputDir = temporaryRoot("qwen38-plan-out")
+        defer {
+            try? FileManager.default.removeItem(atPath: snapshotDir)
+            try? FileManager.default.removeItem(atPath: outputDir)
+        }
+        let snapshot = try SyntheticSnapshot.buildQwen38(at: snapshotDir)
+        let metadata = try IndexLoader.load(snapshotDir: snapshotDir)
+        let arch = try ArchInfo.load(
+            configPath: (snapshotDir as NSString).appendingPathComponent("config.json"))
+        let header = try parseHeader(path: snapshot.shardPath)
+
+        let plan = try RepackPlanner.plan(
+            meta: metadata,
+            arch: arch,
+            shardHeaders: [header],
+            outputDir: outputDir)
+
+        let names = plan.resident.entries.map(\.name)
+        // Embedding first; final norm then the untied lm_head last.
+        #expect(names.first == "language_model.model.embed_tokens.weight")
+        #expect(names.last == "language_model.lm_head.weight")
+        #expect(names.dropLast().last == "language_model.model.norm.weight")
+
+        // Layer 0 is a linear-attention layer: DeltaNet bundle, then the
+        // layer's own MLP, then the two layer norms.
+        let expectedLayer0 = [
+            "linear_attn.in_proj_qkv.weight",
+            "linear_attn.in_proj_z.weight",
+            "linear_attn.in_proj_a.weight",
+            "linear_attn.in_proj_b.weight",
+            "linear_attn.conv1d.weight",
+            "linear_attn.A_log",
+            "linear_attn.dt_bias",
+            "linear_attn.norm.weight",
+            "linear_attn.out_proj.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.down_proj.weight",
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+        ].map { "language_model.model.layers.0." + $0 }
+        let layer0 = names.filter { $0.contains(".layers.0.") }
+        #expect(layer0 == expectedLayer0)
+
+        // Layer 3 is the full-attention layer.
+        let expectedLayer3 = [
+            "self_attn.q_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.v_proj.weight",
+            "self_attn.o_proj.weight",
+            "self_attn.q_norm.weight",
+            "self_attn.k_norm.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.down_proj.weight",
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+        ].map { "language_model.model.layers.3." + $0 }
+        let layer3 = names.filter { $0.contains(".layers.3.") }
+        #expect(layer3 == expectedLayer3)
+
+        // The dense MLP is a quantized U32 entry with companions.
+        let gateProj = try #require(plan.resident.entries.first {
+            $0.name == "language_model.model.layers.0.mlp.gate_proj.weight"
+        })
+        #expect(gateProj.dtype == 0)
+        #expect(gateProj.quantSpec?.bits == 4)
+        #expect(gateProj.sourceScales != nil)
+        #expect(gateProj.sourceBiases != nil)
+
+        // Dense: every layer plan is empty — no experts, no stride, no blob.
+        #expect(plan.layers.count == 4)
+        for lp in plan.layers {
+            #expect(lp.expertsPerLayer == 0)
+            #expect(lp.expertStride == 0)
+            #expect(lp.subTensors.isEmpty)
+        }
+
+        // Vision-tower tensors are dropped, not planned.
+        #expect(plan.excludedMultimodalTensorNames.sorted() == [
+            "vision_tower.blocks.0.norm1.weight",
+            "vision_tower.patch_embed.proj.weight",
+        ])
+        #expect(!names.contains { $0.hasPrefix("vision_tower.") })
+    }
+
+    @Test func qwen38ManifestDeclaresDenseFieldsAndAbsentSlots() throws {
+        let snapshotDir = temporaryRoot("qwen38-manifest")
+        let outputDir = temporaryRoot("qwen38-manifest-out")
+        defer {
+            try? FileManager.default.removeItem(atPath: snapshotDir)
+            try? FileManager.default.removeItem(atPath: outputDir)
+        }
+        let snapshot = try SyntheticSnapshot.buildQwen38(at: snapshotDir)
+        let metadata = try IndexLoader.load(snapshotDir: snapshotDir)
+        let arch = try ArchInfo.load(
+            configPath: (snapshotDir as NSString).appendingPathComponent("config.json"))
+        let header = try parseHeader(path: snapshot.shardPath)
+        let plan = try RepackPlanner.plan(
+            meta: metadata, arch: arch, shardHeaders: [header], outputDir: outputDir)
+
+        let data = try GTurboJSON.encodeManifest(
+            plan: plan,
+            modelID: "unknown/snapshot",
+            sourceSnapshotHash: "sha256:0",
+            files: [],
+            expertsPerLayer: 0,
+            numLayers: arch.numLayers,
+            expertStride: 0,
+            bitWidths: GTurboJSON.QuantBitWidths(
+                embedding: 4, attention: 4, router: 0,
+                sharedExpert: 0, routedExpert: 0))
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let archDict = obj["arch"] as! [String: Any]
+        #expect(archDict["family"] as? String == "qwen38")
+        #expect(archDict["numExperts"] as? Int == 0)
+        #expect(archDict["topKExperts"] as? Int == 0)
+        #expect(archDict["numSharedExperts"] as? Int == 0)
+        #expect(archDict["numDenseLayers"] as? Int == 4)
+        #expect(archDict["denseIntermediateSize"] as? Int == 64)
+        #expect(archDict["linearNumKHeads"] as? Int == 2)
+        #expect(archDict["linearNumVHeads"] as? Int == 4)
+
+        let quant = obj["quant"] as! [String: [String: Any]]
+        for slot in ["embedding", "attention"] {
+            #expect(quant[slot]?["weightBits"] as? Int == 4)
+            #expect(quant[slot]?["scheme"] as? String == "affine")
+            #expect(quant[slot]?["groupSize"] as? Int == 64)
+        }
+        for slot in ["router", "sharedExpert", "routedExpert"] {
+            #expect(quant[slot]?["weightBits"] as? Int == 0)
+            #expect(quant[slot]?["scheme"] as? String == "none")
+            #expect(quant[slot]?["scaleType"] as? String == "none")
+            #expect(quant[slot]?["biasType"] as? String == "none")
+            #expect(quant[slot]?["groupSize"] as? Int == 0)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func writeProductionConfig(
+        to path: String,
+        mutate: (inout [String: Any]) -> Void) throws {
+        var layerTypes: [String] = []
+        for i in 0..<64 {
+            layerTypes.append((i + 1) % 4 == 0 ? "full_attention" : "linear_attention")
+        }
+        var tc: [String: Any] = [
+            "hidden_size": 5120,
+            "intermediate_size": 17_408,
+            "num_attention_heads": 24,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "vocab_size": 248_320,
+            "num_hidden_layers": 64,
+            "layer_types": layerTypes,
+            "full_attention_interval": 4,
+            "rope_parameters": [
+                "rope_theta": 10_000_000.0,
+                "rope_type": "default",
+                "partial_rotary_factor": 0.25
+            ],
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 48,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "attn_output_gate": true,
+            "tie_word_embeddings": false,
+            "rms_norm_eps": 1e-6,
+            "hidden_act": "silu"
+        ]
+        mutate(&tc)
+        let config: [String: Any] = [
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+            "model_type": "qwen3_5",
+            "quantization": ["bits": 4, "group_size": 64, "mode": "affine"],
+            "text_config": tc
+        ]
+        let data = try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+        try data.write(to: URL(fileURLWithPath: path))
+    }
+
+    private func temporaryRoot(_ tag: String) -> String {
+        let path = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("mference-qwen38-plan-\(tag)-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(
+            atPath: path,
+            withIntermediateDirectories: true)
+        return path
+    }
+
+    private func parseHeader(path: String) throws -> Safetensors.Header {
+        let fd = try Posix.openRead(path)
+        defer { close(fd) }
+        var headerSize: UInt64 = 0
+        try withUnsafeMutableBytes(of: &headerSize) {
+            try Posix.preadAll(
+                fd: fd,
+                path: path,
+                buf: $0.baseAddress!,
+                count: 8,
+                offset: 0)
+        }
+        headerSize = UInt64(littleEndian: headerSize)
+        var headerData = Data(count: Int(headerSize))
+        try headerData.withUnsafeMutableBytes {
+            try Posix.preadAll(
+                fd: fd,
+                path: path,
+                buf: $0.baseAddress!,
+                count: $0.count,
+                offset: 8)
+        }
+        return try Safetensors.parseHeaderBytes(
+            path: path,
+            fileSize: try Posix.fileSize(fd: fd, path: path),
+            headerBytes: headerData)
+    }
+}

--- a/Tests/MferenceRepack/Core/Remote/RemoteQwen38InstallTests.swift
+++ b/Tests/MferenceRepack/Core/Remote/RemoteQwen38InstallTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import MferenceRepackCore
+
+extension RemotePayloadCopyTests {
+  @Test func qwen38RemoteInstallCompletesWithDenseManifest() async throws {
+    let snapshotDir = tmpDirForRemote("qwen38-snap")
+    let remoteOutput = tmpPathForRemote("qwen38-remote")
+    defer { cleanUpRemote([snapshotDir, remoteOutput]) }
+    let snapshot = try SyntheticSnapshot.buildQwen38(
+      at: snapshotDir,
+      seed: 0x3800_0102_0304_0506)
+
+    resetFakeHF()
+    FakeHFURLProtocol.files = try remoteFiles(
+      snapshotDir: snapshotDir,
+      snap: snapshot,
+      includeRequiredTokenizer: true,
+      includeOptionalTokenizer: true)
+    let recorder = InstallProgressRecorder()
+
+    let result = try await RemoteStreamingRepacker(
+      options: remoteOptions(
+        outputDir: remoteOutput,
+        session: fakeHFSession())
+    ).run { recorder.append($0) }
+
+    #expect(result.reusedBytes == 0)
+    #expect(result.downloadedThisRunBytes == result.remoteBytesToDownload)
+    #expect(result.expertLayerCount == 4)
+    #expect(result.excludedMultimodalTensorCount == 2)
+    for relativePath in [
+      "model_weights.bin",
+      "packed_experts/layout.json",
+      "manifest.json",
+    ] {
+      let remote = (remoteOutput as NSString).appendingPathComponent(relativePath)
+      #expect(FileManager.default.fileExists(atPath: remote))
+    }
+    // Dense: no packed-expert blob is created for any layer.
+    for layer in 0..<4 {
+      let blob = (remoteOutput as NSString).appendingPathComponent(
+        String(format: "packed_experts/layer_%02d.bin", layer))
+      #expect(!FileManager.default.fileExists(atPath: blob))
+    }
+    #expect(recorder.values.contains(.finalizing))
+    try assertRemoteTokenizerFilesRecorded(
+      outputDir: remoteOutput,
+      expectsOptionalSpecialTokens: true)
+
+    // The manifest carries the qwen38 family extension fields and the
+    // zeroed MoE geometry.
+    let manifestData = try Data(contentsOf: URL(fileURLWithPath:
+      (remoteOutput as NSString).appendingPathComponent("manifest.json")))
+    let manifest = try JSONSerialization.jsonObject(with: manifestData) as! [String: Any]
+    #expect(manifest["expertsPerLayer"] as? Int == 0)
+    #expect((manifest["expertStride"] as? NSNumber)?.uint64Value == 0)
+    let arch = manifest["arch"] as! [String: Any]
+    #expect(arch["family"] as? String == "qwen38")
+    #expect(arch["attnOutputGate"] as? Bool == true)
+    #expect(arch["attentionScale"] as? Double == 0.125)
+    #expect(arch["sharedExpertGated"] as? Bool == false)
+    #expect(arch["ropeNeoxSubdim"] as? Bool == true)
+    #expect(arch["numExperts"] as? Int == 0)
+    #expect(arch["topKExperts"] as? Int == 0)
+    #expect(arch["numSharedExperts"] as? Int == 0)
+    #expect(arch["numDenseLayers"] as? Int == 4)
+    #expect(arch["denseIntermediateSize"] as? Int == 64)
+    #expect(arch["linearNumKHeads"] as? Int == 2)
+    #expect(arch["linearNumVHeads"] as? Int == 4)
+    #expect(arch["linearKeyHeadDim"] as? Int == 32)
+    #expect(arch["linearValueHeadDim"] as? Int == 32)
+    #expect(arch["linearConvKernelSize"] as? Int == 4)
+    #expect(arch["fullAttentionLayerMask"] as? [Int] == [2, 2, 2, 1])
+    #expect(arch["tieWordEmbeddings"] as? Bool == false)
+    #expect(arch["hiddenActivation"] as? String == "silu")
+
+    let quant = manifest["quant"] as! [String: [String: Any]]
+    #expect(quant["embedding"]?["weightBits"] as? Int == 4)
+    #expect(quant["attention"]?["weightBits"] as? Int == 4)
+    for slot in ["router", "sharedExpert", "routedExpert"] {
+      #expect(quant[slot]?["weightBits"] as? Int == 0)
+      #expect(quant[slot]?["scheme"] as? String == "none")
+      #expect(quant[slot]?["groupSize"] as? Int == 0)
+    }
+
+    // The finished install passes post-hoc verification.
+    let verify = try VerifiedInstallTool.run(
+      options: VerifyInstallOptions(inputGTurbo: remoteOutput))
+    #expect(verify.unexpectedEntries.isEmpty)
+    #expect(verify.fileCount > 0)
+  }
+}

--- a/Tests/MferenceRepack/Core/Support/SyntheticSnapshot.swift
+++ b/Tests/MferenceRepack/Core/Support/SyntheticSnapshot.swift
@@ -564,6 +564,193 @@ enum SyntheticSnapshot {
         return Snapshot(shardPath: shardPath)
     }
 
+    // MARK: - Qwen 3.8 variant
+
+    /// Tiny qwen3_5-shaped architecture: the Qwen 3.6 hybrid attention
+    /// schedule (three gated-DeltaNet layers, one full-attention layer) but
+    /// dense — one SwiGLU MLP per layer, no router, no shared expert, no
+    /// routed experts — with an untied lm_head and a nested `text_config`.
+    struct Qwen38Arch {
+        let hidden: Int = 128
+        let intermediate: Int = 64
+        let numHeads: Int = 2
+        let numKVHeads: Int = 2
+        let headDim: Int = 64
+        let vocab: Int = 256
+        let numLayers: Int = 4
+        let groupSize: Int = 64
+        let linearNumKHeads: Int = 2
+        let linearNumVHeads: Int = 4
+        let linearKeyHeadDim: Int = 32
+        let linearValueHeadDim: Int = 32
+        let linearConvKernelSize: Int = 4
+        // layers 0-2 = linear attention, layer 3 = full attention
+        let layerTypes: [String] = ["linear_attention", "linear_attention",
+                                    "linear_attention", "full_attention"]
+        /// Fused qkv rows: 2 * K-dim + V-dim. Also the conv1d channel count.
+        var qkvDim: Int { 2 * linearNumKHeads * linearKeyHeadDim + linearNumVHeads * linearValueHeadDim }
+        var valueDim: Int { linearNumVHeads * linearValueHeadDim }
+    }
+
+    static func buildQwen38(at dir: String,
+                            seed: UInt64 = 0x0038_D0C5_E11A_B1E5) throws -> Snapshot {
+        try? FileManager.default.removeItem(atPath: dir)
+        try FileManager.default.createDirectory(atPath: dir,
+                                                withIntermediateDirectories: true)
+
+        let arch = Qwen38Arch()
+        var rng = SplitMix64(seed: seed)
+
+        var tensors: [(String, String, [Int], [UInt8])] = []
+        tensors.reserveCapacity(80)
+
+        // -- Embedding + untied lm_head (4-bit, group=64)
+        appendQuantizedWeight(name: "language_model.model.embed_tokens",
+                              outerShape: [arch.vocab],
+                              innerLogical: arch.hidden, bits: 4,
+                              groupSize: arch.groupSize, into: &tensors, rng: &rng)
+        appendQuantizedWeight(name: "language_model.lm_head",
+                              outerShape: [arch.vocab],
+                              innerLogical: arch.hidden, bits: 4,
+                              groupSize: arch.groupSize, into: &tensors, rng: &rng)
+
+        for li in 0..<arch.numLayers {
+            let prefix = "language_model.model.layers.\(li)"
+            if arch.layerTypes[li] == "full_attention" {
+                // q_proj emits per-head [query ; gate] halves (attn_output_gate).
+                appendQuantizedWeight(name: prefix + ".self_attn.q_proj",
+                                      outerShape: [2 * arch.numHeads * arch.headDim],
+                                      innerLogical: arch.hidden, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+                appendQuantizedWeight(name: prefix + ".self_attn.k_proj",
+                                      outerShape: [arch.numKVHeads * arch.headDim],
+                                      innerLogical: arch.hidden, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+                appendQuantizedWeight(name: prefix + ".self_attn.v_proj",
+                                      outerShape: [arch.numKVHeads * arch.headDim],
+                                      innerLogical: arch.hidden, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+                appendQuantizedWeight(name: prefix + ".self_attn.o_proj",
+                                      outerShape: [arch.hidden],
+                                      innerLogical: arch.numHeads * arch.headDim, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+                appendUnquantizedBF16(name: prefix + ".self_attn.q_norm.weight",
+                                      shape: [arch.headDim], into: &tensors, rng: &rng)
+                appendUnquantizedBF16(name: prefix + ".self_attn.k_norm.weight",
+                                      shape: [arch.headDim], into: &tensors, rng: &rng)
+            } else {
+                // Gated-DeltaNet linear attention bundle.
+                appendQuantizedWeight(name: prefix + ".linear_attn.in_proj_qkv",
+                                      outerShape: [arch.qkvDim],
+                                      innerLogical: arch.hidden, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+                appendQuantizedWeight(name: prefix + ".linear_attn.in_proj_z",
+                                      outerShape: [arch.valueDim],
+                                      innerLogical: arch.hidden, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+                appendQuantizedWeight(name: prefix + ".linear_attn.in_proj_a",
+                                      outerShape: [arch.linearNumVHeads],
+                                      innerLogical: arch.hidden, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+                appendQuantizedWeight(name: prefix + ".linear_attn.in_proj_b",
+                                      outerShape: [arch.linearNumVHeads],
+                                      innerLogical: arch.hidden, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+                appendUnquantizedBF16(name: prefix + ".linear_attn.conv1d.weight",
+                                      shape: [arch.qkvDim, arch.linearConvKernelSize, 1],
+                                      into: &tensors, rng: &rng)
+                appendUnquantizedBF16(name: prefix + ".linear_attn.A_log",
+                                      shape: [arch.linearNumVHeads], into: &tensors, rng: &rng)
+                appendUnquantizedBF16(name: prefix + ".linear_attn.dt_bias",
+                                      shape: [arch.linearNumVHeads], into: &tensors, rng: &rng)
+                appendUnquantizedBF16(name: prefix + ".linear_attn.norm.weight",
+                                      shape: [arch.linearValueHeadDim], into: &tensors, rng: &rng)
+                appendQuantizedWeight(name: prefix + ".linear_attn.out_proj",
+                                      outerShape: [arch.hidden],
+                                      innerLogical: arch.valueDim, bits: 4,
+                                      groupSize: arch.groupSize, into: &tensors, rng: &rng)
+            }
+
+            // The layer's own SwiGLU MLP — 4-bit, no router in front of it.
+            appendQuantizedWeight(name: prefix + ".mlp.gate_proj",
+                                  outerShape: [arch.intermediate], innerLogical: arch.hidden,
+                                  bits: 4, groupSize: arch.groupSize, into: &tensors, rng: &rng)
+            appendQuantizedWeight(name: prefix + ".mlp.up_proj",
+                                  outerShape: [arch.intermediate], innerLogical: arch.hidden,
+                                  bits: 4, groupSize: arch.groupSize, into: &tensors, rng: &rng)
+            appendQuantizedWeight(name: prefix + ".mlp.down_proj",
+                                  outerShape: [arch.hidden], innerLogical: arch.intermediate,
+                                  bits: 4, groupSize: arch.groupSize, into: &tensors, rng: &rng)
+
+            // Plain pre-norm layer norms.
+            appendUnquantizedBF16(name: prefix + ".input_layernorm.weight",
+                                  shape: [arch.hidden], into: &tensors, rng: &rng)
+            appendUnquantizedBF16(name: prefix + ".post_attention_layernorm.weight",
+                                  shape: [arch.hidden], into: &tensors, rng: &rng)
+        }
+        // Final norm
+        appendUnquantizedBF16(name: "language_model.model.norm.weight",
+                              shape: [arch.hidden], into: &tensors, rng: &rng)
+
+        // Vision-tower tensors included to prove the text-only repacker drops them.
+        appendUnquantizedBF16(name: "vision_tower.blocks.0.norm1.weight",
+                              shape: [arch.hidden], into: &tensors, rng: &rng)
+        appendUnquantizedBF16(name: "vision_tower.patch_embed.proj.weight",
+                              shape: [arch.hidden, arch.hidden], into: &tensors, rng: &rng)
+
+        // -- Encode safetensors.
+        let shardName = "model-00001-of-00001.safetensors"
+        let shardPath = (dir as NSString).appendingPathComponent(shardName)
+        try writeShard(path: shardPath, tensors: tensors)
+
+        // -- Write config.json. Everything is 4-bit affine: no overrides.
+        let textConfig: [String: Any] = [
+            "hidden_size": arch.hidden,
+            "intermediate_size": arch.intermediate,
+            "num_attention_heads": arch.numHeads,
+            "num_key_value_heads": arch.numKVHeads,
+            "head_dim": arch.headDim,
+            "vocab_size": arch.vocab,
+            "num_hidden_layers": arch.numLayers,
+            "layer_types": arch.layerTypes,
+            "full_attention_interval": 4,
+            "rope_parameters": [
+                "rope_theta": 10_000_000.0,
+                "rope_type": "default",
+                "partial_rotary_factor": 0.25
+            ],
+            "linear_num_key_heads": arch.linearNumKHeads,
+            "linear_num_value_heads": arch.linearNumVHeads,
+            "linear_key_head_dim": arch.linearKeyHeadDim,
+            "linear_value_head_dim": arch.linearValueHeadDim,
+            "linear_conv_kernel_dim": arch.linearConvKernelSize,
+            "attn_output_gate": true,
+            "tie_word_embeddings": false,
+            "rms_norm_eps": 1e-6,
+            "hidden_act": "silu"
+        ]
+        let config: [String: Any] = [
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+            "model_type": "qwen3_5",
+            "quantization": ["bits": 4, "group_size": arch.groupSize, "mode": "affine"],
+            "text_config": textConfig
+        ]
+        let configData = try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+        try configData.write(to: URL(fileURLWithPath: (dir as NSString).appendingPathComponent("config.json")))
+
+        // -- Write model.safetensors.index.json.
+        var weightMap: [String: String] = [:]
+        for (name, _, _, _) in tensors { weightMap[name] = shardName }
+        let indexObj: [String: Any] = [
+            "metadata": ["format": "mlx"],
+            "weight_map": weightMap
+        ]
+        let indexData = try JSONSerialization.data(withJSONObject: indexObj, options: [.sortedKeys])
+        let indexPath = (dir as NSString).appendingPathComponent("model.safetensors.index.json")
+        try indexData.write(to: URL(fileURLWithPath: indexPath))
+        return Snapshot(shardPath: shardPath)
+    }
+
     // MARK: - DeepSeek-V4-Flash variant
 
     /// Tiny deepseek_v4-shaped architecture: two sliding-window bootstrap

--- a/docs/QWEN38_PERFORMANCE.md
+++ b/docs/QWEN38_PERFORMANCE.md
@@ -1,0 +1,91 @@
+# Qwen 3.8 27B performance notes
+
+Qwen 3.8-27B-4bit (`mlx-community/Qwen3.8-27B-4bit`, text stack of the
+multimodal checkpoint) is Mference's first dense family: 64 layers — 48
+gated-DeltaNet linear-attention and 16 full-attention — with one SwiGLU MLP
+per layer, no routed experts, and every weight resident. Per decoded token
+the runtime touches ~13 GB of weights, so plain decode is memory-bandwidth
+bound; the family's headline speed comes from MTP speculative decoding,
+which verifies several drafted tokens against one read of the weights.
+
+All numbers below: 24 GB M5 MacBook Pro, macOS 26.5, `--temperature 0`,
+128 generated tokens, fresh process, measured 2026-08-14 at commit
+`66c0f10`. The reference baseline is mlx-vlm 0.6.8 on the identical
+checkpoint: **6.41 tok/s decode, 40.5 tok/s prefill, 18.6 GB peak** (it
+warns it is near the host's working-set ceiling; Mference's text-only
+install is ~3.5 GB leaner because the vision tower is excluded at repack).
+
+## Decode
+
+| Configuration | tok/s | vs mlx-vlm |
+| --- | ---: | ---: |
+| Plain decode | 7.9–8.0 | +25% |
+| MTP speculative, k=3 (default) | **15.0–15.1** | **2.35×** |
+| MTP speculative, chat mode | 16.9 | 2.64× |
+
+Speculative output is byte-identical to plain greedy decode at every k —
+that identity is the acceptance gate, enforced by toy tests with forced
+full/partial/zero acceptance and verified on the real model. Accept rate
+63.6% at k=3 on prose (80% on chat/math; long essays ~50%, still 1.5×).
+
+The plain-decode path took two accepted optimizations on the way:
+
+- **Chunked prefill** (the qwen36 prefill kernel set; the DeltaNet scan's
+  FP32 state is exactly the token-by-token state): prefill 6.0 →
+  10.2 tok/s, byte-identical.
+- **Fused Hv=48 GDN decode kernel** (`gdn_delta_gated_decode_qwen38`):
+  recurrence + gated norm in one dispatch, bit-identical to the generic
+  two-dispatch path; 48 fewer dispatches per token. Decode 7.26 → 7.80.
+- **tensorops.metal GPUCompiler-32023 fix**: the MPP tensor-ops prefill
+  GEMMs had been silently unavailable on macOS 26.5 (naive-QMM fallback).
+  Re-enabled: prefill 10.2 → **~60 tok/s** at a 373-token prompt — past
+  mlx-vlm's 40.5. This fix also restores the MPP prefill path for the
+  other families on macOS 26.5 hosts.
+
+## MTP speculative decoding
+
+The checkpoint ships a native multi-token-prediction draft: one
+full-attention transformer layer plus a `fc([norm(embed); norm(hidden)])`
+fusion, sharing the target's embedding and lm_head. The mlx 4-bit repo
+drops these tensors; `MferenceRepack --attach-mtp <shard>` quantizes them
+(INT4 affine group-64 via `Int4AffineEncoder`; norms BF16) from the
+original repo's final shard and appends them to an installed
+`qwen38.gturbo` in place (+239 MB, ~8 s).
+
+Per round the drafter proposes k tokens; the target verifies all of them
+in one pass through decode-exact "multix" kernels (one weight read applied
+to k+1 token rows with per-token arithmetic replicating the decode GEMV
+and fused-head order bitwise — the prefill QMM/MPP paths are *not*
+ulp-identical to decode and cannot be used for verification). DeltaNet
+FP32 states and conv tails are blit-captured per verified position; a
+partial acceptance restores the arena slot and rewinds the KV cursor, so
+a partial round costs the same single weight read as a full one.
+
+Controls: on by default for greedy decode when MTP tensors are present;
+`MFERENCE_MTP=0` disables; `MFERENCE_MTP_K` (1–6, default 3) sets the
+draft depth. k=3 measured best; k=4+ loses more to accept-rate decay than
+it gains in depth.
+
+`MFERENCE_PHASES=1` snapshot (128-token run above): 44 rounds, drafted
+132 / accepted 84 (63.6%), 26 rollbacks; draft 875 ms, verify 8391 ms,
+accept 503 ms — verify dominates, as it should: it is the one full read
+of the weights per round.
+
+## Memory
+
+~15.1 GB install (+239 MB with MTP attached). The fully-resident region
+exceeds this host's 13.3 GB `maxBufferLength`, so the loader wraps it as
+multiple chunked buffers cut between tensor spans. Decode working set is
+the whole install plus ~144 MB of GDN FP32 state and a ~450 MB capture
+arena during speculative verify (k=3).
+
+## Measuring
+
+```bash
+.build/release/MferenceCLI \
+  --model scratch/qwen38-mtp.gturbo \
+  --prompt "..." --max-new 128 --temperature 0
+```
+
+`MFERENCE_MTP=0` A/Bs the speculative path against plain decode;
+outputs must be byte-identical.

--- a/docs/RUNTIME_CONTROLS.md
+++ b/docs/RUNTIME_CONTROLS.md
@@ -98,8 +98,10 @@ rather than emitting corrupt output (default on). `MFERENCE_ROUTER_EVENT=0`
 disables the early mid-buffer router readback. `MFERENCE_SPEC_PREFETCH`
 selects the speculative-prefetch mode — shadow prefetch is the accepted
 DeepSeek-V4-Flash default, off elsewhere — and `MFERENCE_SHADOW_BUDGET` caps
-its per-layer speculative reads. All are byte-identical toggles, not quality
-controls.
+its per-layer speculative reads. For Qwen 3.8, `MFERENCE_MTP=0` disables MTP
+speculative decoding (on by default for greedy decode when the install
+carries the attached MTP tensors) and `MFERENCE_MTP_K` (1–6, default 3) sets
+the draft depth. All are byte-identical toggles, not quality controls.
 
 Changing context length, expert-cache slots, RDADVISE, model verification,
 prompt-prefill enablement, the prefill chunk size, or FlashHead selection


### PR DESCRIPTION
First dense family, built to the family gate. Text-only port of mlx-community/Qwen3.8-27B-4bit (64-layer DeltaNet/full-attention hybrid, dense SwiGLU, 4-bit affine).

## Results (24 GB M5, greedy, byte-identical gates throughout)
| | Mference | mlx-vlm same checkpoint |
|---|---|---|
| Decode (MTP speculative, k=3) | **15.0–15.1 tok/s** | 6.41 |
| Decode (plain) | 7.9–8.0 | 6.41 |
| Prefill (373-tok prompt) | **~60 tok/s** | 40.5 |
| Install | 15.1 GB (no vision tower) | 18.6 GB peak |

## What's in here
- **Family foundation + repack**: nested `text_config` parsing, vision-tower exclusion, zero-expert manifests, pinned source, chunked ResidentBuffer (the 15 GB resident region exceeds the M5's 13.3 GB `maxBufferLength`).
- **Self-contained `Qwen38ForwardRunner`**: GDN + gated full attention + dense MLP, one CB per token; chunked prefill with chunked≡sequential parity tests; fused Hv=48 GDN kernel (bit-identical, 48 fewer dispatches/token).
- **tensorops.metal GPUCompiler-32023 fix**: MPP prefill GEMMs were silently dead on macOS 26.5 for every family — re-enabled (this alone: qwen38 prefill 10→60 tok/s; also restores Gemma/Inkling/Qwen 3.6 MPP prefill on such hosts).
- **MTP speculative decoding**: native draft layer attached from the original repo's shard (`--attach-mtp`, INT4 via `Int4AffineEncoder`), decode-exact multix verify kernels (prefill QMM is not ulp-identical to decode — parity-locked new kernels instead), full DeltaNet capture-arena rollback, `MFERENCE_MTP=0` / `MFERENCE_MTP_K` controls. Byte-identical greedy output at every k, enforced by forced-partial-acceptance toy tests and verified on the real model.

## Gate
Full suite ×3 green (1043 tests / 168 suites), release build clean, link checker green, real-model install + raw/chat smokes, phases snapshot and family docs in `docs/QWEN38_PERFORMANCE.md`, kill-switches for every accepted default. Merge-compat: no changes to other families' runtime paths except the shared tensorops fix (validated by their existing parity suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)