### PR TITLE
feat: Mac app support for Qwen 3.8 + attach-step receipt regeneration

### DIFF
--- a/Sources/MferenceApp/Core/Installation/AppModelInstallDescriptor.swift
+++ b/Sources/MferenceApp/Core/Installation/AppModelInstallDescriptor.swift
@@ -105,12 +105,27 @@ public struct AppModelInstallDescriptor: Equatable, Sendable {
         rangeStagingBytes: UInt64(RemoteChunkPolicy.defaultBytes),
         reserveBytes: 1_073_741_824)
 
+    /// Pinned to the same revision/index digest as
+    /// `SupportedModelSource.qwen38`; installed bytes measured after the
+    /// first real install with the MTP tensors attached.
+    public static let qwen38 = AppModelInstallDescriptor(
+        family: .qwen38,
+        displayName: "Qwen3.8 27B 4-bit",
+        repoID: "mlx-community/Qwen3.8-27B-4bit",
+        revision: "3e6447f082e89cc7f0bc6e5441afd38dfce760ff",
+        sourceIndexSHA256:
+            "13b840162b4cb35c66fef7df072f7dbb4717908204364f5e5d9f9655a2758fa8",
+        approximateDownloadBytes: 15_200_000_000,
+        installedBytes: 15_371_847_680,
+        rangeStagingBytes: UInt64(RemoteChunkPolicy.defaultBytes),
+        reserveBytes: 1_073_741_824)
+
     /// The shipped descriptor for a model family, if one exists.
     public static func descriptor(for family: ModelFamily) -> AppModelInstallDescriptor? {
         switch family {
         case .gemma4: return .default
         case .qwen36: return .qwen36
-        case .qwen38: return nil   // no shipped app descriptor yet
+        case .qwen38: return .qwen38
         case .deepseekV4Flash: return .deepseekV4Flash
         case .inklingSmall: return .inklingSmall
         case .maple: return .maple
@@ -139,6 +154,7 @@ public struct AppModelInstallDescriptor: Equatable, Sendable {
             .string(forKey: "model")
         switch environmentValue ?? preferenceValue {
         case "qwen36": return .qwen36
+        case "qwen38": return .qwen38
         case "deepseekv4flash", "dsv4": return .deepseekV4Flash
         case "inklingsmall", "inkling": return .inklingSmall
         case "maple": return .maple

--- a/Sources/MferenceRepack/Core/Workflow/MTPAttachTool.swift
+++ b/Sources/MferenceRepack/Core/Workflow/MTPAttachTool.swift
@@ -322,9 +322,14 @@ public enum MTPAttachTool {
             options: [.sortedKeys, .withoutEscapingSlashes])
         try Posix.atomicWrite(newManifest, to: manifestPath,
                               durableIn: gturboDirectory)
+        // The attach invalidated the old receipt; regenerate it so installs
+        // that gate on verified-install.json (the Mac app) keep working
+        // without a manual --verify-install pass.
         let receiptPath = (gturboDirectory as NSString)
             .appendingPathComponent("verified-install.json")
         try? FileManager.default.removeItem(atPath: receiptPath)
+        _ = try VerifiedInstallTool.run(
+            options: VerifyInstallOptions(inputGTurbo: gturboDirectory))
 
         return Result(tensorCount: newEntries.count,
                       appendedBytes: UInt64(appended.count),

--- a/Sources/MferenceRepack/Core/Workflow/MTPAttachTool.swift
+++ b/Sources/MferenceRepack/Core/Workflow/MTPAttachTool.swift
@@ -70,6 +70,26 @@ public enum MTPAttachTool {
             throw RepackError.configurationInvalid(
                 detail: "\(manifestPath) is not a Qwen 3.8 manifest")
         }
+        // -- Every manifest file must exist at its recorded size BEFORE the
+        // irreversible append: a pre-existing missing/truncated sidecar would
+        // otherwise only surface in the post-attach receipt pass, when a
+        // retry is already rejected as "already attached".
+        if let files = manifestRoot["files"] as? [String: Any] {
+            for (name, entry) in files {
+                let path = (gturboDirectory as NSString).appendingPathComponent(name)
+                let recorded = (entry as? [String: Any])?["size"] as? Int
+                let actual = (try? FileManager.default
+                    .attributesOfItem(atPath: path)[.size] as? Int) ?? nil
+                guard let recorded, let actual, recorded == actual else {
+                    throw RepackError.configurationInvalid(detail:
+                        "install file \(name) is missing or has size " +
+                        "\(actual.map(String.init) ?? "unknown") (manifest records " +
+                        "\(recorded.map(String.init) ?? "unknown")); repair the " +
+                        "install before attaching MTP tensors")
+                }
+            }
+        }
+
         let qDim = numHeads * headDim
         let kvDim = numKVHeads * headDim
         let expected: [ExpectedTensor] = [
@@ -324,12 +344,21 @@ public enum MTPAttachTool {
                               durableIn: gturboDirectory)
         // The attach invalidated the old receipt; regenerate it so installs
         // that gate on verified-install.json (the Mac app) keep working
-        // without a manual --verify-install pass.
+        // without a manual --verify-install pass. The attach itself is
+        // complete at this point, so a receipt failure must say so and point
+        // at the retryable step rather than reading as a failed attach.
         let receiptPath = (gturboDirectory as NSString)
             .appendingPathComponent("verified-install.json")
         try? FileManager.default.removeItem(atPath: receiptPath)
-        _ = try VerifiedInstallTool.run(
-            options: VerifyInstallOptions(inputGTurbo: gturboDirectory))
+        do {
+            _ = try VerifiedInstallTool.run(
+                options: VerifyInstallOptions(inputGTurbo: gturboDirectory))
+        } catch {
+            throw RepackError.configurationInvalid(detail:
+                "MTP tensors were attached, but regenerating the install " +
+                "receipt failed (\(error)); repair the install and run " +
+                "--verify-install --input-gturbo \(gturboDirectory)")
+        }
 
         return Result(tensorCount: newEntries.count,
                       appendedBytes: UInt64(appended.count),

--- a/Tests/Mference/Core/Runtime/Qwen38MTPSpecTests.swift
+++ b/Tests/Mference/Core/Runtime/Qwen38MTPSpecTests.swift
@@ -87,6 +87,18 @@ import Testing
     @Test func attachProducesLoadableInstall() throws {
         let dir = try Self.makeAttachedDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
+        // The attach must leave a fresh install receipt behind — the Mac app
+        // gates "installed" on verified-install.json, so a stale or missing
+        // receipt strands an otherwise valid install on the download screen.
+        let receiptURL = dir.appendingPathComponent("verified-install.json")
+        let receiptData = try Data(contentsOf: receiptURL)
+        let receipt = try JSONSerialization.jsonObject(with: receiptData) as? [String: Any]
+        let receiptFiles = receipt?["files"] as? [String: [String: Any]] ?? [:]
+        let weightsEntry = receiptFiles["model_weights.bin"]
+        let weightsSize = try FileManager.default
+            .attributesOfItem(atPath: dir.appendingPathComponent("model_weights.bin").path)[.size] as? Int
+        #expect(weightsEntry?["size"] as? Int == weightsSize,
+                "receipt must record the post-attach weights size")
         let ctx = try MetalContext()
         // Model.load re-verifies the manifest sha256 of the rewritten
         // weights file, so a load success also validates the attach output.


### PR DESCRIPTION
Two pieces found by actually launching the app on the new family:

- **App descriptor wiring**: shipped `AppModelInstallDescriptor.qwen38` (pinned revision + index digest, measured install size) and the `qwen38` model-selector case — the app now loads the family via `MFERENCE_MODEL=qwen38` or the model preference.
- **Bug fix**: `--attach-mtp` deleted the invalidated `verified-install.json` but never regenerated it. The Mac app gates "installed" on that receipt, so a valid MTP-attached install stranded on the download screen. The attach step now finishes by re-running the verifier; round-trip test asserts the receipt matches post-attach sizes.

Full suite 1043/168 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)